### PR TITLE
Remove assignment to ip in test files

### DIFF
--- a/IPython/core/tests/test_async_helpers.py
+++ b/IPython/core/tests/test_async_helpers.py
@@ -3,7 +3,6 @@ Test for async helpers.
 
 Should only trigger on python 3.5+ or will have syntax errors.
 """
-
 import sys
 from itertools import chain, repeat
 import nose.tools as nt
@@ -11,7 +10,7 @@ from textwrap import dedent, indent
 from unittest import TestCase
 from IPython.testing.decorators import skip_without
 
-ip = get_ipython()
+
 iprc = lambda x: ip.run_cell(dedent(x)).raise_error()
 iprc_nr = lambda x: ip.run_cell(dedent(x))
 

--- a/IPython/core/tests/test_autocall.py
+++ b/IPython/core/tests/test_autocall.py
@@ -8,11 +8,6 @@ with better-isolated tests that don't rely on the global instance in iptest.
 from IPython.core.splitinput import LineInfo
 from IPython.core.prefilter import AutocallChecker
 from IPython.utils import py3compat
-from IPython.testing.globalipapp import get_ipython
-
-
-ip = get_ipython()
-
 
 def doctest_autocall():
     """

--- a/IPython/core/tests/test_displayhook.py
+++ b/IPython/core/tests/test_displayhook.py
@@ -3,8 +3,6 @@ from IPython.testing.tools import AssertPrints, AssertNotPrints
 from IPython.core.displayhook import CapturingDisplayHook
 from IPython.utils.capture import CapturedIO
 
-ip = get_ipython()
-
 def test_output_displayed():
     """Checking to make sure that output is displayed"""
   

--- a/IPython/core/tests/test_handlers.py
+++ b/IPython/core/tests/test_handlers.py
@@ -10,7 +10,6 @@ import nose.tools as nt
 # our own packages
 from IPython.core import autocall
 from IPython.testing import tools as tt
-from IPython.testing.globalipapp import get_ipython
 from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------
@@ -18,7 +17,6 @@ from IPython.utils import py3compat
 #-----------------------------------------------------------------------------
 
 # Get the public instance of IPython
-ip = get_ipython()
 
 failures = []
 num_tests = 0

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -8,14 +8,6 @@
 import nose.tools as nt
 
 # our own packages
-from IPython.testing.globalipapp import get_ipython
-
-#-----------------------------------------------------------------------------
-# Globals
-#-----------------------------------------------------------------------------
-
-# Get the public instance of IPython
-ip = get_ipython()
 
 #-----------------------------------------------------------------------------
 # Test functions

--- a/IPython/core/tests/test_logger.py
+++ b/IPython/core/tests/test_logger.py
@@ -6,8 +6,6 @@ import os.path
 import nose.tools as nt
 from IPython.utils.tempdir import TemporaryDirectory
 
-_ip = get_ipython()
-
 def test_logstart_inaccessible_file():
     try:
         _ip.logger.logstart(logfname="/")   # Opening that filename will fail.

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -6,12 +6,10 @@
 import nose.tools as nt
 
 from IPython.core.prefilter import AutocallChecker
-from IPython.testing.globalipapp import get_ipython
 
 #-----------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------
-ip = get_ipython()
 
 def test_prefilter():
     """Test user input conversions"""

--- a/IPython/core/tests/test_prompts.py
+++ b/IPython/core/tests/test_prompts.py
@@ -4,10 +4,6 @@
 import unittest
 
 from IPython.core.prompts import  LazyEvaluate
-from IPython.testing.globalipapp import get_ipython
-
-ip = get_ipython()
-
 
 class PromptTests(unittest.TestCase):
     def test_lazy_eval_unicode(self):


### PR DESCRIPTION
This is already added in globals by the test runner