### PR TITLE
optionally enable case-insensitive tab completion in %cd, for macOS users

### DIFF
--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -30,7 +30,7 @@ from time import time
 from zipimport import zipimporter
 
 # Our own imports
-from IPython.core.completer import expand_user, compress_user
+from IPython.core.completer import expand_user, compress_user, glob_incase
 from IPython.core.error import TryNext
 from IPython.utils._process_common import arg_split
 
@@ -294,7 +294,6 @@ def magic_run_completer(self, event):
     #print('run comp:', dirs+pys) # dbg
     return [compress_user(p, tilde_expand, tilde_val) for p in matches]
 
-
 def cd_completer(self, event):
     """Completer function for cd, which only returns directories."""
     ip = get_ipython()
@@ -326,7 +325,10 @@ def cd_completer(self, event):
     relpath = relpath.replace('\\','/')
 
     found = []
-    for d in [f.replace('\\','/') + '/' for f in glob.glob(relpath+'*')
+    lglob = glob.glob
+    if event.ignore_case:
+        lglob = glob_incase
+    for d in [f.replace('\\','/') + '/' for f in lglob(relpath+'*')
               if os.path.isdir(f)]:
         if ' ' in d:
             # we don't want to deal with any of that, complex code

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -389,6 +389,10 @@ class InteractiveShell(SingletonConfigurable):
         help="""Select the loop runner that will be used to execute top-level asynchronous code"""
     ).tag(config=True)
 
+    completion_sensitive = Bool(True,
+        help="Keep case-sensitive matching during tab completion",
+    ).tag(config=True)
+
     @default('loop_runner')
     def _default_loop_runner(self):
         return import_item("IPython.core.interactiveshell._asyncio_runner")


### PR DESCRIPTION
Currently the tab completion in %cd relies on glob.glob(), which strangely case sensible on macOS, while case-insensitive was actually the default setting of macOS.
This PR trying to address it, while keeps original behavior as default, simple add 'c.TerminalInteractiveShell.completion_sensitive = False' to config file enables case-insensible completion in %cd command.