### PR TITLE
Support prompt_toolkit 3.0 as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ install_requires = [
     'decorator',
     'pickleshare',
     'traitlets>=4.2',
-    'prompt_toolkit>=2.0.0,<2.1.0',
+    'prompt_toolkit>=2.0.0,<3.1.0',
     'pygments',
     'backcall',
 ]


### PR DESCRIPTION
These are the required changes to support prompt_toolkit 3.0, once released.

The two biggest changes in prompt_toolkit 3.0 are:
- We have >95% of the code base covered with strict type annotations.
- It uses the asyncio event loop internally, rather then a custom built loop. This is also interesting for IPython, because asyncio tasks created in the repl keep running.

Because of the asyncio event loop, the way input hooks work is slightly different. This works now by creating a custom Selector object, and passing that to an asyncio SelectorLoop.

We can easily remain compatible with both prompt_toolkit 2 & 3, because the rest of the API remains mostly untouched.

Some further testing is required:
- Make sure that the input hooks are actually working correctly for IPython.
- Make sure it runs fine on Windows as well (I did some basic testing).
- Make sure it runs fine on Windows, using Python 3.8. - Python 3.8 will get the ProactorEventLoop by default on Windows, I believe there are still some issues with the prompt_toolkit/ProactorEventLoop/inputhooks combination.
