### PR TITLE
docs: typo fix

### DIFF
--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -698,7 +698,7 @@ your Python programs for this to work (detailed examples follow later)::
     embed() # this call anywhere in your program will start IPython
 
 You can also embed an IPython *kernel*, for use with qtconsole, etc. via
-``IPython.embed_kernel()``. This should function work the same way, but you can
+``IPython.embed_kernel()``. This should work the same way, but you can
 connect an external frontend (``ipython qtconsole`` or ``ipython console``),
 rather than interacting with it in the terminal.
 


### PR DESCRIPTION
While reading the documentation, I found what seems to be a small duplication (the "function" / "work" means the same), so I removed it.