### PR TITLE
Misc modifications for pytest compatibility

### DIFF
--- a/IPython/core/tests/test_magic_terminal.py
+++ b/IPython/core/tests/test_magic_terminal.py
@@ -18,7 +18,6 @@ from IPython.testing import tools as tt
 #-----------------------------------------------------------------------------
 # Globals
 #-----------------------------------------------------------------------------
-ip = get_ipython()
 
 #-----------------------------------------------------------------------------
 # Test functions begin
@@ -170,7 +169,7 @@ class PasteTestCase(TestCase):
             ip.write = writer
         nt.assert_equal(ip.user_ns['a'], 100)
         nt.assert_equal(ip.user_ns['b'], 200)
-        nt.assert_equal(out, code+"\n## -- End pasted text --\n")
+        assert out == code+"\n## -- End pasted text --\n"
 
     def test_paste_leading_commas(self):
         "Test multiline strings with leading commas"

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -39,7 +39,7 @@ def recursionlimit(frames):
     def inner(test_function):
         def wrapper(*args, **kwargs):
             _orig_rec_limit = ultratb._FRAME_RECURSION_LIMIT
-            ultratb._FRAME_RECURSION_LIMIT = frames - 50
+            ultratb._FRAME_RECURSION_LIMIT = 50
 
             rl = sys.getrecursionlimit()
             sys.setrecursionlimit(frames)
@@ -327,17 +327,17 @@ def r3o2():
         with tt.AssertNotPrints("frames repeated"):
             ip.run_cell("non_recurs()")
 
-    @recursionlimit(65)
+    @recursionlimit(150)
     def test_recursion_one_frame(self):
         with tt.AssertPrints("1 frames repeated"):
             ip.run_cell("r1()")
 
-    @recursionlimit(65)
+    @recursionlimit(150)
     def test_recursion_three_frames(self):
         with tt.AssertPrints("3 frames repeated"):
             ip.run_cell("r3o2()")
 
-    @recursionlimit(65)
+    @recursionlimit(150)
     def test_find_recursion(self):
         captured = []
         def capture_exc(*args, **kwargs):

--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -128,6 +128,6 @@ int()
 map()
 """
     for c in range(16, 22):
-        yield lambda: expect_token("int", cell, c)
+        yield lambda cell, c: expect_token("int", cell, c), cell, c
     for c in range(22, 28):
-        yield lambda: expect_token("map", cell, c)
+        yield lambda cell, c: expect_token("map", cell, c), cell, c


### PR DESCRIPTION
1) remove objects creations `ip = get_ipython()` which is anyway
injected in builtins.

2) use proper xunit test cases for capturing warnings.

3) Use proper assertWarns instead of assert print, as pytest captures
warnings.

4) fix recusrsion limit in pytest whcih need to be higher

5) properly capture context in yielded tests.