### PR TITLE
Allow custom completions to define their own ordering.

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -175,6 +175,20 @@ class TestCompleter(unittest.TestCase):
 
         ip.complete("x.")
 
+    def test_custom_completion_ordering(self):
+        """Test that errors from custom attribute completers are silenced."""
+        ip = get_ipython()
+
+        _, matches = ip.complete('in')
+        assert matches.index('input') < matches.index('int')
+
+        def complete_example(a):
+            return ['example2', 'example1']
+
+        ip.Completer.custom_completers.add_re('ex*', complete_example)
+        _, matches = ip.complete('ex')
+        assert matches.index('example2') < matches.index('example1')
+
     def test_unicode_completions(self):
         ip = get_ipython()
         # Some strings that trigger different types of completion.  Check them both


### PR DESCRIPTION
The completer by default orders all of the matches.  

<img width="839" alt="Screen Shot 2019-08-14 at 5 24 18 PM" src="https://user-images.githubusercontent.com/4236275/63057576-92f06a00-beb8-11e9-92ae-b4e0d3cb9be0.png">

An author may desire to present an unordered set of completions.  This pull requests modifies the completer to return custom ordered completions, sorted results may be explicitly defined by a completer function.