### PR TITLE
Update StoreMagic docstring on how to remove an alias

### DIFF
--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -112,6 +112,7 @@ class StoreMagics(Magics):
         python types can be safely %store'd.
 
         Also aliases can be %store'd across sessions.
+        To remove an alias from the storage, use the %unalias magic.
         """
 
         opts,argsl = self.parse_options(parameter_s,'drz',mode='string')


### PR DESCRIPTION
I was playing a bit with the `%store` magic and I was surprised that I couldn't delete the aliases with the `%store -z`/`%store -d`. Then I started reading the code and realized that there is an `%unalias` method for that (which is logical, but not obvious when you are in the `%store` documentation), so I've update the documentation with a small info about that.
I hope it will help someone in the future to avoid this confusion.