### PR TITLE
Simplify _completer() constr. in core/completer.py

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2198,7 +2198,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # Inject names into __builtin__ so we can complete on the added names.
         with self.builtin_trap:
-            return self.Completer.complete(text, line, cursor_pos)
+            return self.Completer.complete(line, cursor_pos)
 
     def set_custom_completer(self, completer, pos=0):
         """Adds a new custom completer function.


### PR DESCRIPTION
Exclude the text field from the constructor and made modifications
accordingly to this new requirement.

This is part of #11622, still much more to do. I excluded the text field from the _complete() function and modified the class' constructor accordingly.