### PR TITLE
[Outdated] Add prompt_toolkit 3.0 support

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -16,6 +16,7 @@ from traitlets import (
 )
 
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
+from prompt_toolkit.eventloop.inputhook import set_eventloop_with_inputhook
 from prompt_toolkit.filters import (HasFocus, Condition, IsDone)
 from prompt_toolkit.formatted_text import PygmentsTokens
 from prompt_toolkit.history import InMemoryHistory
@@ -291,6 +292,8 @@ class TerminalInteractiveShell(InteractiveShell):
                             color_depth=self.color_depth,
                             **self._extra_prompt_options())
 
+        set_eventloop_with_inputhook(self.inputhook)
+
     def _make_style_from_name_or_cls(self, name_or_cls):
         """
         Small wrapper that make an IPython compatible style from a style name
@@ -393,8 +396,7 @@ class TerminalInteractiveShell(InteractiveShell):
                         processor=HighlightMatchingBracketProcessor(chars='[](){}'),
                         filter=HasFocus(DEFAULT_BUFFER) & ~IsDone() &
                             Condition(lambda: self.highlight_matching_brackets))],
-                'inputhook': self.inputhook,
-                }
+        }
 
     def prompt_for_code(self):
         if self.rl_next_input:

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ install_requires = [
     'decorator',
     'pickleshare',
     'traitlets>=4.2',
-    'prompt_toolkit>=3.0.0,<3.1.0',
+    'prompt_toolkit>=2.0.0,<3.1.0',
     'pygments',
     'backcall',
 ]

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ install_requires = [
     'decorator',
     'pickleshare',
     'traitlets>=4.2',
-    'prompt_toolkit>=2.0.0,<2.1.0',
+    'prompt_toolkit>=3.0.0,<3.1.0',
     'pygments',
     'backcall',
 ]


### PR DESCRIPTION
**This shouldn't be merged before the official release of [`prompt_toolkit` 3.0](https://github.com/prompt-toolkit/python-prompt-toolkit/commit/c7851c09ffbfa7d06458408abee77ab6f548852d)**. See the *[changelog](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/CHANGELOG)* for more infos

This will most likely be done by jonathanslenders once it is ready, but I allowed myself to start the work (at least make IPython usable). There's probably more potential (cool asyncio..). 

I hope that's not an issue if this PR waits.

## Details

<details>
<summary>
So far, this makes IPython runnable but triggers warnings on closing (I don't think that's on IPython's side)
</summary>

```
Do you really want to exit ([y]/n)? 

Task was destroyed but it is pending!
task: <Task pending coro=<History._start_loading() running at /home/gpotter/.pyenv/versions/3.7.2/lib/python3.7/site-packages/prompt_toolkit-3.0.0-py3.7.egg/prompt_toolkit/history.py:39>>
/home/gpotter/.pyenv/versions/3.7.2/lib/python3.7/asyncio/base_events.py:609: RuntimeWarning: coroutine 'History._start_loading' was never awaited
  self._ready.clear()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Task was destroyed but it is pending!
task: <Task pending coro=<History._start_loading() running at /home/gpotter/.pyenv/versions/3.7.2/lib/python3.7/site-packages/prompt_toolkit-3.0.0-py3.7.egg/prompt_toolkit/history.py:39>>
Task was destroyed but it is pending!
task: <Task pending coro=<History._start_loading() running at /home/gpotter/.pyenv/versions/3.7.2/lib/python3.7/site-packages/prompt_toolkit-3.0.0-py3.7.egg/prompt_toolkit/history.py:39>>
```

*(It's actually a single issue that makes multiple warnings, I suspect it's a bug (ptk v3 is in early stages))*

</details>

<details>
<summary> 
 `patch_stdout` is said to have been updated for a newer format, but this info doesn't match the code behind it.
</summary>

From the changelog:
> `patch_stdout` now requires an `Application` as input.

In reality (as of writing): [commit](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/c7851c09ffbfa7d06458408abee77ab6f548852d/prompt_toolkit/patch_stdout.py#L35-L46)

```python
def patch_stdout(raw: bool = False) -> Generator[None, None, None]:
    """
    Replace `sys.stdout` by an :class:`_StdoutProxy` instance.
    Writing to this proxy will make sure that the text appears above the
    prompt, and that it doesn't destroy the output from the renderer.  If no
    application is curring, the behaviour should be identical to writing to
    `sys.stdout` directly.
    :param raw: (`bool`) When True, vt100 terminal escape sequences are not
                removed/escaped.
    """
```

</details>

## Status

**Important note:** `prompt_toolkit 3.0` requires `Python 3.6+`. ~~It's however totally doable to support both V2 and V3. However I'm not sure how IPython deals with versioning, therefore any directions would be appreciated.~~ **Therefore this supports both v2 and v3**

I'll update the PR to keep it working, if other changes are made, until it either gets discussed, or a better PR replaces it (in which case feel free to close this)