### PR TITLE
Fixed PyQt 5.11 backwards incompatibility causing sip import failure

### DIFF
--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -220,10 +220,6 @@ def import_pyqt5():
 
     from PyQt5 import QtCore, QtSvg, QtWidgets, QtGui
     
-    # Note that import sip must follow other PyQt5 imports for PyQt >5.11
-    # http://pyqt.sourceforge.net/Docs/PyQt5/incompatibilities.html#pyqt-v5-11
-    import sip
-    
     # Alias PyQt-specific functions for PySide compatibility.
     QtCore.Signal = QtCore.pyqtSignal
     QtCore.Slot = QtCore.pyqtSlot

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -217,10 +217,13 @@ def import_pyqt5():
 
     ImportErrors rasied within this function are non-recoverable
     """
-    import sip
 
     from PyQt5 import QtCore, QtSvg, QtWidgets, QtGui
-
+    
+    # Note that import sip must follow other PyQt5 imports for PyQt >5.11
+    # http://pyqt.sourceforge.net/Docs/PyQt5/incompatibilities.html#pyqt-v5-11
+    import sip
+    
     # Alias PyQt-specific functions for PySide compatibility.
     QtCore.Signal = QtCore.pyqtSignal
     QtCore.Slot = QtCore.pyqtSlot


### PR DESCRIPTION
See issue: #11612 

This is the same fix as implemented in https://github.com/jupyter/qtconsole/issues/319.