### PR TITLE
Add 'id' to Audio widget's HTML for javascript interaction

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -89,7 +89,7 @@ class Audio(DisplayObject):
     """
     _read_flags = 'rb'
 
-    def __init__(self, data=None, filename=None, url=None, embed=None, rate=None, autoplay=False, normalize=True,
+    def __init__(self, data=None, filename=None, url=None, embed=None, rate=None, autoplay=False, normalize=True, *,
                  element_id=None):
         if filename is None and url is None and data is None:
             raise ValueError("No audio data found. Expecting filename, url, or data.")

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -86,6 +86,11 @@ class Audio(DisplayObject):
         Audio(b'RAW_WAV_DATA..)  # From bytes
         Audio(data=b'RAW_WAV_DATA..)
 
+    See Also
+    --------
+    
+    See also the ``Audio`` widgets form the ``ipywidget`` package for more flexibility and options.
+    
     """
     _read_flags = 'rb'
 

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -89,7 +89,8 @@ class Audio(DisplayObject):
     """
     _read_flags = 'rb'
 
-    def __init__(self, data=None, filename=None, url=None, embed=None, rate=None, autoplay=False, normalize=True):
+    def __init__(self, data=None, filename=None, url=None, embed=None, rate=None, autoplay=False, normalize=True,
+                 element_id=None):
         if filename is None and url is None and data is None:
             raise ValueError("No audio data found. Expecting filename, url, or data.")
         if embed is False and url is None:
@@ -100,6 +101,7 @@ class Audio(DisplayObject):
         else:
             self.embed = True
         self.autoplay = autoplay
+        self.element_id = element_id
         super(Audio, self).__init__(data=data, url=url, filename=filename)
 
         if self.data is not None and not isinstance(self.data, bytes):
@@ -198,12 +200,13 @@ class Audio(DisplayObject):
 
     def _repr_html_(self):
         src = """
-                <audio controls="controls" {autoplay}>
+                <audio {element_id} controls="controls" {autoplay}>
                     <source src="{src}" type="{type}" />
                     Your browser does not support the audio element.
                 </audio>
               """
-        return src.format(src=self.src_attr(),type=self.mimetype, autoplay=self.autoplay_attr())
+        return src.format(src=self.src_attr(), type=self.mimetype, autoplay=self.autoplay_attr(),
+                          element_id=self.element_id_attr())
 
     def src_attr(self):
         import base64
@@ -219,6 +222,12 @@ class Audio(DisplayObject):
     def autoplay_attr(self):
         if(self.autoplay):
             return 'autoplay="autoplay"'
+        else:
+            return ''
+    
+    def element_id_attr(self):
+        if (self.element_id):
+            return 'id="{element_id}"'.format(element_id=self.element_id)
         else:
             return ''
 


### PR DESCRIPTION
**Problem**: At present, the Audio widget can play a .wav, numpy data among others. However, once initialized, we cannot interact with this Widget through code. This is a problem when creating e.g. an interactive audio dashboard.

**Solution**: By adding an `id` to the HTML code, we can grab the Audio widget through JavaScript.

With this pull request, you can do the following:

Cell 1
```
import numpy as np
from IPython.display import Audio

# 2 seconds sine wave
sr = 22050 # sample rate
T = 2.0    # seconds
t = np.linspace(0, T, int(T*sr), endpoint=False) # time variable
x = 0.5*np.sin(2*np.pi*440*t)                # pure sine wave at 440 Hz

Audio(x, rate=sr, element_id="my-audio")
```
Output: Audio widget

Cell 2
```
%%javascript

// Get the Audio widget from the DOM
var aud_js = document.getElementById("my-audio");
aud_js.play();
```

**Result**: Code controlled audio play

---
While this solution allows for Audio widget interaction, such as 'play', 'pause' and 'currentTime' (seeking), it might be more desirable that this is implemented at a Widget level.

Even more desirable might be to expose these JavaScript functions through a Python interface, preventing the need for the user to write any JavaScript code. The library Panel, from PyViz has taken this approach: https://github.com/pyviz/panel/pull/215