### PR TITLE
Add %pip and %conda magic functions

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2220,7 +2220,8 @@ class InteractiveShell(SingletonConfigurable):
         self.register_magics(m.AutoMagics, m.BasicMagics, m.CodeMagics,
             m.ConfigMagics, m.DisplayMagics, m.ExecutionMagics,
             m.ExtensionMagics, m.HistoryMagics, m.LoggingMagics,
-            m.NamespaceMagics, m.OSMagics, m.PylabMagics, m.ScriptMagics,
+            m.NamespaceMagics, m.OSMagics, m.PackagingMagics,
+            m.PylabMagics, m.ScriptMagics,
         )
         if sys.version_info >(3,5):
             self.register_magics(m.AsyncMagics)

--- a/IPython/core/magics/__init__.py
+++ b/IPython/core/magics/__init__.py
@@ -24,6 +24,7 @@ from .history import HistoryMagics
 from .logging import LoggingMagics
 from .namespace import NamespaceMagics
 from .osm import OSMagics
+from .packaging import PackagingMagics
 from .pylab import PylabMagics
 from .script import ScriptMagics
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -179,7 +179,7 @@ class BasicMagics(Magics):
     @line_magic
     def lsmagic(self, parameter_s=''):
         """List currently available magic functions."""
-        return MagicsDisplay(self.shell.magics_manager, ignore=[self.pip])
+        return MagicsDisplay(self.shell.magics_manager, ignore=[])
 
     def _magic_docs(self, brief=False, rest=False):
         """Return docstrings from magic functions."""

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -379,25 +379,6 @@ Currently the magic system has the following functions:""",
         except:
             xmode_switch_err('user')
 
-
-
-    @line_magic
-    def pip(self, args=''):
-        """
-        Intercept usage of ``pip`` in IPython and direct user to run command outside of IPython.
-        """
-        print(textwrap.dedent('''
-        The following command must be run outside of the IPython shell:
-
-            $ pip {args}
-
-        The Python package manager (pip) can only be used from outside of IPython.
-        Please reissue the `pip` command in a separate terminal or command prompt.
-
-        See the Python documentation for more information on how to install packages:
-
-            https://docs.python.org/3/installing/'''.format(args=args)))
-
     @line_magic
     def quickref(self, arg):
         """ Show a quick reference sheet """

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -66,6 +66,7 @@ class PackagingMagics(Magics):
           %pip install [pkgs]
         """
         self.shell.system(' '.join([sys.executable, '-m', 'pip', line]))
+        print("Note: you may need to restart the kernel to use updated packages.")
 
     @line_magic
     def conda(self, line):
@@ -99,3 +100,4 @@ class PackagingMagics(Magics):
             extra_args.extend(["--prefix", sys.prefix])
 
         self.shell.system(' '.join([conda, command] + extra_args + args))
+        print("\nNote: you may need to restart the kernel to use updated packages.")

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -1,0 +1,101 @@
+"""Implementation of packaging-related magic functions.
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (c) 2018 The IPython Development Team.
+#
+#  Distributed under the terms of the Modified BSD License.
+#
+#  The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import re
+import shlex
+import sys
+from subprocess import Popen, PIPE
+
+from IPython.core.magic import Magics, magics_class, line_magic
+
+
+def _is_conda_environment():
+    """Return True if the current Python executable is in a conda env"""
+    # TODO: does this need to change on windows?
+    conda_history = os.path.join(sys.prefix, 'conda-meta', 'history')
+    return os.path.exists(conda_history)
+
+
+def _get_conda_executable():
+    """Find the path to the conda executable"""
+    # Check if there is a conda executable in the same directory as the Python executable.
+    # This is the case within conda's root environment.
+    conda = os.path.join(os.path.dirname(sys.executable), 'conda')
+    if os.path.isfile(conda):
+        return conda
+
+    # Otherwise, attempt to extract the executable from conda history.
+    # This applies in any conda environment.
+    R = re.compile(r"^#\s*cmd:\s*(?P<command>.*conda)\s[create|install]")
+    for line in open(os.path.join(sys.prefix, 'conda-meta', 'history')):
+        match = R.match(line)
+        if match:
+            return match.groupdict()['command']
+    
+    # Fallback: assume conda is available on the system path.
+    return "conda"
+
+
+CONDA_COMMANDS_REQUIRING_PREFIX = {
+    'install', 'list', 'remove', 'uninstall', 'update', 'upgrade',
+}
+CONDA_COMMANDS_REQUIRING_YES = {
+    'install', 'remove', 'uninstall', 'update', 'upgrade',
+}
+CONDA_ENV_FLAGS = {'-p', '--prefix', '-n', '--name'}
+CONDA_YES_FLAGS = {'-y', '--y'}
+
+
+@magics_class
+class PackagingMagics(Magics):
+    """Magics related to packaging & installation"""
+
+    @line_magic
+    def pip(self, line):
+        """Run the pip package manager within the current kernel.
+
+        Usage:
+          %pip install [pkgs]
+        """
+        self.shell.system(' '.join([sys.executable, '-m', 'pip', line]))
+
+    @line_magic
+    def conda(self, line):
+        """Run the conda package manager within the current kernel.
+        
+        Usage:
+          %conda install [pkgs]
+        """
+        if not _is_conda_environment():
+            raise ValueError("The python kernel does not appear to be a conda environment.  "
+                             "Please use ``%pip install`` instead.")
+        
+        conda = _get_conda_executable()
+        args = shlex.split(line)
+        command = args[0]
+        args = args[1:]
+        extra_args = []
+
+        # When the subprocess does not allow us to respond "yes" during the installation,
+        # we need to insert --yes in the argument list for some commands
+        stdin_disabled = getattr(self.shell, 'kernel', None) is not None
+        needs_yes = command in CONDA_COMMANDS_REQUIRING_YES
+        has_yes = set(args).intersection(CONDA_YES_FLAGS)
+        if stdin_disabled and needs_yes and not has_yes:
+            extra_args.append("--yes")
+
+        # Add --prefix to point conda installation to the current environment
+        needs_prefix = command in CONDA_COMMANDS_REQUIRING_PREFIX
+        has_prefix = set(args).intersection(CONDA_ENV_FLAGS)
+        if needs_prefix and not has_prefix:
+            extra_args.extend(["--prefix", sys.prefix])
+
+        self.shell.system(' '.join([conda, command] + extra_args + args))


### PR DESCRIPTION
This PR adds ``%pip`` and ``%conda`` magic functions which automatically install packages into the currently-running kernel in an IPython or Jupyter notebook session.

<img width="893" alt="screen shot 2018-12-05 at 9 41 51 pm" src="https://user-images.githubusercontent.com/781659/49563899-a2a1c280-f8d6-11e8-8b17-4b66e4af703b.png">

Why? Correctly installing Python packages within a running kernel has long been a point of confusion within the Jupyter ecosystem. While this might seem like an anti-pattern for the traditional local kernel use-case, the recent popularity of cloud-backed Jupyter notebook services has made this more relevant.

For some background on why ``!pip install`` or ``!conda install`` are incorrect in ways that can be very subtle and confusing, see my blog post from last year: [Installing Python Packages From a Jupyter Notebook](https://jakevdp.github.io/blog/2017/12/05/installing-python-packages-from-jupyter/).

There are some existing issues requesting this sort of feature (see #9517 & #11481) as well as some prior art on pip and conda magic function implementations by @minrk (https://github.com/minrk/condamagic/) and @Carreau (https://github.com/Carreau/pip_magic), but the fact that these third-party functions must be manually installed limits their usefulness to people who are having trouble installing things :smile:.

I'm hoping that including functionality like this within IPython itself will address the bulk of the confusion many of us have seen from users of the Jupyter stack.