### PR TITLE
Make all_completions use new completion code

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1134,13 +1134,14 @@ class IPCompleter(Completer):
                 self.dict_key_matches,
             ]
 
-    def all_completions(self, text):
+    def all_completions(self, text) -> List[str]:
         """
         Wrapper around the completions method for the benefit of emacs.
         """
         prefix = text[:text.rfind(".") + 1]
-        return map(lambda c: prefix + c.text,
-                   self.completions(text, len(text)))
+        with provisionalcompleter():
+            return list(map(lambda c: prefix + c.text,
+                   self.completions(text, len(text))))
 
         return self.complete(text)[1]
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1136,8 +1136,12 @@ class IPCompleter(Completer):
 
     def all_completions(self, text):
         """
-        Wrapper around the complete method for the benefit of emacs.
+        Wrapper around the completions method for the benefit of emacs.
         """
+        prefix = text[:text.rfind(".") + 1]
+        return map(lambda c: prefix + c.text,
+                   self.completions(text, len(text)))
+
         return self.complete(text)[1]
 
     def _clean_glob(self, text):


### PR DESCRIPTION
This fixes a bug affecting emacs users introduced by 7.2.

Fixes https://github.com/ipython/ipython/issues/11541