### PR TITLE
Try to speedup autoreload by walking all the object using gc.

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -111,6 +111,7 @@ skip_doctest = True
 #-----------------------------------------------------------------------------
 
 import os
+import gc
 import sys
 import traceback
 import types
@@ -268,54 +269,16 @@ def update_function(old, new):
             pass
 
 
-def update_instances(old, new, objects=None, visited={}):
+def update_instances(old, new):
     """Iterate through objects recursively, searching for instances of old and
     replace their __class__ reference with new. If no objects are given, start 
     with the current ipython workspace.
     """
-    if objects is None:
-        # make sure visited is cleaned when not called recursively
-        visited = {}
-        # find ipython workspace stack frame
-        frame = next(frame_nfo.frame for frame_nfo in inspect.stack() 
-                     if 'trigger' in frame_nfo.function)
-        # build generator for non-private variable values from workspace
-        shell = frame.f_locals['self'].shell
-        user_ns = shell.user_ns
-        user_ns_hidden = shell.user_ns_hidden
-        nonmatching = object()
-        objects = ( value for key, value in user_ns.items()
-                if not key.startswith('_') 
-                and (value is not user_ns_hidden.get(key, nonmatching)) 
-                and not inspect.ismodule(value))
-    
-    # use dict values if objects is a dict but don't touch private variables
-    if hasattr(objects, 'items'):
-        objects = (value for key, value in objects.items()
-                       if not str(key).startswith('_')
-                       and not inspect.ismodule(value) )
-
     # try if objects is iterable
     try:
-        for obj in (obj for obj in objects if id(obj) not in visited):
-            # add current object to visited to avoid revisiting
-            visited.update({id(obj):obj})
-
-            # update, if object is instance of old_class (but no subclasses)
+        for obj in gc.get_objects():
             if type(obj) is old:
                 obj.__class__ = new
-                
-
-            # if object is instance of other class, look for nested instances
-            if hasattr(obj, '__dict__') and not (inspect.isfunction(obj)
-                                                 or inspect.ismethod(obj)):
-                update_instances(old, new, obj.__dict__, visited)
-
-            # if object is a container, search it
-            if hasattr(obj, 'items') or (hasattr(obj, '__contains__')
-                                         and not isinstance(obj, str)):
-                update_instances(old, new, obj, visited)
-
     except TypeError:
         pass
 


### PR DESCRIPTION
Unsure if this work; we were avoid this initially as this crawl more
objects; but at the same time we do less objects introspection.

Another possibility is to look for all gc.referers(OldClass), as I
believe their __class__ will point to that; so they should be related by
only one degree.

May Close #11817