### PR TITLE
Add new exception-reporting mode and %tb mode option.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -580,7 +580,7 @@ class InteractiveShell(SingletonConfigurable):
     separate_out = SeparateUnicode('').tag(config=True)
     separate_out2 = SeparateUnicode('').tag(config=True)
     wildcards_case_sensitive = Bool(True).tag(config=True)
-    xmode = CaselessStrEnum(('Context','Plain', 'Verbose'),
+    xmode = CaselessStrEnum(('Context', 'Plain', 'Verbose', 'Minimal'),
                             default_value='Context',
                             help="Switch modes for the IPython exception handlers."
                             ).tag(config=True)
@@ -1788,7 +1788,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # The interactive one is initialized with an offset, meaning we always
         # want to remove the topmost item in the traceback, which is our own
-        # internal code. Valid modes: ['Plain','Context','Verbose']
+        # internal code. Valid modes: ['Plain','Context','Verbose','Minimal']
         self.InteractiveTB = ultratb.AutoFormattedTB(mode = 'Plain',
                                                      color_scheme='NoColor',
                                                      tb_offset = 1,

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -363,7 +363,7 @@ Currently the magic system has the following functions:""",
     def xmode(self, parameter_s=''):
         """Switch modes for the exception handlers.
 
-        Valid modes: Plain, Context and Verbose.
+        Valid modes: Plain, Context, Verbose, and Minimal.
 
         If called without arguments, acts as a toggle."""
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -466,10 +466,35 @@ python-profiler package from non-free.""")
 
     @line_magic
     def tb(self, s):
-        """Print the last traceback with the currently active exception mode.
+        """Print the last traceback.
 
-        See %xmode for changing exception reporting modes."""
-        self.shell.showtraceback()
+        Optionally, specify an exception reporting mode, tuning the
+        verbosity of the traceback. By default the currently-active exception
+        mode is used. See %xmode for changing exception reporting modes.
+
+        Valid modes: Plain, Context, Verbose, and Minimal.
+        """
+        interactive_tb = self.shell.InteractiveTB
+        if s:
+            # Switch exception reporting mode for this one call.
+            # Ensure it is switched back.
+            def xmode_switch_err(name):
+                warn('Error changing %s exception modes.\n%s' %
+                    (name,sys.exc_info()[1]))
+
+            new_mode = s.strip().capitalize()
+            original_mode = interactive_tb.mode
+            try:
+                try:
+                    interactive_tb.set_mode(mode=new_mode)
+                except Exception:
+                    xmode_switch_err('user')
+                else:
+                    self.shell.showtraceback()
+            finally:
+                interactive_tb.set_mode(mode=original_mode)
+        else:
+            self.shell.showtraceback()
 
     @skip_doctest
     @line_magic

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -473,7 +473,7 @@ def test_cd_force_quiet():
 def test_xmode():
     # Calling xmode three times should be a no-op
     xmode = _ip.InteractiveTB.mode
-    for i in range(3):
+    for i in range(4):
         _ip.magic("xmode")
     nt.assert_equal(_ip.InteractiveTB.mode, xmode)
     

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -115,6 +115,9 @@ class NonAsciiTest(unittest.TestCase):
         with tt.AssertPrints(u"Exception: é"):
             ip.run_cell(cell)
 
+        # Put this back into Context mode for later tests.
+        ip.run_cell("%xmode context")
+
 class NestedGenExprTestCase(unittest.TestCase):
     """
     Regression test for the following issues:

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -111,6 +111,9 @@ class NonAsciiTest(unittest.TestCase):
         with tt.AssertPrints(expected):
             ip.run_cell(cell)
 
+        ip.run_cell("%xmode minimal")
+        with tt.AssertPrints(u"Exception: é"):
+            ip.run_cell(cell)
 
 class NestedGenExprTestCase(unittest.TestCase):
     """

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1251,7 +1251,7 @@ class FormattedTB(VerboseTB, ListTB):
                  parent=None, config=None):
 
         # NEVER change the order of this list. Put new modes at the end:
-        self.valid_modes = ['Plain', 'Context', 'Verbose']
+        self.valid_modes = ['Plain', 'Context', 'Verbose', 'Minimal']
         self.verbose_modes = self.valid_modes[1:3]
 
         VerboseTB.__init__(self, color_scheme=color_scheme, call_pdb=call_pdb,
@@ -1262,7 +1262,8 @@ class FormattedTB(VerboseTB, ListTB):
 
         # Different types of tracebacks are joined with different separators to
         # form a single string.  They are taken from this dict
-        self._join_chars = dict(Plain='', Context='\n', Verbose='\n')
+        self._join_chars = dict(Plain='', Context='\n', Verbose='\n',
+                                Minimal='')
         # set_mode also sets the tb_join_char attribute
         self.set_mode(mode)
 
@@ -1280,6 +1281,8 @@ class FormattedTB(VerboseTB, ListTB):
             return VerboseTB.structured_traceback(
                 self, etype, value, tb, tb_offset, number_of_lines_of_context
             )
+        elif mode == 'Minimal':
+            return ListTB.get_exception_only(self, etype, value)
         else:
             # We must check the source cache because otherwise we can print
             # out-of-date source code.
@@ -1323,6 +1326,9 @@ class FormattedTB(VerboseTB, ListTB):
 
     def verbose(self):
         self.set_mode(self.valid_modes[2])
+
+    def minimal(self):
+        self.set_mode(self.valid_modes[3])
 
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
This adds a new mode to [`%xmode`](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-xmode) tentatively named `'Minimal'` that shows only the exception --- no traceback.

```python                                                                       
In [1]: %xmode minimal                                                          
Exception reporting mode: Minimal                                               
                                                                                
In [2]: def f():                                                                
    ...:     3/0                                                                
    ...:                                                                        
                                                                                
In [3]: f()                                                                     
ZeroDivisionError: division by zero
```

In many contexts, you might say this leaves out too much information. Here is the context that I feel this will be useful in. Novice Python users are using IPython to execute rote procedures in a framework that happens to produce very deep tracebacks. They are completely lost in / overwhelmed by the full tracebacks and --- during the short time they grabble with IPython --- unable to absorb the rule, "Just scroll to the bottom." Therefore, an aggressively succinct `%xmode` setting may be less disorienting. Multiple experienced IPython users at my facility have suggested that this setting would be help elicit more useful bug reports.

Of course, if the problem is not immediately clear, it will be essential to access the full traceback. This could be done by switching to a more verbose `%xmode` and then using `%tb` to show the most recent traceback. In order to streamline that, this PR also adds an optional parameter to `%tb` that temporarily switches the exception-reporting mode for that single use.

```python
In [4]: %tb verbose                                                             
---------------------------------------------------------------------------     
ZeroDivisionError                         Traceback (most recent call last)     
<ipython-input-3-c43e34e6d405> in <module>                                      
----> 1 f()                                                                     
        global f = <function f at 0x10e52de18>                                  
                                                                                
<ipython-input-2-cd4172d70b5b> in f()                                           
        1 def f():                                                               
----> 2     3/0                                                                 
        3                                                                       
                                                                                
ZeroDivisionError: division by zero                                             
                                                                                
In [5]: f()  # The default reporting mode has not been changed....              
ZeroDivisionError: division by zero
```