### PR TITLE
Handle edge case when requesting subclasses.

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -860,7 +860,7 @@ class Inspector(Colorable):
             if init_ds:
                 out['init_docstring'] = init_ds
 
-            names = [sub.__name__ for sub in obj.__subclasses__()]
+            names = [sub.__name__ for sub in type.__subclasses__(obj)]
             if len(names) < 10:
                 all_names = ', '.join(names)
             else:

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -363,6 +363,12 @@ def test_pinfo_nonascii():
     ip.user_ns['nonascii2'] = nonascii2
     ip._inspect('pinfo', 'nonascii2', detail_level=1)
 
+def test_pinfo_type():
+    """
+    type can fail in various edge case, for example `type.__subclass__()`
+    """
+    ip._inspect('pinfo', 'type')
+
 
 def test_pinfo_docstring_no_source():
     """Docstring should be included with detail_level=1 if there is no source"""


### PR DESCRIPTION
`obj.__subclasses__` does not have the usual meaning in case obj == type.

Closes #11607