### PR TITLE
Accept matplotlib backends in uppercase

### DIFF
--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -96,7 +96,7 @@ class PylabMagics(Magics):
             backends_list = list(backends.keys())
             print("Available matplotlib backends: %s" % backends_list)
         else:
-            gui, backend = self.shell.enable_matplotlib(args.gui)
+            gui, backend = self.shell.enable_matplotlib(args.gui.lower())
             self._show_matplotlib_backend(args.gui, backend)
 
     @skip_doctest


### PR DESCRIPTION
Call to `str.lower()` to accept matplotlib backends written in uppercase, i.e. "Qt5" or "GTK3"