### PR TITLE
Pass color depth for debugger prompt

### DIFF
--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -58,6 +58,7 @@ class TerminalPdb(Pdb):
                             complete_style=self.shell.pt_complete_style,
                             style=self.shell.style,
                             inputhook=self.shell.inputhook,
+                            color_depth=self.shell.color_depth,
         )
 
     def cmdloop(self, intro=None):

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -288,7 +288,7 @@ class TerminalInteractiveShell(InteractiveShell):
                             include_default_pygments_style=False,
                             mouse_support=self.mouse_support,
                             enable_open_in_editor=self.extra_open_editor_shortcuts,
-                            color_depth=(ColorDepth.TRUE_COLOR if self.true_color else None),
+                            color_depth=self.color_depth,
                             **self._extra_prompt_options())
 
     def _make_style_from_name_or_cls(self, name_or_cls):
@@ -364,6 +364,10 @@ class TerminalInteractiveShell(InteractiveShell):
             'column': CompleteStyle.COLUMN,
             'readlinelike': CompleteStyle.READLINE_LIKE,
         }[self.display_completions]
+
+    @property
+    def color_depth(self):
+        return (ColorDepth.TRUE_COLOR if self.true_color else None)
 
     def _extra_prompt_options(self):
         """


### PR DESCRIPTION
`color_depth` option for `PromptSession` should be handed off for interactive terminal prompt, but is currently missing for the debugger. This PR places the same option we already have in the terminal for the debugger.

Some terminal settings (i.e. [base16-shell](https://github.com/chriskempson/base16-shell)) require users to set `true_color` for properly rendering colors in the prompt. A notable example is completion menu shown below.

- Before
<img width="524" alt="without-color-depth" src="https://user-images.githubusercontent.com/906626/50954281-bbb80900-146a-11e9-879d-27b6b5ec7eb8.png">

- After
<img width="524" alt="with-color-depth" src="https://user-images.githubusercontent.com/906626/50954288-beb2f980-146a-11e9-9960-f96f5a071f6d.png">

See #11209 and prompt-toolkit/python-prompt-toolkit#766 for related discussion.