### PR TITLE
Naive fix for deprecation warning.

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -16,7 +16,7 @@ import nose.tools as nt
 from traitlets.config.loader import Config
 from IPython import get_ipython
 from IPython.core import completer
-from IPython.external.decorators.dec import knownfailureif
+from IPython.external import decorators
 from IPython.utils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 from IPython.utils.generics import complete_object
 from IPython.testing import decorators as dec
@@ -183,7 +183,7 @@ def test_forward_unicode_completion():
     nt.assert_equal(matches[0], 'Ⅴ')
 
 @nt.nottest # now we have a completion for \jmath
-@dec.knownfailureif(sys.platform == 'win32', 'Fails if there is a C:\\j... path')
+@decorators.dec.knownfailureif(sys.platform == 'win32', 'Fails if there is a C:\\j... path')
 def test_no_ascii_back_completion():
     ip = get_ipython()
     with TemporaryWorkingDirectory():  # Avoid any filename completions
@@ -234,7 +234,7 @@ def test_has_open_quotes4():
         nt.assert_false(completer.has_open_quotes(s))
 
 
-@knownfailureif(sys.platform == 'win32', "abspath completions fail on Windows")
+@decorators.dec.knownfailureif(sys.platform == 'win32', "abspath completions fail on Windows")
 def test_abspath_file_completions():
     ip = get_ipython()
     with TemporaryDirectory() as tmpdir:

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -16,7 +16,7 @@ import nose.tools as nt
 from traitlets.config.loader import Config
 from IPython import get_ipython
 from IPython.core import completer
-from IPython.external.decorators import knownfailureif
+from IPython.external.decorators.dec import knownfailureif
 from IPython.utils.tempdir import TemporaryDirectory, TemporaryWorkingDirectory
 from IPython.utils.generics import complete_object
 from IPython.testing import decorators as dec

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -538,7 +538,7 @@ def test_run_tb():
         nt.assert_in("RuntimeError", out)
         nt.assert_equal(out.count("---->"), 3)
 
-@dec.knownfailureif(sys.platform == 'win32', "writes to io.stdout aren't captured on Windows")
+@dec.dec.knownfailureif(sys.platform == 'win32', "writes to io.stdout aren't captured on Windows")
 def test_script_tb():
     """Test traceback offset in `ipython script.py`"""
     with TemporaryDirectory() as td:

--- a/IPython/external/decorators/__init__.py
+++ b/IPython/external/decorators/__init__.py
@@ -1,5 +1,6 @@
 try:
     from numpy.testing import *
+    from numpy.testing import dec
     from numpy.testing.noseclasses import KnownFailure
 except ImportError:
     from ._decorators import *

--- a/IPython/external/decorators/__init__.py
+++ b/IPython/external/decorators/__init__.py
@@ -1,5 +1,5 @@
 try:
-    from numpy.testing.decorators import *
+    from numpy.testing import *
     from numpy.testing.noseclasses import KnownFailure
 except ImportError:
     from ._decorators import *

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -333,7 +333,7 @@ skipif_not_matplotlib = skip_without('matplotlib')
 
 skipif_not_sympy = skip_without('sympy')
 
-skip_known_failure = knownfailureif(True,'This test is known to fail')
+skip_known_failure = dec.knownfailureif(True,'This test is known to fail')
 
 # A null 'decorator', useful to make more readable code that needs to pick
 # between different decorators based on OS or other conditions

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -37,7 +37,7 @@ from IPython import version_info
 from IPython.utils.py3compat import decode
 from IPython.utils.importstring import import_item
 from IPython.testing.plugin.ipdoctest import IPythonDoctest
-from IPython.external.decorators import KnownFailure, knownfailureif
+from IPython.external.decorators import KnownFailure, dec
 
 pjoin = path.join
 
@@ -83,7 +83,7 @@ else:
 # ------------------------------------------------------------------------------
 def monkeypatch_xunit():
     try:
-        knownfailureif(True)(lambda: None)()
+        dec.knownfailureif(True)(lambda: None)()
     except Exception as e:
         KnownFailureTest = type(e)
 


### PR DESCRIPTION
`DeprecationWarning: Importing from numpy.testing.decorators is deprecated, import from numpy.testing instead.`