### PR TITLE
allow type of already existing class instances to be updated

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -323,7 +323,6 @@ def update_instances(old, new, objects=None, visited={}):
 def update_class(old, new):
     """Replace stuff in the __dict__ of a class, and upgrade
     method code objects, and add new methods, if any"""
-    print('old is', id(old))
     for key in list(old.__dict__.keys()):
         old_obj = getattr(old, key)
         try:

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -268,66 +268,14 @@ def update_function(old, new):
             pass
 
 
-def _find_instances(old_type):
-    """Try to find all instances of a class that need updating.
-
-    Classic graph exploration, we want to avoid re-visiting object multiple times.
-    """
-    # find ipython workspace stack frame, this is just to bootstrap where we
-    # find the object that need updating.
-    frame = next(frame_nfo.frame for frame_nfo in inspect.stack()
-                 if 'trigger' in frame_nfo.function)
-    # build generator for non-private variable values from workspace
-    shell = frame.f_locals['self'].shell
-    user_ns = shell.user_ns
-    user_ns_hidden = shell.user_ns_hidden
-    nonmatching = object()
-    objects = ( value for key, value in user_ns.items()
-            if not key.startswith('_')
-            and (value is not user_ns_hidden.get(key, nonmatching))
-            and not inspect.ismodule(value))
-
-    # note:  in the following we do use dict as object might not be hashable.
-    # list of objects we found that will need an update.
-    to_update = {}
-
-    # list of object we have not recursed into yet
-    open_set = {}
-
-    # list of object we have visited already
-    closed_set = {}
-
-    open_set.update({id(o):o for o in objects})
-
-    it = 0
-    while len(open_set) > 0:
-        it += 1
-        if it > 100_000:
-            raise ValueError('infinite')
-        (current_id,current) =  next(iter(open_set.items()))
-        if type(current) is old_type:
-            to_update[current_id] = current
-        if hasattr(current, '__dict__') and not (inspect.isfunction(current)
-                                                 or inspect.ismethod(current)):
-            potential_new = {id(o):o for o in current.__dict__.values() if id(o) not in closed_set.keys()}
-            open_set.update(potential_new)
-        # if object is a container, search it
-        if hasattr(current, 'items') or (hasattr(current, '__contains__')
-                                         and not isinstance(current, str)):
-            potential_new = (value for key, value in current.items()
-                       if not str(key).startswith('_')
-                       and not inspect.ismodule(value) and not id(value) in closed_set.keys())
-            open_set.update(potential_new)
-        del open_set[id(current)]
-        closed_set[id(current)] = current
-    return to_update.values()
-
-def update_instances(old, new, objects=None):
+def update_instances(old, new, objects=None, visited={}):
     """Iterate through objects recursively, searching for instances of old and
     replace their __class__ reference with new. If no objects are given, start 
     with the current ipython workspace.
     """
-    if not objects:
+    if objects is None:
+        # make sure visited is cleaned when not called recursively
+        visited = {}
         # find ipython workspace stack frame
         frame = next(frame_nfo.frame for frame_nfo in inspect.stack() 
                      if 'trigger' in frame_nfo.function)
@@ -349,7 +297,9 @@ def update_instances(old, new, objects=None):
 
     # try if objects is iterable
     try:
-        for obj in objects:
+        for obj in (obj for obj in objects if id(obj) not in visited):
+            # add current object to visited to avoid revisiting
+            visited.update({id(obj):obj})
 
             # update, if object is instance of old_class (but no subclasses)
             if type(obj) is old:
@@ -359,21 +309,21 @@ def update_instances(old, new, objects=None):
             # if object is instance of other class, look for nested instances
             if hasattr(obj, '__dict__') and not (inspect.isfunction(obj)
                                                  or inspect.ismethod(obj)):
-                update_instances(old, new, obj.__dict__)
+                update_instances(old, new, obj.__dict__, visited)
 
             # if object is a container, search it
             if hasattr(obj, 'items') or (hasattr(obj, '__contains__')
                                          and not isinstance(obj, str)):
-                update_instances(old, new, obj)
+                update_instances(old, new, obj, visited)
 
     except TypeError:
         pass
 
-        
+
 def update_class(old, new):
     """Replace stuff in the __dict__ of a class, and upgrade
     method code objects, and add new methods, if any"""
-    print('old is', old)
+    print('old is', id(old))
     for key in list(old.__dict__.keys()):
         old_obj = getattr(old, key)
         try:
@@ -405,8 +355,7 @@ def update_class(old, new):
                 pass # skip non-writable attributes
 
     # update all instances of class
-    for instance in _find_instances(old):
-        instance.__class__ = new
+    update_instances(old, new)
 
 
 def update_property(old, new):

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -115,6 +115,7 @@ import sys
 import traceback
 import types
 import weakref
+import inspect
 from importlib import import_module
 from importlib.util import source_from_cache
 from imp import reload
@@ -267,6 +268,54 @@ def update_function(old, new):
             pass
 
 
+def update_instances(old, new, objects=None):
+    """Iterate through objects recursively, searching for instances of old and
+    replace their __class__ reference with new. If no objects are given, start 
+    with the current ipython workspace.
+    """
+    if not objects:
+        # find ipython workspace stack frame
+        frame = next(frame_nfo.frame for frame_nfo in inspect.stack() 
+                     if 'trigger' in frame_nfo.function)
+        # build generator for non-private variable values from workspace
+        shell = frame.f_locals['self'].shell
+        user_ns = shell.user_ns
+        user_ns_hidden = shell.user_ns_hidden
+        nonmatching = object()
+        objects = ( value for key, value in user_ns.items()
+                if not key.startswith('_') 
+                and (value is not user_ns_hidden.get(key, nonmatching)) 
+                and not inspect.ismodule(value))
+    
+    # use dict values if objects is a dict but don't touch private variables
+    if hasattr(objects, 'items'):
+        objects = (value for key, value in objects.items()
+                       if not str(key).startswith('_')
+                       and not inspect.ismodule(value) )
+
+    # try if objects is iterable
+    try:
+        for obj in objects:
+
+            # update, if object is instance of old_class (but no subclasses)
+            if type(obj) is old:
+                obj.__class__ = new
+                
+
+            # if object is instance of other class, look for nested instances
+            if hasattr(obj, '__dict__') and not (inspect.isfunction(obj)
+                                                 or inspect.ismethod(obj)):
+                update_instances(old, new, obj.__dict__)
+
+            # if object is a container, search it
+            if hasattr(obj, 'items') or (hasattr(obj, '__contains__')
+                                         and not isinstance(obj, str)):
+                update_instances(old, new, obj)
+
+    except TypeError:
+        pass
+
+        
 def update_class(old, new):
     """Replace stuff in the __dict__ of a class, and upgrade
     method code objects, and add new methods, if any"""
@@ -299,6 +348,9 @@ def update_class(old, new):
                 setattr(old, key, getattr(new, key))
             except (AttributeError, TypeError):
                 pass # skip non-writable attributes
+
+    # update all instances of class
+    update_instances(old, new)
 
 
 def update_property(old, new):

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -35,10 +35,12 @@ from IPython.core.events import EventManager, pre_run_cell
 
 noop = lambda *a, **kw: None
 
-class FakeShell(object):
+class FakeShell:
 
     def __init__(self):
         self.ns = {}
+        self.user_ns = {}
+        self.user_ns_hidden = {}
         self.events = EventManager(self, {'pre_run_cell', pre_run_cell})
         self.auto_magics = AutoreloadMagics(shell=self)
         self.events.register('pre_run_cell', self.auto_magics.pre_run_cell)

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -39,7 +39,7 @@ class FakeShell:
 
     def __init__(self):
         self.ns = {}
-        self.user_ns = {}
+        self.user_ns = self.ns
         self.user_ns_hidden = {}
         self.events = EventManager(self, {'pre_run_cell', pre_run_cell})
         self.auto_magics = AutoreloadMagics(shell=self)
@@ -49,7 +49,7 @@ class FakeShell:
 
     def run_code(self, code):
         self.events.trigger('pre_run_cell')
-        exec(code, self.ns)
+        exec(code, self.user_ns)
         self.auto_magics.post_execute_hook()
 
     def push(self, items):
@@ -106,7 +106,7 @@ class Fixture(object):
         (because that is stored in the file).  The only reliable way
         to achieve this seems to be to sleep.
         """
-
+        content = textwrap.dedent(content)
         # Sleep one second + eps
         time.sleep(1.05)
 
@@ -115,6 +115,7 @@ class Fixture(object):
             f.write(content)
 
     def new_module(self, code):
+        code = textwrap.dedent(code)
         mod_name, mod_fn = self.get_module()
         with open(mod_fn, 'w') as f:
             f.write(code)
@@ -123,6 +124,17 @@ class Fixture(object):
 #-----------------------------------------------------------------------------
 # Test automatic reloading
 #-----------------------------------------------------------------------------
+
+def pickle_get_current_class(obj):
+    """
+    Original issue comes from pickle; hence the name.
+    """
+    name = obj.__class__.__name__
+    module_name = getattr(obj, "__module__", None)
+    obj2 = sys.modules[module_name]
+    for subpath in name.split("."):
+        obj2 = getattr(obj2, subpath)
+    return obj2
 
 class TestAutoreload(Fixture):
 
@@ -146,6 +158,42 @@ class TestAutoreload(Fixture):
                             """))
         with tt.AssertNotPrints(('[autoreload of %s failed:' % mod_name), channel='stderr'):
             self.shell.run_code("pass")  # trigger another reload
+
+    def test_reload_class_type(self):
+        self.shell.magic_autoreload("2")
+        mod_name, mod_fn = self.new_module(
+            """
+            class Test():
+                def meth(self):
+                    return "old"
+        """
+        )
+        assert "test" not in self.shell.ns
+        assert "result" not in self.shell.ns
+
+        self.shell.run_code("from %s import Test" % mod_name)
+        self.shell.run_code("test = Test()")
+
+        self.write_file(
+            mod_fn,
+            """
+            class Test():
+                def meth(self):
+                    return "new"
+        """,
+        )
+
+        test_object = self.shell.ns["test"]
+
+        # important to trigger autoreload logic !
+        self.shell.run_code("pass")
+
+        test_class = pickle_get_current_class(test_object)
+        assert isinstance(test_object, test_class)
+
+        # extra check.
+        self.shell.run_code("import pickle")
+        self.shell.run_code("p = pickle.dumps(test)")
 
     def test_reload_class_attributes(self):
         self.shell.magic_autoreload("2")
@@ -394,6 +442,7 @@ x = -99
 
     def test_smoketest_autoreload(self):
         self._check_smoketest(use_aimport=False)
+
 
 
 


### PR DESCRIPTION
This is my first attempt in solving the problematic discussed in https://github.com/ipython/ipython/issues/11588. Although `%autoreload` updates class attributes for reloaded modules "on the fly", thus providing these updated attributes also to previously instantiated objects of that class, these old objects remain of type "old class definition", meaning that they can't be pickled. 

(This is also my first open source contribution in general, so be gentle with me :) )

As you can see, this relies on identifying the execution frame from the stack that holds all user defined variables. My current search conditions were inspired by the definition of `%who_ls`, but even though it worked for manual tests (creating a module with a class, creating an instance of that class, change the definition inside the module, compare type of already existing instance with new ones), I couldn't get it to work in the FakeShell environment of the tests in test_autoreload. So maybe there is a more general/fail proof possibility to find the user namespace?

EDIT: The tests fail mainly because `FakeShell` doesn't have a `user_ns`. Adding an empty namespace lets the tests succeed, but the functionality is still lost.