### PR TITLE
fix a memory leak on exception (caused by the stored traceback)

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1949,6 +1949,8 @@ class InteractiveShell(SingletonConfigurable):
             etype, value, tb = sys.exc_info()
         else:
             etype, value, tb = exc_tuple
+        # must not create circular reference to locals() in each frame of stored tb
+        traceback.clear_frames(tb)
 
         if etype is None:
             if hasattr(sys, 'last_type'):


### PR DESCRIPTION
Currently ipython stores the traceback on exception. The problem is that it creates a circular reference to locals() in each frame of the traceback. And until next exception arrives gc.collect() will fail to collect. If locals() happened to be huge variables, like 8GB of GPU RAM, the user has no choice but to restart ipython/jupyter to recover.

Solution - cleanse the saved tb from any references to `locals()` by running it through: `traceback.clear_frames(tb)`

My fix was made to only one such location in the ipython code and there is a dozen other places where it does that. So please kindly review for other similar situations.

I wrote a test case that demonstrates the problem and putting this fix in that particular location fixed that leak. But I don't know whether they are other situations where a similar fix needs to be applied.

You can see the test case here (run it with Alt-F so it runs all cells ignoring the errors)
https://hub.mybinder.org/user/stas00-fastai-misc-xbrsnjae/notebooks/debug/ipython/locals_leak_on_exc.ipynb
It shows how if there is a local variable that is of 128MB in size, an exception involving that function will leak that much RAM. And it shows how the next exception will release the previously held locals() allowing gc.collect() to recover that leaked memory.

The source of the test case is here:
https://github.com/stas00/fastai-misc/blob/master/debug/ipython/locals_leak_on_exc.ipynb

and here it is in straight ipython's output:

```
In [1]: import numpy as np                                                                                                                                                  

In [2]: def consume_cpu_ram(n): return np.ones((n, n)) 
   ...: def consume_cpu_ram_128mb():  return consume_cpu_ram(2**12)                                                                                                         

In [3]: import gc, os, sys, time, psutil 
   ...: process = psutil.Process(os.getpid()) 
   ...: def cpu_ram_used():  return process.memory_info().rss                                                                                                               

In [4]: def fail(): 
   ...:     x = consume_cpu_ram_128mb() 
   ...:     raise ValueError("Ouch") 
   ...:                                                                                                                                                                     

In [5]: before = cpu_ram_used() 
   ...: fail()                                                                                                                                                              
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-3b8b03759f74> in <module>
      1 before = cpu_ram_used()
----> 2 fail()

<ipython-input-4-e846ddbe1c18> in fail()
      1 def fail():
      2     x = consume_cpu_ram_128mb()
----> 3     raise ValueError("Ouch")
      4 

ValueError: Ouch

In [6]: gc.collect() 
   ...: after = cpu_ram_used() 
   ...: print(f"Difference { (after-before)/2**20}")                                                                                                                        
Out[6]: 1105
Difference 128.62890625

In [7]: # force ipython to reset its %tb 
   ...: raise ValueError("Reset")                                                                                                                                           
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-7-31374e7d7384> in <module>
      1 # force ipython to reset its %tb
----> 2 raise ValueError("Reset")

ValueError: Reset

In [8]: gc.collect() 
   ...: after = cpu_ram_used() 
   ...: print(f"Difference { (after-before)/2**20}")                                                                                                                        
Out[8]: 418
Difference 0.77734375
```
