### PR TITLE
Speed up timeit arguments test

### DIFF
--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -1165,8 +1165,8 @@ def test_time_no_var_expand():
 def test_timeit_arguments():
     "Test valid timeit arguments, should not cause SyntaxError (GH #1269)"
     if sys.version_info < (3,7):
-        _ip.magic("timeit ('#')")
+        _ip.magic("timeit -n1 -r1 ('#')")
     else:
         # 3.7 optimize no-op statement like above out, and complain there is
         # nothing in the for loop.
-        _ip.magic("timeit a=('#')")
+        _ip.magic("timeit -n1 -r1 a=('#')")


### PR DESCRIPTION
Fixes #11751 
This is a my first pull request, seemed relatively straightforward (assuming I understood the intent).
Ran the test on both Python 3.6/3.7, time reduced significantly.

Test group: IPython.core.tests.test_magic:test_timeit_arguments
.
----------------------------------------------------------------------
Ran 1 test in 0.009s