### PR TITLE
Properly don't require numpy to run tests.

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -183,7 +183,7 @@ def test_forward_unicode_completion():
     nt.assert_equal(matches[0], 'Ⅴ')
 
 @nt.nottest # now we have a completion for \jmath
-@decorators.dec.knownfailureif(sys.platform == 'win32', 'Fails if there is a C:\\j... path')
+@decorators.knownfailureif(sys.platform == 'win32', 'Fails if there is a C:\\j... path')
 def test_no_ascii_back_completion():
     ip = get_ipython()
     with TemporaryWorkingDirectory():  # Avoid any filename completions
@@ -234,7 +234,7 @@ def test_has_open_quotes4():
         nt.assert_false(completer.has_open_quotes(s))
 
 
-@decorators.dec.knownfailureif(sys.platform == 'win32', "abspath completions fail on Windows")
+@decorators.knownfailureif(sys.platform == 'win32', "abspath completions fail on Windows")
 def test_abspath_file_completions():
     ip = get_ipython()
     with TemporaryDirectory() as tmpdir:

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -538,7 +538,7 @@ def test_run_tb():
         nt.assert_in("RuntimeError", out)
         nt.assert_equal(out.count("---->"), 3)
 
-@dec.dec.knownfailureif(sys.platform == 'win32', "writes to io.stdout aren't captured on Windows")
+@dec.knownfailureif(sys.platform == 'win32', "writes to io.stdout aren't captured on Windows")
 def test_script_tb():
     """Test traceback offset in `ipython script.py`"""
     with TemporaryDirectory() as td:

--- a/IPython/external/decorators/__init__.py
+++ b/IPython/external/decorators/__init__.py
@@ -1,9 +1,7 @@
 try:
-    from numpy.testing import *
-    from numpy.testing import dec
-    from numpy.testing.noseclasses import KnownFailure
+    from numpy.testing.noseclasses import KnownFailure, knownfailureif
 except ImportError:
-    from ._decorators import *
+    from ._decorators import knownfailureif
     try:
         from ._numpy_testing_noseclasses import KnownFailure
     except ImportError:

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -26,10 +26,16 @@ from io import BytesIO
 
 # Third-party imports
 import nose.tools as nt
-import numpy
+
+try:
+    import numpy
+except ImportError:
+    pass
 
 # Our own imports
 from IPython.lib import display
+
+from IPython.testing.decorators import skipif_not_numpy
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -188,19 +194,24 @@ def test_audio_from_file():
     display.Audio(filename=path)
 
 class TestAudioDataWithNumpy(TestCase):
+
+    @skipif_not_numpy
     def test_audio_from_numpy_array(self):
         test_tone = get_test_tone()
         audio = display.Audio(test_tone, rate=44100)
         nt.assert_equal(len(read_wav(audio.data)), len(test_tone))
 
+    @skipif_not_numpy
     def test_audio_from_list(self):
         test_tone = get_test_tone()
         audio = display.Audio(list(test_tone), rate=44100)
         nt.assert_equal(len(read_wav(audio.data)), len(test_tone))
 
+    @skipif_not_numpy
     def test_audio_from_numpy_array_without_rate_raises(self):
         nt.assert_raises(ValueError, display.Audio, get_test_tone())
 
+    @skipif_not_numpy
     def test_audio_data_normalization(self):
         expected_max_value = numpy.iinfo(numpy.int16).max
         for scale in [1, 0.5, 2]:
@@ -208,6 +219,7 @@ class TestAudioDataWithNumpy(TestCase):
             actual_max_value = numpy.max(numpy.abs(read_wav(audio.data)))
             nt.assert_equal(actual_max_value, expected_max_value)
 
+    @skipif_not_numpy
     def test_audio_data_without_normalization(self):
         max_int16 = numpy.iinfo(numpy.int16).max
         for scale in [1, 0.5, 0.2]:
@@ -233,6 +245,7 @@ def simulate_numpy_not_installed():
 class TestAudioDataWithoutNumpy(TestAudioDataWithNumpy):
     # All tests from `TestAudioDataWithNumpy` are inherited.
 
+    @skipif_not_numpy
     def test_audio_raises_for_nested_list(self):
         stereo_signal = [list(get_test_tone())] * 2
         nt.assert_raises(

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -47,7 +47,7 @@ from .ipunittest import ipdoctest, ipdocstring
 # Grab the numpy-specific decorators which we keep in a file that we
 # occasionally update from upstream: decorators.py is a copy of
 # numpy.testing.decorators, we expose all of it here.
-from IPython.external.decorators import *
+from IPython.external.decorators import knownfailureif
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -333,7 +333,7 @@ skipif_not_matplotlib = skip_without('matplotlib')
 
 skipif_not_sympy = skip_without('sympy')
 
-skip_known_failure = dec.knownfailureif(True,'This test is known to fail')
+skip_known_failure = knownfailureif(True,'This test is known to fail')
 
 # A null 'decorator', useful to make more readable code that needs to pick
 # between different decorators based on OS or other conditions

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -37,7 +37,7 @@ from IPython import version_info
 from IPython.utils.py3compat import decode
 from IPython.utils.importstring import import_item
 from IPython.testing.plugin.ipdoctest import IPythonDoctest
-from IPython.external.decorators import KnownFailure, dec
+from IPython.external.decorators import KnownFailure, knownfailureif
 
 pjoin = path.join
 


### PR DESCRIPTION
Import explicitly instead of *-import to make sure we do not use
non-mocked features.

And skip tests that would actually require numpy.

Make it easier to test on nightly when numpy is hard to build.

Closes #11709