### PR TITLE
Verbose error message when displaying a nonexistent image.

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1270,10 +1270,12 @@ class Image(DisplayObject):
             return b64_data
 
     def _repr_png_(self):
-        return self._data_and_metadata()
+        if self.embed and self.format == self._FMT_PNG:
+            return self._data_and_metadata()
 
     def _repr_jpeg_(self):
-        return self._data_and_metadata()
+        if self.embed and self.format == self._FMT_JPEG:
+            return self._data_and_metadata()
 
     def _find_ext(self, s):
         return s.split('.')[-1].lower()

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1250,7 +1250,11 @@ class Image(DisplayObject):
 
     def _data_and_metadata(self, always_both=False):
         """shortcut for returning metadata with shape information, if defined"""
-        b64_data = b2a_base64(self.data).decode('ascii')
+        try:
+            b64_data = b2a_base64(self.data).decode('ascii')
+        except TypeError:
+            raise FileNotFoundError(
+                "No such file or directory: '%s'" % (self.data))
         md = {}
         if self.metadata:
             md.update(self.metadata)
@@ -1266,12 +1270,10 @@ class Image(DisplayObject):
             return b64_data
 
     def _repr_png_(self):
-        if self.embed and self.format == self._FMT_PNG:
-            return self._data_and_metadata()
+        return self._data_and_metadata()
 
     def _repr_jpeg_(self):
-        if self.embed and self.format == self._FMT_JPEG:
-            return self._data_and_metadata()
+        return self._data_and_metadata()
 
     def _find_ext(self, s):
         return s.split('.')[-1].lower()


### PR DESCRIPTION
The error is now a FileNotFoundError - the same as the Image class when the filename does not exist.
