### PR TITLE
Fix improper non-SyntaxError in return outside of function.

### DIFF
--- a/IPython/core/async_helpers.py
+++ b/IPython/core/async_helpers.py
@@ -112,6 +112,7 @@ class _AsyncSyntaxErrorVisitor(ast.NodeVisitor):
         if isinstance(node, func_types) and should_traverse:
             self.depth += 1
             super().generic_visit(node)
+            self.depth -= 1
         elif isinstance(node, invalid_types_by_depth[self.depth]):
             raise SyntaxError()
         else:

--- a/IPython/core/tests/test_async_helpers.py
+++ b/IPython/core/tests/test_async_helpers.py
@@ -139,7 +139,13 @@ if sys.version_info > (3, 5):
             tl_err_test_cases = self._get_top_level_cases()
             tl_err_test_cases.extend(self._get_ry_syntax_errors())
 
-            vals = ('return', 'yield', 'yield from (_ for _ in range(3))')
+            vals = ('return', 'yield', 'yield from (_ for _ in range(3))',
+                    dedent('''
+                        def f():
+                            pass
+                        return
+                        '''),
+                    )
 
             for test_name, test_case in tl_err_test_cases:
                 # This example should work if 'pass' is used as the value


### PR DESCRIPTION
The current depth was not properly tracked, which let to false-negative
on `SyntaxError`s

Closes #11638