### PR TITLE
Added support to list all available object types for the magic function "%psearch".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ __pycache__
 .vscode
 .pytest_cache
 .python-version
+venv*/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__
 .pytest_cache
 .python-version
 venv*/
+.idea/

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -173,6 +173,9 @@ class NamespaceMagics(Magics):
           'builtin', 'user', 'user_global','internal', 'alias', where
           'builtin' and 'user' are the search defaults.  Note that you should
           not use quotes when specifying namespaces.
+          
+          -l: List all available object types for object matching. This function
+          can be used without arguments.
 
           'Builtin' contains the python module builtin, 'user' contains all
           user data, 'alias' only contain the shell aliases and no python
@@ -200,6 +203,10 @@ class NamespaceMagics(Magics):
         Show objects beginning with a single _::
 
           %psearch -a _*         list objects beginning with a single underscore
+          
+        List available objects::
+        
+          %psearch -l            list all available object types
         """
         try:
             parameter_s.encode('ascii')
@@ -211,10 +218,15 @@ class NamespaceMagics(Magics):
         def_search = ['user_local', 'user_global', 'builtin']
 
         # Process options/args
-        opts,args = self.parse_options(parameter_s,'cias:e:',list_all=True)
+        opts,args = self.parse_options(parameter_s,'cias:e:l',list_all=True)
         opt = opts.get
         shell = self.shell
         psearch = shell.inspector.psearch
+        
+        # select list object types
+        list_types = False
+        if 'l' in opts:
+            list_types = True
 
         # select case options
         if 'i' in opts:
@@ -232,7 +244,7 @@ class NamespaceMagics(Magics):
         # Call the actual search
         try:
             psearch(args,shell.ns_table,ns_search,
-                    show_all=opt('a'),ignore_case=ignore_case)
+                    show_all=opt('a'),ignore_case=ignore_case, list_types=list_types)
         except:
             shell.showtraceback()
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -35,6 +35,7 @@ from IPython.utils.dir2 import safe_hasattr
 from IPython.utils.path import compress_user
 from IPython.utils.text import indent
 from IPython.utils.wildcard import list_namespace
+from IPython.utils.wildcard import typestr2type
 from IPython.utils.coloransi import TermColors, ColorScheme, ColorSchemeTable
 from IPython.utils.py3compat import cast_unicode
 from IPython.utils.colorable import Colorable
@@ -962,7 +963,7 @@ class Inspector(Colorable):
             return False
 
     def psearch(self,pattern,ns_table,ns_search=[],
-                ignore_case=False,show_all=False):
+                ignore_case=False,show_all=False, list_types=False):
         """Search namespaces with wildcards for objects.
 
         Arguments:
@@ -981,12 +982,19 @@ class Inspector(Colorable):
 
           - show_all(False): show all names, including those starting with
             underscores.
+            
+          - list_types(False): list all available object types for object matching.
         """
         #print 'ps pattern:<%r>' % pattern # dbg
 
         # defaults
         type_pattern = 'all'
         filter = ''
+
+        # list all object types
+        if list_types:
+            page.page('\n'.join(sorted(typestr2type)))
+            return
 
         cmds = pattern.split()
         len_cmds  =  len(cmds)

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -963,7 +963,7 @@ class Inspector(Colorable):
             return False
 
     def psearch(self,pattern,ns_table,ns_search=[],
-                ignore_case=False,show_all=False, list_types=False):
+                ignore_case=False,show_all=False, *, list_types=False):
         """Search namespaces with wildcards for objects.
 
         Arguments:


### PR DESCRIPTION
These commits add the functionality to list available object types for the **%psearch** magic. The reason for this modification is the need to know which objects are available for filtering. The documentation is also outdated and commands like:
`%psearch a* function` produce no results.

The correct command would be:
`%psearch a* builtinmethod`

Usage of new function:
`%psearch -l`, produces the following output in Python 3.6.8:

> asyncgenerator
> builtinfunction
> builtinmethod
> code
> coroutine
> frame
> function
> generator
> getsetdescriptor
> lambda
> mappingproxy
> memberdescriptor
> method
> module
> traceback