### PR TITLE
Tests: Allow setting a custom timeout scale

### DIFF
--- a/IPython/terminal/tests/test_debug_magic.py
+++ b/IPython/terminal/tests/test_debug_magic.py
@@ -14,6 +14,7 @@
 import os
 import sys
 from IPython.testing.decorators import skip_win32
+from IPython.testing import IPYTHON_TESTING_TIMEOUT_SCALE
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -31,11 +32,11 @@ def test_debug_magic_passes_through_generators():
     env = os.environ.copy()
     child = pexpect.spawn(sys.executable, ['-m', 'IPython', '--colors=nocolor', '--simple-prompt'],
                           env=env)
-    child.timeout = 15
+    child.timeout = 15 * IPYTHON_TESTING_TIMEOUT_SCALE
 
     child.expect(in_prompt)
 
-    child.timeout = 2
+    child.timeout = 2 * IPYTHON_TESTING_TIMEOUT_SCALE
 
     child.sendline("def f(x):")
     child.sendline("    raise Exception")

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -17,6 +17,7 @@ import sys
 import nose.tools as nt
 from IPython.utils.tempdir import NamedFileInTemporaryDirectory
 from IPython.testing.decorators import skip_win32
+from IPython.testing import IPYTHON_TESTING_TIMEOUT_SCALE
 
 #-----------------------------------------------------------------------------
 # Tests
@@ -72,7 +73,7 @@ def test_nest_embed():
 
     child = pexpect.spawn(sys.executable, ['-m', 'IPython', '--colors=nocolor'],
                           env=env)
-    child.timeout = 5
+    child.timeout = 5 * IPYTHON_TESTING_TIMEOUT_SCALE
     child.expect(ipy_prompt)
     child.sendline("import IPython")
     child.expect(ipy_prompt)

--- a/IPython/testing/__init__.py
+++ b/IPython/testing/__init__.py
@@ -8,6 +8,9 @@
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
+
+import os
+
 #-----------------------------------------------------------------------------
 # Functions
 #-----------------------------------------------------------------------------
@@ -32,6 +35,14 @@ def test(**kwargs):
     for name, val in kwargs.items():
         setattr(options, name, val)
     run_iptestall(options)
+
+#-----------------------------------------------------------------------------
+# Constants
+#-----------------------------------------------------------------------------
+
+# We scale all timeouts via this factor, slow machines can increase it
+IPYTHON_TESTING_TIMEOUT_SCALE = float(os.getenv(
+                                    'IPYTHON_TESTING_TIMEOUT_SCALE', 1))
 
 # So nose doesn't try to run this as a test itself and we end up with an
 # infinite test loop


### PR DESCRIPTION
Add environment variable `IPYTHON_TESTING_TIMEOUT_SCALE` that can be used to scale all the timeouts in tests.

Useful on slow machines, such as Fedora armv7hl/aarch64 builders.

Fixes https://github.com/ipython/ipython/issues/11754