### PR TITLE
Fix %matplotlib

### DIFF
--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -37,7 +37,7 @@ magic_gui_arg = magic_arguments.argument(
 @magics_class
 class PylabMagics(Magics):
     """Magics related to matplotlib's pylab support"""
-    
+
     @skip_doctest
     @line_magic
     @magic_arguments.magic_arguments()
@@ -46,23 +46,23 @@ class PylabMagics(Magics):
     @magic_gui_arg
     def matplotlib(self, line=''):
         """Set up matplotlib to work interactively.
-        
+
         This function lets you activate matplotlib interactive support
         at any point during an IPython session. It does not import anything
         into the interactive namespace.
-        
+
         If you are using the inline matplotlib backend in the IPython Notebook
         you can set which figure formats are enabled using the following::
-        
+
             In [1]: from IPython.display import set_matplotlib_formats
-            
+
             In [2]: set_matplotlib_formats('pdf', 'svg')
 
         The default for inline figures sets `bbox_inches` to 'tight'. This can
         cause discrepancies between the displayed image and the identical
         image created using `savefig`. This behavior can be disabled using the
         `%config` magic::
-            
+
             In [3]: %config InlineBackend.print_figure_kwargs = {'bbox_inches':None}
 
         In addition, see the docstring of
@@ -73,7 +73,7 @@ class PylabMagics(Magics):
         Examples
         --------
         To enable the inline backend for usage with the IPython Notebook::
-        
+
             In [1]: %matplotlib inline
 
         In this case, where the matplotlib default is TkAgg::
@@ -96,7 +96,7 @@ class PylabMagics(Magics):
             backends_list = list(backends.keys())
             print("Available matplotlib backends: %s" % backends_list)
         else:
-            gui, backend = self.shell.enable_matplotlib(args.gui.lower())
+            gui, backend = self.shell.enable_matplotlib(args.gui.lower() if isinstance(args.gui, str) else args.gui)
             self._show_matplotlib_backend(args.gui, backend)
 
     @skip_doctest
@@ -105,7 +105,7 @@ class PylabMagics(Magics):
     @magic_arguments.argument(
         '--no-import-all', action='store_true', default=None,
         help="""Prevent IPython from performing ``import *`` into the interactive namespace.
-        
+
         You can govern the default behavior of this flag with the
         InteractiveShellApp.pylab_import_all configurable.
         """
@@ -116,23 +116,23 @@ class PylabMagics(Magics):
 
         This function lets you activate pylab (matplotlib, numpy and
         interactive support) at any point during an IPython session.
-        
+
         %pylab makes the following imports::
-        
+
             import numpy
             import matplotlib
             from matplotlib import pylab, mlab, pyplot
             np = numpy
             plt = pyplot
-            
+
             from IPython.display import display
             from IPython.core.pylabtools import figsize, getfigs
-            
+
             from pylab import *
             from numpy import *
 
         If you pass `--no-import-all`, the last two `*` imports will be excluded.
-        
+
         See the %matplotlib magic for more details about activating matplotlib
         without affecting the interactive namespace.
         """
@@ -159,7 +159,7 @@ class PylabMagics(Magics):
             warn("pylab import has clobbered these variables: %s"  % clobbered +
             "\n`%matplotlib` prevents importing * from pylab and numpy"
             )
-    
+
     def _show_matplotlib_backend(self, gui, backend):
         """show matplotlib message backend message"""
         if not gui or gui == 'auto':


### PR DESCRIPTION
Hey, I did a PR some days ago (#11748) in order to allow `%matplotlib` to accept uppercase backend names. However, I have just realized that I totally overlooked the fact that `args.gui` may not be a `str`. I think it can only be none or a string, but I feel this solution is safer. I am really sorry because now `%matplotlib` with no backend does not work. 

@Carreau 