### PR TITLE
Provide completions for unicode names

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -168,6 +168,12 @@ MATCHES_LIMIT = 500
 
 _deprecation_readline_sentinel = object()
 
+names = []
+for c in range(0,0x10FFFF + 1):
+    try:
+        names.append(unicodedata.name(char(c)))
+    except ValueError:
+        pass
 
 class ProvisionalCompleterWarning(FutureWarning):
     """
@@ -2065,20 +2071,12 @@ class IPCompleter(Completer):
         return text, _matches, origins, completions
         
     def fwd_unicode_match(self, text:str) -> Tuple[str, list]:
-    # initial code based on latex_matches() method
+        # initial code based on latex_matches() method
         slashpos = text.rfind('\\')
         # if text starts with slash
         if slashpos > -1:
-            s = text[slashpos:]
-            # check if s is already a unicode, maybe this is not necessary
-            try unicodedata.lookup(s):
-                # need to find the unicodes equivalent list to latex_symbols
-                return s, [latex_symbols[s]]
-            except KeyError:
-                return u'', []
-            # need to find the unicode equivalent to latex_symbols and do something similar 
-            matches = [k for k in latex_symbols if k.startswith(s)]
-            return s, matches
+            s = text[slashpos+1:]
+            return s, [x for x in names if x.startswith(s)]
         
         # if text does not start with slash
         else:

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2073,8 +2073,12 @@ class IPCompleter(Completer):
         # if text starts with slash
         if slashpos > -1:
             s = text[slashpos+1:]
-            return s, [x for x in names if x.startswith(s)]
+            candidates = [x for x in names if x.startswith(s)]
+            if candidates:
+                return s, [x for x in names if x.startswith(s)]
+            else:
+                return '', ()
         
         # if text does not start with slash
         else:
-            return u'', []
+            return u'', ()

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -67,9 +67,9 @@ Experimental
 
 Starting with IPython 6.0, this module can make use of the Jedi library to
 generate completions both using static analysis of the code, and dynamically
-inspecting multiple namespaces. The APIs attached to this new mechanism is
-unstable and will raise unless use in an :any:`provisionalcompleter` context
-manager.
+inspecting multiple namespaces. Jedi is an autocompletion and static analysis 
+for Python. The APIs attached to this new mechanism is unstable and will 
+raise unless use in an :any:`provisionalcompleter` context manager.
 
 You will find that the following are experimental:
 
@@ -84,7 +84,7 @@ You will find that the following are experimental:
 
 We welcome any feedback on these new API, and we also encourage you to try this
 module in debug mode (start IPython with ``--Completer.debug=True``) in order
-to have extra logging information is :any:`jedi` is crashing, or if current
+to have extra logging information if :any:`jedi` is crashing, or if current
 IPython completer pending deprecations are returning results not yet handled
 by :any:`jedi`
 
@@ -1986,9 +1986,12 @@ class IPCompleter(Completer):
             name_matches = []
             for meth in (self.unicode_name_matches, back_latex_name_matches, back_unicode_name_matches):
                 name_text, name_matches = meth(base_text)
+                completion_text, completion_matches = self.fwd_unicode_match(base_text)
                 if name_text:
                     return name_text, name_matches[:MATCHES_LIMIT], \
                            [meth.__qualname__]*min(len(name_matches), MATCHES_LIMIT), ()
+                elif (completion_text):
+                    return completion_text, completion_matches, ()
 
 
         # If no line buffer is given, assume the input text is all there was
@@ -2059,3 +2062,14 @@ class IPCompleter(Completer):
         self.matches = _matches
 
         return text, _matches, origins, completions
+
+    def fwd_unicode_match(self, text:str) -> Tuple[str, list]:
+    # `text` is what the user typed. If it start with `\`, 
+    # then lookup in `names`  (defined above), all the possible candidates.
+    # return text, [list of candidates]
+        unicode_matches = []
+        if (text[0] == "\\"):
+            # lookup in names
+            pass
+        else:
+            return [text,unicode_matches]

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1984,6 +1984,7 @@ class IPCompleter(Completer):
                 return latex_text, latex_matches, ['latex_matches']*len(latex_matches), ()
             name_text = ''
             name_matches = []
+            # need to add self.fwd_unicode_match() function here when done
             for meth in (self.unicode_name_matches, back_latex_name_matches, back_unicode_name_matches):
                 name_text, name_matches = meth(base_text)
                 completion_text, completion_matches = self.fwd_unicode_match(base_text)
@@ -2062,14 +2063,23 @@ class IPCompleter(Completer):
         self.matches = _matches
 
         return text, _matches, origins, completions
-
+        
     def fwd_unicode_match(self, text:str) -> Tuple[str, list]:
-    # `text` is what the user typed. If it start with `\`, 
-    # then lookup in `names`  (defined above), all the possible candidates.
-    # return text, [list of candidates]
-        unicode_matches = []
-        if (text[0] == "\\"):
-            # lookup in names
-            pass
+    # initial code based on latex_matches() method
+        slashpos = text.rfind('\\')
+        # if text starts with slash
+        if slashpos > -1:
+            s = text[slashpos:]
+            # check if s is already a unicode, maybe this is not necessary
+            try unicodedata.lookup(s):
+                # need to find the unicodes equivalent list to latex_symbols
+                return s, [latex_symbols[s]]
+            except KeyError:
+                return u'', []
+            # need to find the unicode equivalent to latex_symbols and do something similar 
+            matches = [k for k in latex_symbols if k.startswith(s)]
+            return s, matches
+        
+        # if text does not start with slash
         else:
-            return [text,unicode_matches]
+            return u'', []

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1991,14 +1991,11 @@ class IPCompleter(Completer):
             name_text = ''
             name_matches = []
             # need to add self.fwd_unicode_match() function here when done
-            for meth in (self.unicode_name_matches, back_latex_name_matches, back_unicode_name_matches):
+            for meth in (self.unicode_name_matches, back_latex_name_matches, back_unicode_name_matches, self.fwd_unicode_match):
                 name_text, name_matches = meth(base_text)
-                completion_text, completion_matches = self.fwd_unicode_match(base_text)
                 if name_text:
                     return name_text, name_matches[:MATCHES_LIMIT], \
                            [meth.__qualname__]*min(len(name_matches), MATCHES_LIMIT), ()
-                elif (completion_text):
-                    return completion_text, completion_matches, ()
 
 
         # If no line buffer is given, assume the input text is all there was

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -171,7 +171,7 @@ _deprecation_readline_sentinel = object()
 names = []
 for c in range(0,0x10FFFF + 1):
     try:
-        names.append(unicodedata.name(char(c)))
+        names.append(unicodedata.name(chr(c)))
     except ValueError:
         pass
 

--- a/IPython/terminal/tests/test_debug_magic.py
+++ b/IPython/terminal/tests/test_debug_magic.py
@@ -31,9 +31,12 @@ def test_debug_magic_passes_through_generators():
     env = os.environ.copy()
     child = pexpect.spawn(sys.executable, ['-m', 'IPython', '--colors=nocolor', '--simple-prompt'],
                           env=env)
-    child.timeout = 2
+    child.timeout = 15
 
     child.expect(in_prompt)
+
+    child.timeout = 2
+
     child.sendline("def f(x):")
     child.sendline("    raise Exception")
     child.sendline("")


### PR DESCRIPTION
As discussed in #11449 , this is a WIP. 

I'm having trouble in looking up for possible unicode completions (inserted comments int the code). The draft of the new function to be added is at the bottom of the file. I'm trying to do something similar with the completions for latex, but cannot figure how to look up for completion candidates.

This patch also include documentation modifications. 