### PR TITLE
Fix 11559 weird regexp writefile

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -825,7 +825,7 @@ class OSMagics(Magics):
         The file will be overwritten unless the -a (--append) flag is specified.
         """
         args = magic_arguments.parse_argstring(self.writefile, line)
-        if re.match(r'[\'*\']|["*"]', args.filename):
+        if re.match(r'^(\'.*\')|(".*")$', args.filename):
             filename = os.path.expanduser(args.filename[1:-1])
         else:
             filename = os.path.expanduser(args.filename)

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -769,6 +769,34 @@ def test_file():
         nt.assert_in('line1\n', s)
         nt.assert_in('line2', s)
 
+def test_file_single_quote():
+    """Basic %%writefile with embedded single quotes"""
+    ip = get_ipython()
+    with TemporaryDirectory() as td:
+        fname = os.path.join(td, '\'file1\'')
+        ip.run_cell_magic("writefile", fname, u'\n'.join([
+            'line1',
+            'line2',
+        ]))
+        with open(fname) as f:
+            s = f.read()
+        nt.assert_in('line1\n', s)
+        nt.assert_in('line2', s)
+
+def test_file_double_quote():
+    """Basic %%writefile with embedded double quotes"""
+    ip = get_ipython()
+    with TemporaryDirectory() as td:
+        fname = os.path.join(td, '"file1"')
+        ip.run_cell_magic("writefile", fname, u'\n'.join([
+            'line1',
+            'line2',
+        ]))
+        with open(fname) as f:
+            s = f.read()
+        nt.assert_in('line1\n', s)
+        nt.assert_in('line2', s)
+
 def test_file_var_expand():
     """%%writefile $filename"""
     ip = get_ipython()

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -769,6 +769,7 @@ def test_file():
         nt.assert_in('line1\n', s)
         nt.assert_in('line2', s)
 
+@dec.skip_win32
 def test_file_single_quote():
     """Basic %%writefile with embedded single quotes"""
     ip = get_ipython()
@@ -783,6 +784,7 @@ def test_file_single_quote():
         nt.assert_in('line1\n', s)
         nt.assert_in('line2', s)
 
+@dec.skip_win32
 def test_file_double_quote():
     """Basic %%writefile with embedded double quotes"""
     ip = get_ipython()


### PR DESCRIPTION
Hi, This is a fix for 11559 Weird regexp ['*']. I have fixed the regexp and added 2 test cases to handle embedded quotes in filenames in magic writefile. I have run regression testing locally without any issue.
