### PR TITLE
Fix state leakage and speedup in test-suite

### DIFF
--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -35,7 +35,6 @@ from IPython.utils.io import capture_output
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.core import debugger
 
-
 def doctest_refbug():
     """Very nasty problem with references held by multiple runs of a script.
     See: https://github.com/ipython/ipython/issues/141
@@ -537,6 +536,8 @@ def test_run_tb():
         nt.assert_not_in("execfile", out)
         nt.assert_in("RuntimeError", out)
         nt.assert_equal(out.count("---->"), 3)
+        del ip.user_ns['bar']
+        del ip.user_ns['foo']
 
 @dec.knownfailureif(sys.platform == 'win32', "writes to io.stdout aren't captured on Windows")
 def test_script_tb():

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -137,6 +137,12 @@ INDENT_SIZE = 8
 # to users of ultratb who are NOT running inside ipython.
 DEFAULT_SCHEME = 'NoColor'
 
+
+# Number of frame above which we are likely to have a recursion and will
+# **attempt** to detect it.  Made modifiable mostly to speedup test suite
+# as detecting recursion is one of our slowest test
+_FRAME_RECURSION_LIMIT = 500
+
 # ---------------------------------------------------------------------------
 # Code begins
 
@@ -431,7 +437,7 @@ def is_recursion_error(etype, value, records):
     # a recursion error.
     return (etype is recursion_error_type) \
            and "recursion" in str(value).lower() \
-           and len(records) > 500
+           and len(records) > _FRAME_RECURSION_LIMIT
 
 def find_recursion(etype, value, records):
     """Identify the repeating stack frames from a RecursionError traceback

--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -3,10 +3,13 @@ import tempfile, os
 from traitlets.config.loader import Config
 import nose.tools as nt
 
-ip = get_ipython()
-ip.magic('load_ext storemagic')
+
+def setup_module():
+    ip.magic('load_ext storemagic')
 
 def test_store_restore():
+    assert 'bar' not in ip.user_ns, "Error: some other test leaked `bar` in user_ns"
+    assert 'foo' not in ip.user_ns, "Error: some other test leaked `foo` in user_ns"
     ip.user_ns['foo'] = 78
     ip.magic('alias bar echo "hello"')
     tmpd = tempfile.mkdtemp()

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -122,6 +122,7 @@ def start_ipython():
     _ip = shell
     get_ipython = _ip.get_ipython
     builtin_mod._ip = _ip
+    builtin_mod.ip = _ip
     builtin_mod.get_ipython = get_ipython
 
     # Override paging, so we don't require user interaction during the tests.


### PR DESCRIPTION
This is mostly visible when running the test via pytest that
collect-then-run vs nose that runs as it collects.

While I was at it I've improved some tests to be faster by changing the
maximum recursion limit.