### PR TITLE
Fix skip decorator.

### DIFF
--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -245,8 +245,10 @@ def skip(msg=None):
          Decorator, which, when applied to a function, causes SkipTest
          to be raised, with the optional message added.
       """
-
-    return skipif(True,msg)
+    if msg and not isinstance(msg, str):
+        raise ValueError('invalid object passed to `@skip` decorator, did you '
+                         'meant `@skip()` with brackets ?')
+    return skipif(True, msg)
 
 
 def onlyif(condition, msg):

--- a/IPython/testing/tests/test_decorators.py
+++ b/IPython/testing/tests/test_decorators.py
@@ -46,7 +46,7 @@ def trivial():
     pass
 
 
-@dec.skip
+@dec.skip()
 def test_deliberately_broken():
     """A deliberately broken test - we want to skip this one."""
     1/0


### PR DESCRIPTION
If called w/o argument would just skip the function always.
Now raises if no message is passed.