### PR TITLE
Enable changing the font color for LaTeX rendering

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -10,7 +10,7 @@ import tempfile
 import shutil
 import subprocess
 from base64 import encodebytes
-from textwrap import wrap as splitstring
+import textwrap
 
 from IPython.utils.process import find_cmd, FindCmdError
 from traitlets.config import get_config
@@ -94,7 +94,7 @@ def latex_to_png(s, encode=False, backend=None, wrap=False, color='Black',
             if len(color) == 7:
                 try:
                     color = "RGB {}".format(" ".join([str(int(x, 16)) for x in
-                                                      splitstring(color[1:], 2)]))
+                                                      textwrap.wrap(color[1:], 2)]))
                 except ValueError:
                     raise ValueError('Invalid color specification {}.'.format(color))
             else:

--- a/IPython/lib/tests/test_latextools.py
+++ b/IPython/lib/tests/test_latextools.py
@@ -134,12 +134,16 @@ $$x^2$$
 \end{document}''')
 
 
+@skipif_not_matplotlib
+@onlyif_cmds_exist('latex', 'dvipng')
 def test_latex_to_png_color():
     """
     Test color settings for latex_to_png.
     """
     latex_string = "$x^2$"
     default_value = latextools.latex_to_png(latex_string, wrap=False)
+    default_hexblack = latextools.latex_to_png(latex_string, wrap=False,
+                                               color='#000000')
     dvipng_default = latextools.latex_to_png_dvipng(latex_string, False)
     dvipng_black = latextools.latex_to_png_dvipng(latex_string, False, 'Black')
     nt.assert_equal(dvipng_default, dvipng_black)
@@ -147,11 +151,31 @@ def test_latex_to_png_color():
     mpl_black = latextools.latex_to_png_mpl(latex_string, False, 'Black')
     nt.assert_equal(mpl_default, mpl_black)
     nt.assert_in(default_value, [dvipng_black, mpl_black])
+    nt.assert_in(default_hexblack, [dvipng_black, mpl_black])
 
     # Test that dvips name colors can be used without error
-    dvipng_maroon = latextools.latex_to_png_dvipng(latex_string, False, 'Maroon')
+    dvipng_maroon = latextools.latex_to_png_dvipng(latex_string, False,
+                                                   'Maroon')
     # And that it doesn't return the black one
     nt.assert_not_equal(dvipng_black, dvipng_maroon)
 
     mpl_maroon = latextools.latex_to_png_mpl(latex_string, False, 'Maroon')
     nt.assert_not_equal(mpl_black, mpl_maroon)
+    mpl_white = latextools.latex_to_png_mpl(latex_string, False, 'White')
+    mpl_hexwhite = latextools.latex_to_png_mpl(latex_string, False, '#FFFFFF')
+    nt.assert_equal(mpl_white, mpl_hexwhite)
+
+    mpl_white_scale = latextools.latex_to_png_mpl(latex_string, False,
+                                                  'White', 1.2)
+    nt.assert_not_equal(mpl_white, mpl_white_scale)
+
+
+def test_latex_to_png_invalid_hex_colors():
+    """
+    Test that invalid hex colors provided to dvipng gives an exception.
+    """
+    latex_string = "$x^2$"
+    nt.assert_raises(ValueError, lambda: latextools.latex_to_png(latex_string,
+                                        backend='dvipng', color="#f00bar"))
+    nt.assert_raises(ValueError, lambda: latextools.latex_to_png(latex_string,
+                                        backend='dvipng', color="#f00"))

--- a/IPython/lib/tests/test_latextools.py
+++ b/IPython/lib/tests/test_latextools.py
@@ -62,7 +62,7 @@ def test_latex_to_png_mpl_runs():
 @skipif_not_matplotlib
 def test_latex_to_html():
     img = latextools.latex_to_html("$x^2$")
-    nt.assert_in("data:image/png;base64,iVBOR", img) 
+    nt.assert_in("data:image/png;base64,iVBOR", img)
 
 
 def test_genelatex_no_wrap():
@@ -132,3 +132,26 @@ def test_genelatex_wrap_without_breqn():
 \begin{document}
 $$x^2$$
 \end{document}''')
+
+
+def test_latex_to_png_color():
+    """
+    Test color settings for latex_to_png.
+    """
+    latex_string = "$x^2$"
+    default_value = latextools.latex_to_png(latex_string, wrap=False)
+    dvipng_default = latextools.latex_to_png_dvipng(latex_string, False)
+    dvipng_black = latextools.latex_to_png_dvipng(latex_string, False, 'Black')
+    nt.assert_equal(dvipng_default, dvipng_black)
+    mpl_default = latextools.latex_to_png_mpl(latex_string, False)
+    mpl_black = latextools.latex_to_png_mpl(latex_string, False, 'Black')
+    nt.assert_equal(mpl_default, mpl_black)
+    nt.assert_in(default_value, [dvipng_black, mpl_black])
+
+    # Test that dvips name colors can be used without error
+    dvipng_maroon = latextools.latex_to_png_dvipng(latex_string, False, 'Maroon')
+    # And that it doesn't return the black one
+    nt.assert_not_equal(dvipng_black, dvipng_maroon)
+
+    mpl_maroon = latextools.latex_to_png_mpl(latex_string, False, 'Maroon')
+    nt.assert_not_equal(mpl_black, mpl_maroon)


### PR DESCRIPTION
An issue that shows up in quite a lot of places is that SymPy rendering doesn't consider the background color.

IPython: https://github.com/ipython/ipython/issues/9451 
Spyder: https://github.com/spyder-ide/spyder/issues/3798
SymPy: https://github.com/sympy/sympy/issues/10655

This PR makes it possible to send along a dvips color name (default is black), which will make it a bit easier for all these tools to do something clever.

One could considering adding an "auto" default option as well, see https://github.com/sympy/sympy/pull/17244, but it wasn't clear if it was a good idea and/or possible to get the colors variable from lib.latextools (I imagine it is sometimes used standalone?). This would effectively (or at least in a statistical sense) close https://github.com/ipython/ipython/issues/9451 

If it makes sense, I can easily add a `scale` keyword argument as well to deal with high dpi screens. SymPy just got one: https://github.com/sympy/sympy/pull/17298