### PR TITLE
Add a -q parameter to %rerun magic

### DIFF
--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -289,8 +289,12 @@ class HistoryMagics(Magics):
           current command.
 
           -g foo : Repeat the most recent line which contains foo
+
+          -q     : Quiet mode: do not add the code being executed or any headings
+          to the output, output only what the original cell would have.
+
         """
-        opts, args = self.parse_options(parameter_s, 'l:g:', mode='string')
+        opts, args = self.parse_options(parameter_s, 'l:g:q', mode='string')
         if "l" in opts:         # Last n lines
             n = int(opts['l'])
             hist = self.shell.history_manager.get_tail(n)
@@ -312,7 +316,8 @@ class HistoryMagics(Magics):
             print("No lines in history match specification")
             return
         histlines = "\n".join(hist)
-        print("=== Executing: ===")
-        print(histlines)
-        print("=== Output: ===")
+        if 'q' not in opts:
+            print("=== Executing: ===")
+            print(histlines)
+            print("=== Output: ===")
         self.shell.run_cell("\n".join(hist), store_history=False)

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -21,6 +21,7 @@ from traitlets.config.loader import Config
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.core.history import HistoryManager, extract_hist_ranges
 from IPython.testing.decorators import skipif
+from IPython.utils.capture import capture_output
 
 def setUp():
     nt.assert_equal(sys.getdefaultencoding(), "utf-8")
@@ -167,6 +168,28 @@ def test_magic_rerun():
     nt.assert_equal(ip.user_ns["a"], 11)
     ip.run_cell("%rerun", store_history=True)
     nt.assert_equal(ip.user_ns["a"], 12)
+
+def test_magic_rerun_search():
+    """Test for %rerun -g (searching for text match)"""
+    ip = get_ipython()
+    ip.run_cell("a = 10", store_history=True)
+    ip.run_cell("a += 1", store_history=True)
+    nt.assert_equal(ip.user_ns["a"], 11)
+    ip.run_cell("%rerun -g 10", store_history=True)
+    nt.assert_equal(ip.user_ns["a"], 10)
+
+
+def test_magic_rerun_quiet():
+    """Simple test for %rerun -q (quiet, no echoing of output)"""
+    ip = get_ipython()
+    ip.run_cell("a = 10", store_history=True)
+    ip.run_cell("a += 1", store_history=True)
+    nt.assert_equal(ip.user_ns["a"], 11)
+    with capture_output() as cap:
+        ip.run_cell("%rerun -q", store_history=True)
+    nt.assert_equal(ip.user_ns["a"], 12)
+    nt.assert_not_in("a += 1", cap.stdout)
+
 
 def test_timestamp_type():
     ip = get_ipython()

--- a/docs/source/whatsnew/pr/quiet-rerun-feature.rst
+++ b/docs/source/whatsnew/pr/quiet-rerun-feature.rst
@@ -1,0 +1,5 @@
+Quiet %rerun magic
+==================
+
+The %rerun magic accepts a new parameter, -q, which suppresses the printing of
+the target cell's contents when re-running.


### PR DESCRIPTION
This allows the rerun magic to be run in quiet mode, which suppresses
the `=== Executing: ===` and `=== Output: ===` headings as well as the
text of the cell being re-run. This means that cells that print can
optionally be re-run as part of a larger control structure like a loop
without IPython-specific noise.