### PR TITLE
Fix #11527 initialize posix aliases after a %reset

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1433,6 +1433,13 @@ class InteractiveShell(SingletonConfigurable):
         self.alias_manager.clear_aliases()
         self.alias_manager.init_aliases()
 
+        # Now define aliases that only make sense on the terminal, because they
+        # need direct access to the console in a way that we can't emulate in
+        # GUI or web frontend
+        if os.name == 'posix':
+            for cmd in ('clear', 'more', 'less', 'man'):
+                self.alias_manager.soft_define_alias(cmd, cmd)
+
         # Flush the private list of module references kept for script
         # execution protection
         self.clear_main_mod_cache()

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -495,6 +495,16 @@ class InteractiveShellTestCase(unittest.TestCase):
         self.assertFalse(ip.last_execution_result.success)
         self.assertIsInstance(ip.last_execution_result.error_in_exec, NameError)
 
+    def test_reset_aliasing(self):
+        """ Check that standard posix aliases work after %reset. """
+        if os.name != 'posix':
+            return
+
+        ip.reset()
+        for cmd in ('clear', 'more', 'less', 'man'):
+            res = ip.run_cell('%' + cmd)
+            self.assertEqual(res.success, True)
+
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -447,7 +447,7 @@ class TerminalInteractiveShell(InteractiveShell):
         # need direct access to the console in a way that we can't emulate in
         # GUI or web frontend
         if os.name == 'posix':
-            for cmd in ['clear', 'more', 'less', 'man']:
+            for cmd in ('clear', 'more', 'less', 'man'):
                 self.alias_manager.soft_define_alias(cmd, cmd)
 
 


### PR DESCRIPTION
Changes the behavior of %reset by initializing the posix aliases `clear`, `less`, `more`, and `man` during a reset. It's not clear to me what the intended behavior should be, but it fixes #11527.