### PR TITLE
Sets error_before_exec to be the value of the exception instead of th…

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2988,7 +2988,7 @@ class InteractiveShell(SingletonConfigurable):
             self.showtraceback(preprocessing_exc_tuple)
             if store_history:
                 self.execution_count += 1
-            return error_before_exec(preprocessing_exc_tuple[2])
+            return error_before_exec(preprocessing_exc_tuple[1])
 
         # Our own compiler remembers the __future__ environment. If we want to
         # run code with a separate __future__ environment, use the default


### PR DESCRIPTION
…e stack trace

The problem with the current code is that the tuple has values `(type, error, stacktrace)` and it sets `error_before_exec` as the stack trace (index 2). This pull request fixes this by setting it to the correct value: the exception (index 1).

Otherwise, the original code causes a crash when `raise_error()` is called because the traceback object is not an exception.

```
Traceback (most recent call last):
  File "repo.py", line 23, in <module>
    main()
  File "repo.py", line 20, in main
    result.raise_error()
  File "/usr/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 329, in raise_error
    raise self.error_before_exec
TypeError: exceptions must derive from BaseException
```

The (previously) non-working code is attached:
```
#!/usr/bin/env python3

import sys
import importlib
import traceback

from IPython.core.interactiveshell import InteractiveShell
from IPython.utils.io import capture_output

class IS(InteractiveShell):
    def enable_gui(self, gui=None):
        pass

def main():
    # Create the IPython shell
    shell = IS()
    code = "def blah(n):\n" + "   # TODO\n" + "   if n == 0:\n" + "        return 1\n" + "    \n" + "    return 1"
    with capture_output() as io:
        result = shell.run_cell(code, store_history=False)
    result.raise_error()

if __name__ == '__main__':
    main()
```