### PR TITLE
Fix Mixin Inheritence in Xunit unittest.

### DIFF
--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -530,6 +530,10 @@ class TestSafeExecfileNonAsciiPath(unittest.TestCase):
         ip.safe_execfile(self.fname, {}, raise_exceptions=True)
 
 class ExitCodeChecks(tt.TempFileMixin):
+
+    def setUp(self):
+        self.system = ip.system_raw
+
     def test_exit_code_ok(self):
         self.system('exit 0')
         self.assertEqual(ip.user_ns['_exit_code'], 0)
@@ -559,8 +563,11 @@ class ExitCodeChecks(tt.TempFileMixin):
                 del os.environ['SHELL']
 
 
-class TestSystemRaw(ExitCodeChecks, unittest.TestCase):
-    system = ip.system_raw
+class TestSystemRaw(ExitCodeChecks):
+
+    def setUp(self):
+        super().setUp()
+        self.sytem = ip.system_raw
 
     @onlyif_unicode_paths
     def test_1(self):
@@ -580,8 +587,11 @@ class TestSystemRaw(ExitCodeChecks, unittest.TestCase):
         self.assertEqual(ip.user_ns['_exit_code'], -signal.SIGINT)
 
 # TODO: Exit codes are currently ignored on Windows.
-class TestSystemPipedExitCode(ExitCodeChecks, unittest.TestCase):
-    system = ip.system_piped
+class TestSystemPipedExitCode(ExitCodeChecks):
+
+    def setUp(self):
+        super().setUp()
+        self.sytem = ip.system_piped
 
     @skip_win32
     def test_exit_code_ok(self):
@@ -595,7 +605,7 @@ class TestSystemPipedExitCode(ExitCodeChecks, unittest.TestCase):
     def test_exit_code_signal(self):
         ExitCodeChecks.test_exit_code_signal(self)
 
-class TestModules(tt.TempFileMixin, unittest.TestCase):
+class TestModules(tt.TempFileMixin):
     def test_extraneous_loads(self):
         """Test we're not loading modules on startup that we shouldn't.
         """
@@ -944,7 +954,7 @@ def wrn():
 
 class TestImportNoDeprecate(tt.TempFileMixin):
 
-    def setup(self):
+    def setUp(self):
         """Make a valid python temp file."""
         self.mktmp("""
 import warnings
@@ -954,6 +964,7 @@ def wrn():
         DeprecationWarning
     )
 """)
+        super().setUp()
 
     def test_no_dep(self):
         """

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -165,7 +165,7 @@ def doctest_reset_del():
 
 class TestMagicRunPass(tt.TempFileMixin):
 
-    def setup(self):
+    def setUp(self):
         content = "a = [1,2,3]\nb = 1"
         self.mktmp(content)
         

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -24,6 +24,8 @@ from io import StringIO
 import nose.tools as nt
 import IPython.testing.tools as tt
 
+from unittest import TestCase
+
 from IPython.testing.decorators import skipif
 
 from IPython.extensions.autoreload import AutoreloadMagics
@@ -63,7 +65,7 @@ class FakeShell:
         self.auto_magics.post_execute_hook()
 
 
-class Fixture(object):
+class Fixture(TestCase):
     """Fixture for creating test module files"""
 
     test_dir = None

--- a/IPython/testing/tests/test_tools.py
+++ b/IPython/testing/tests/test_tools.py
@@ -85,7 +85,7 @@ class TestAssertPrints(unittest.TestCase):
         self.assertRaises(AssertionError, func)
 
 
-class Test_ipexec_validate(unittest.TestCase, tt.TempFileMixin):
+class Test_ipexec_validate(tt.TempFileMixin):
     def test_main_path(self):
         """Test with only stdout results.
         """

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import tempfile
+import unittest
 
 from contextlib import contextmanager
 from io import StringIO
@@ -262,7 +263,7 @@ def ipexec_validate(fname, expected_out, expected_err='',
     nt.assert_equal("\n".join(out.strip().splitlines()), "\n".join(expected_out.strip().splitlines()))
 
 
-class TempFileMixin(object):
+class TempFileMixin(unittest.TestCase):
     """Utility class to create temporary Python/IPython files.
 
     Meant as a mixin class for test cases."""

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -90,7 +90,7 @@ def test_arg_split_win32():
         nt.assert_equal(arg_split(argstr), argv)
 
 
-class SubProcessTestCase(TestCase, tt.TempFileMixin):
+class SubProcessTestCase(tt.TempFileMixin):
     def setUp(self):
         """Make a valid python temp file."""
         lines = [ "import sys",


### PR DESCRIPTION
Some unittest were weird mixin, properly make the base class an
TestCase, and use setup/teardown to set local attributes.

This adds compatibility with PyTest