### PR TITLE
Add 'normalize' argument to Audio to make normalization optional

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -97,6 +97,8 @@ class Audio(DisplayObject):
         super(Audio, self).__init__(data=data, url=url, filename=filename)
 
         if self.data is not None and not isinstance(self.data, bytes):
+            if rate is None:
+                raise ValueError("rate must be specified when data is a numpy array or list of audio samples.")
             self.data = Audio._make_wav(data, rate)
 
     def reload(self):

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -85,7 +85,7 @@ class Audio(DisplayObject):
 
     def __init__(self, data=None, filename=None, url=None, embed=None, rate=None, autoplay=False):
         if filename is None and url is None and data is None:
-            raise ValueError("No image data found. Expecting filename, url, or data.")
+            raise ValueError("No audio data found. Expecting filename, url, or data.")
         if embed is False and url is None:
             raise ValueError("No url found. Expecting url when embed=False")
 

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -159,16 +159,12 @@ class Audio(DisplayObject):
 
     @staticmethod
     def _validate_and_normalize_without_numpy(data):
-        # check that it is a "1D" list
-        idata = iter(data)  # fails if not an iterable
         try:
-            iter(idata.next())
+            maxabsvalue = float(max([abs(x) for x in data]))
+        except TypeError:
             raise TypeError('Only lists of mono audio are '
                 'supported if numpy is not installed')
-        except TypeError:
-            # this means it's not a nested list, which is what we want
-            pass
-        maxabsvalue = float(max([abs(x) for x in data]))
+
         scaled = [int(x/maxabsvalue*32767) for x in data]
         nchan = 1
         return scaled, nchan

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -19,7 +19,10 @@ try:
     import pathlib
 except ImportError:
     pass
-from unittest import mock
+from unittest import TestCase, mock
+import struct
+import wave
+from io import BytesIO
 
 # Third-party imports
 import nose.tools as nt
@@ -184,25 +187,66 @@ def test_audio_from_file():
     path = pjoin(dirname(__file__), 'test.wav')
     display.Audio(filename=path)
 
-def test_audio_from_numpy_array():
-    display.Audio(get_test_tone(), rate=44100)
+class TestAudioDataWithNumpy(TestCase):
+    def test_audio_from_numpy_array(self):
+        test_tone = get_test_tone()
+        audio = display.Audio(test_tone, rate=44100)
+        nt.assert_equal(len(read_wav(audio.data)), len(test_tone))
 
-def test_audio_from_list_without_numpy():
-    # Simulate numpy not installed.
-    with mock.patch('numpy.array', side_effect=ImportError):
-        display.Audio(list(get_test_tone()), rate=44100)
+    def test_audio_from_list(self):
+        test_tone = get_test_tone()
+        audio = display.Audio(list(test_tone), rate=44100)
+        nt.assert_equal(len(read_wav(audio.data)), len(test_tone))
 
-def test_audio_from_list_without_numpy_raises_for_nested_list():
-    # Simulate numpy not installed.
-    with mock.patch('numpy.array', side_effect=ImportError):
+    def test_audio_from_numpy_array_without_rate_raises(self):
+        nt.assert_raises(ValueError, display.Audio, get_test_tone())
+
+    def test_audio_data_normalization(self):
+        expected_max_value = numpy.iinfo(numpy.int16).max
+        for scale in [1, 0.5, 2]:
+            audio = display.Audio(get_test_tone(scale), rate=44100)
+            actual_max_value = numpy.max(numpy.abs(read_wav(audio.data)))
+            nt.assert_equal(actual_max_value, expected_max_value)
+
+    def test_audio_data_without_normalization(self):
+        max_int16 = numpy.iinfo(numpy.int16).max
+        for scale in [1, 0.5, 0.2]:
+            test_tone = get_test_tone(scale)
+            test_tone_max_abs = numpy.max(numpy.abs(test_tone))
+            expected_max_value = int(max_int16 * test_tone_max_abs)
+            audio = display.Audio(test_tone, rate=44100, normalize=False)
+            actual_max_value = numpy.max(numpy.abs(read_wav(audio.data)))
+            nt.assert_equal(actual_max_value, expected_max_value)
+
+    def test_audio_data_without_normalization_raises_for_invalid_data(self):
+        nt.assert_raises(
+            ValueError,
+            lambda: display.Audio([1.001], rate=44100, normalize=False))
+        nt.assert_raises(
+            ValueError,
+            lambda: display.Audio([-1.001], rate=44100, normalize=False))
+
+def simulate_numpy_not_installed():
+    return mock.patch('numpy.array', mock.MagicMock(side_effect=ImportError))
+
+@simulate_numpy_not_installed()
+class TestAudioDataWithoutNumpy(TestAudioDataWithNumpy):
+    # All tests from `TestAudioDataWithNumpy` are inherited.
+
+    def test_audio_raises_for_nested_list(self):
         stereo_signal = [list(get_test_tone())] * 2
-        nt.assert_raises(TypeError, lambda: display.Audio(stereo_signal, rate=44100))
+        nt.assert_raises(
+            TypeError,
+            lambda: display.Audio(stereo_signal, rate=44100))
 
-def test_audio_from_numpy_array_without_rate_raises():
-    nt.assert_raises(ValueError, display.Audio, get_test_tone())
+def get_test_tone(scale=1):
+    return numpy.sin(2 * numpy.pi * 440 * numpy.linspace(0, 1, 44100)) * scale
 
-def get_test_tone():
-    return numpy.sin(2 * numpy.pi * 440 * numpy.linspace(0, 1, 44100))
+def read_wav(data):
+    with wave.open(BytesIO(data)) as wave_file:
+        wave_data = wave_file.readframes(wave_file.getnframes())
+        num_samples = wave_file.getnframes() * wave_file.getnchannels()
+        return struct.unpack('<%sh' % num_samples, wave_data)
 
 def test_code_from_file():
     c = display.Code(filename=__file__)

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -19,6 +19,7 @@ try:
     import pathlib
 except ImportError:
     pass
+from unittest import mock
 
 # Third-party imports
 import nose.tools as nt
@@ -185,6 +186,17 @@ def test_audio_from_file():
 
 def test_audio_from_numpy_array():
     display.Audio(get_test_tone(), rate=44100)
+
+def test_audio_from_list_without_numpy():
+    # Simulate numpy not installed.
+    with mock.patch('numpy.array', side_effect=ImportError):
+        display.Audio(list(get_test_tone()), rate=44100)
+
+def test_audio_from_list_without_numpy_raises_for_nested_list():
+    # Simulate numpy not installed.
+    with mock.patch('numpy.array', side_effect=ImportError):
+        stereo_signal = [list(get_test_tone())] * 2
+        nt.assert_raises(TypeError, lambda: display.Audio(stereo_signal, rate=44100))
 
 def test_audio_from_numpy_array_without_rate_raises():
     nt.assert_raises(ValueError, display.Audio, get_test_tone())

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -22,10 +22,10 @@ except ImportError:
 
 # Third-party imports
 import nose.tools as nt
+import numpy
 
 # Our own imports
 from IPython.lib import display
-from IPython.testing.decorators import skipif_not_numpy
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -179,10 +179,18 @@ def test_recursive_FileLinks():
     actual = actual.split('\n')
     nt.assert_equal(len(actual), 2, actual)
 
-@skipif_not_numpy
 def test_audio_from_file():
     path = pjoin(dirname(__file__), 'test.wav')
     display.Audio(filename=path)
+
+def test_audio_from_numpy_array():
+    display.Audio(get_test_tone(), rate=44100)
+
+def test_audio_from_numpy_array_without_rate_raises():
+    nt.assert_raises(ValueError, display.Audio, get_test_tone())
+
+def get_test_tone():
+    return numpy.sin(2 * numpy.pi * 440 * numpy.linspace(0, 1, 44100))
 
 def test_code_from_file():
     c = display.Code(filename=__file__)

--- a/docs/source/whatsnew/pr/optional-audio-normalization.rst
+++ b/docs/source/whatsnew/pr/optional-audio-normalization.rst
@@ -1,0 +1,7 @@
+Make audio normalization optional
+=================================
+
+Added 'normalize' argument to `IPython.display.Audio`. This argument applies
+when audio data is given as an array of samples. The default of `normalize=True`
+preserves prior behavior of normalizing the audio to the maximum possible range.
+Setting to `False` disables normalization.


### PR DESCRIPTION
Fixes #8608. Based on #11161 with changes as discussed (see [comment](https://github.com/ipython/ipython/pull/11161#issuecomment-470323709)).
It might be easier to review each commit separately in this PR.

While working on the fix, I encountered and fixed the following small bugs:
* Audio from list of samples, without numpy installed, would fail with ugly exception on Python 3.
* When rate wasn't specified but audio data was given, error was not helpful.
* Error when data was not found said 'image' instead of 'audio'.

