### PR TITLE
Fix several DeprecationWarning: invalid escape sequence

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -82,7 +82,7 @@ ipython_savefig_dir:
     Sphinx source directory. The default is `html_static_path`.
 ipython_rgxin:
     The compiled regular expression to denote the start of IPython input
-    lines. The default is ``re.compile('In \[(\d+)\]:\s?(.*)\s*')``. You
+    lines. The default is ``re.compile('In \\[(\\d+)\\]:\\s?(.*)\\s*')``. You
     shouldn't need to change this.
 ipython_warning_is_error: [default to True]
     Fail the build if something unexpected happen, for example if a block raise
@@ -90,7 +90,7 @@ ipython_warning_is_error: [default to True]
     what is considered strict, may change between the sphinx directive version.
 ipython_rgxout:
     The compiled regular expression to denote the start of IPython output
-    lines. The default is ``re.compile('Out\[(\d+)\]:\s?(.*)\s*')``. You
+    lines. The default is ``re.compile('Out\\[(\\d+)\\]:\\s?(.*)\\s*')``. You
     shouldn't need to change this.
 ipython_promptin:
     The string to represent the IPython input prompt in the generated ReST.
@@ -1047,9 +1047,9 @@ def setup(app):
     app.add_config_value('ipython_savefig_dir', 'savefig', 'env')
     app.add_config_value('ipython_warning_is_error', True, 'env')
     app.add_config_value('ipython_rgxin',
-                         re.compile('In \[(\d+)\]:\s?(.*)\s*'), 'env')
+                         re.compile(r'In \[(\d+)\]:\s?(.*)\s*'), 'env')
     app.add_config_value('ipython_rgxout',
-                         re.compile('Out\[(\d+)\]:\s?(.*)\s*'), 'env')
+                         re.compile(r'Out\[(\d+)\]:\s?(.*)\s*'), 'env')
     app.add_config_value('ipython_promptin', 'In [%d]:', 'env')
     app.add_config_value('ipython_promptout', 'Out[%d]:', 'env')
 

--- a/IPython/terminal/tests/test_debug_magic.py
+++ b/IPython/terminal/tests/test_debug_magic.py
@@ -26,7 +26,7 @@ def test_debug_magic_passes_through_generators():
     """
     import pexpect
     import re
-    in_prompt = re.compile(b'In ?\[\\d+\]:')
+    in_prompt = re.compile(br'In ?\[\d+\]:')
     ipdb_prompt = 'ipdb>'
     env = os.environ.copy()
     child = pexpect.spawn(sys.executable, ['-m', 'IPython', '--colors=nocolor', '--simple-prompt'],

--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -105,7 +105,7 @@ class ApiDocWriter(object):
             if *package_name* is ``sphinx``, then ``sphinx.util`` will
             result in ``.util`` being passed for earching by these
             regexps.  If is None, gives default. Default is:
-            ['\.tests$']
+            ['\\.tests$']
         module_skip_patterns : None or sequence
             Sequence of strings giving URIs of modules to be excluded
             Operates on the module name including preceding URI path,
@@ -113,7 +113,7 @@ class ApiDocWriter(object):
             ``sphinx.util.console`` results in the string to search of
             ``.util.console``
             If is None, gives default. Default is:
-            ['\.setup$', '\._']
+            ['\\.setup$', '\\._']
         names_from__all__ : set, optional
             Modules listed in here will be scanned by doing ``from mod import *``,
             rather than finding function and class definitions by scanning the
@@ -355,7 +355,7 @@ class ApiDocWriter(object):
         >>> mods = dw.discover_modules()
         >>> 'sphinx.util' in mods
         True
-        >>> dw.package_skip_patterns.append('\.util$')
+        >>> dw.package_skip_patterns.append('\\.util$')
         >>> 'sphinx.util' in dw.discover_modules()
         False
         >>>

--- a/setupbase.py
+++ b/setupbase.py
@@ -270,7 +270,7 @@ class build_scripts_entrypt(build_scripts):
                 # Write .cmd wrappers for Windows so 'ipython' etc. work at the
                 # command line
                 cmd_file = os.path.join(self.build_dir, name + '.cmd')
-                cmd = '@"{python}" "%~dp0\{script}" %*\r\n'.format(
+                cmd = r'@"{python}" "%~dp0\{script}" %*\r\n'.format(
                         python=sys.executable, script=name)
                 log.info("Writing %s wrapper script" % cmd_file)
                 with open(cmd_file, 'w') as f:
@@ -358,7 +358,7 @@ def git_prebuild(pkg_dir, build_cmd=build_py):
         def run(self):
             # loose as `.dev` is suppose to be invalid
             print("check version number")
-            loose_pep440re = re.compile('^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$')
+            loose_pep440re = re.compile(r'^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$')
             if not loose_pep440re.match(version):
                 raise ValueError("Version number '%s' is not valid (should match [N!]N(.N)*[{a|b|rc}N][.postN][.devN])" % version)
 


### PR DESCRIPTION
Hello,

This is a little patch to fix all `DeprecationWarning: invalid escape sequence`.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>