### PR TITLE
Restore trace function after exiting debugger.

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -934,6 +934,7 @@ python-profiler package from non-free.""")
                 deb._exec_filename = filename
             while True:
                 try:
+                    trace = sys.gettrace()
                     deb.run(code, code_ns)
                 except Restart:
                     print("Restarting")
@@ -943,6 +944,8 @@ python-profiler package from non-free.""")
                     continue
                 else:
                     break
+                finally:
+                    sys.settrace(trace)
             
 
         except:


### PR DESCRIPTION
This should bump coverage; as pdb test where removing the coverage
function.