### PR TITLE
Fixing duplicated definition of magic aliases after reset

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1435,9 +1435,9 @@ class InteractiveShell(SingletonConfigurable):
         drop_keys.discard('__name__')
         for k in drop_keys:
             del ns[k]
-        
+
         self.user_ns_hidden.clear()
-        
+
         # Restore the user namespaces to minimal usability
         self.init_user_ns()
 
@@ -1450,9 +1450,7 @@ class InteractiveShell(SingletonConfigurable):
         # GUI or web frontend
         if os.name == 'posix':
             for cmd in ('clear', 'more', 'less', 'man'):
-                try:
-                    name = self.magics_manager.magics['line'][cmd]
-                except KeyError:
+                if cmd not in self.magics_manager.magics['line']:
                     self.alias_manager.soft_define_alias(cmd, cmd)
 
         # Flush the private list of module references kept for script

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1450,7 +1450,10 @@ class InteractiveShell(SingletonConfigurable):
         # GUI or web frontend
         if os.name == 'posix':
             for cmd in ('clear', 'more', 'less', 'man'):
-                self.alias_manager.soft_define_alias(cmd, cmd)
+                try:
+                    name = self.magics_manager.magics['line'][cmd]
+                except KeyError:
+                    self.alias_manager.soft_define_alias(cmd, cmd)
 
         # Flush the private list of module references kept for script
         # execution protection

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -371,6 +371,31 @@ def test_reset_in_length():
     _ip.run_cell("reset -f in")
     nt.assert_equal(len(_ip.user_ns['In']), _ip.displayhook.prompt_count+1)
 
+class TestResetErrors(TestCase):
+
+    def test_reset_redefine(self):
+
+        @magics_class
+        class KernelMagics(Magics):
+              @line_magic
+              def less(self, shell): pass
+
+        _ip.register_magics(KernelMagics)
+
+        with self.assertLogs() as cm:
+            # hack, we want to just capture logs, but assertLogs fails if not
+            # logs get produce.
+            # so log one things we ignore.
+            import logging as log_mod
+            log = log_mod.getLogger()
+            log.info('Nothing')
+            # end hack.
+            _ip.run_cell("reset -f")
+
+        assert len(cm.output) == 1
+        for out in cm.output:
+            assert "Invalid alias" not in out
+
 def test_tb_syntaxerror():
     """test %tb after a SyntaxError"""
     ip = get_ipython()


### PR DESCRIPTION
Fixes #11646 by avoiding the double definition of the magic aliases. 