### PR TITLE
Fix UnicodeEncodeError and crash. Fixes #11706

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -187,7 +187,12 @@ class DisplayHook(Configurable):
                 # But avoid extraneous empty lines.
                 result_repr = '\n' + result_repr
 
-        print(result_repr)
+        try:
+            print(result_repr)
+        except UnicodeEncodeError:
+            # If a character is not supported by the terminal encoding replace
+            # it with its \u or \x representation
+            print(result_repr.encode(sys.stdout.encoding,'backslashreplace').decode(sys.stdout.encoding))
 
     def update_user_ns(self, result):
         """Update user_ns with various things like _, __, _1, etc."""


### PR DESCRIPTION
If a character is not supported by the terminal encoding replace it with the \u or \x representation, instead of giving an error or even crashing IPython.

Fixes #11706