### PR TITLE
Use ast.parse a  when breaking lines for the IPython Sphinx Directive

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -813,6 +813,8 @@ class EmbeddedSphinxShell(object):
         fmtoutput = []
         for block in output:
             for i, line in enumerate(block):
+                if line[:8] == '@savefig':
+                    fmtoutput.append(line)
                 if i == 0:
                     modified = u'%s %s' % (fmtin % ct, line.strip())
                     continuation = u'   %s:' % ''.join(['.']*(len(str(ct))+2))


### PR DESCRIPTION
Currently, IPython's sphinx directive doesn't really use the `ast.parse` to decide where to break lines, except for functions. This encourages the directive to do just that. 

This will likely break a bunch of people's docs, so I would suggest we do this right and give some warning. 

Additionally, I think currently bad syntax gets ignored by the code. This will now crash.

xref #11362