### PR TITLE
Fix manpage path in FreeBSD

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -162,7 +162,10 @@ def find_data_files():
     Just man pages at this point.
     """
 
-    manpagebase = pjoin('share', 'man', 'man1')
+    if "freebsd" in sys.platform:
+        manpagebase = pjoin('man', 'man1')
+    else:
+        manpagebase = pjoin('share', 'man', 'man1')
 
     # Simple file lists can be made by hand
     manpages = [f for f in glob(pjoin('docs','man','*.1.gz')) if isfile(f)]


### PR DESCRIPTION
FreeBSD stores manpages under ${PREFIX}/man (defaults to /usr/local/man)
rather than ${PREFIX}/share/man.