### PR TITLE
Expose pdb.Pdb API

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -195,21 +195,6 @@ def decorate_fn_with_doc(new_fn, old_fn, additional_text=""):
     return wrapper
 
 
-def _file_lines(fname):
-    """Return the contents of a named file as a list of lines.
-
-    This function never raises an IOError exception: if the file can't be
-    read, it simply returns an empty list."""
-
-    try:
-        outfile = open(fname)
-    except IOError:
-        return []
-    else:
-        with out:
-            return outfile.readlines()
-
-
 class Pdb(OldPdb):
     """Modified Pdb class, does not load readline.
 

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -205,6 +205,18 @@ class Pdb(OldPdb):
 
     def __init__(self, color_scheme=None, completekey=None,
                  stdin=None, stdout=None, context=5, **kwargs):
+        """Create a new IPython debugger.
+        
+        :param color_scheme: Deprecated, do not use.
+        :param completekey: Passed to pdb.Pdb.
+        :param stdin: Passed to pdb.Pdb.
+        :param stdout: Passed to pdb.Pdb.
+        :param context: Number of lines of source code context to show when
+            displaying stacktrace information.
+        :param kwargs: Passed to pdb.Pdb.
+            The possibilities are python version dependent, see the python
+            docs for more info.
+        """
 
         # Parent constructor:
         try:

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -225,6 +225,7 @@ class Pdb(OldPdb):
                 raise ValueError("Context must be a positive integer")
         except (TypeError, ValueError):
                 raise ValueError("Context must be a positive integer")
+
         # `kwargs` ensures full compatibility with stdlib's `pdb.Pdb`.
         OldPdb.__init__(self, completekey, stdin, stdout, **kwargs)
 

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -204,7 +204,7 @@ class Pdb(OldPdb):
     """
 
     def __init__(self, color_scheme=None, completekey=None,
-                 stdin=None, stdout=None, context=5):
+                 stdin=None, stdout=None, context=5, **kwargs):
 
         # Parent constructor:
         try:
@@ -213,8 +213,8 @@ class Pdb(OldPdb):
                 raise ValueError("Context must be a positive integer")
         except (TypeError, ValueError):
                 raise ValueError("Context must be a positive integer")
-
-        OldPdb.__init__(self, completekey, stdin, stdout)
+        # `kwargs` ensures full compatibility with stdlib's `pdb.Pdb`.
+        OldPdb.__init__(self, completekey, stdin, stdout, **kwargs)
 
         # IPython changes...
         self.shell = get_ipython()

--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -19,6 +19,8 @@ from prompt_toolkit.formatted_text import PygmentsTokens
 
 
 class TerminalPdb(Pdb):
+    """Standalone IPython debugger."""
+
     def __init__(self, *args, **kwargs):
         Pdb.__init__(self, *args, **kwargs)
         self._ptcomp = None

--- a/docs/source/whatsnew/pr/expose-pdb-api.rst
+++ b/docs/source/whatsnew/pr/expose-pdb-api.rst
@@ -1,0 +1,15 @@
+Expose Pdb API
+===================
+
+Expose the built-in ``pdb.Pdb`` API. ``Pdb`` constructor arguments are generically 
+exposed, regardless of python version.
+Newly exposed arguments:
+
+- ``skip``  - Python 3.1+
+- ``nosiginnt`` - Python 3.2+
+- ``readrc`` - Python 3.6+
+
+Try it out::
+
+    from IPython.terminal.debugger import TerminalPdb
+    pdb = TerminalPdb(skip=["skipthismodule"])


### PR DESCRIPTION
See #11851  
No new tests.
I manually verified by running the following with and without changes:
```python
from IPython.terminal.debugger import TerminalPdb
pdb = TerminalPdb(skip=[], nosigint=False, readrc=False)
```
Without changes:  
`TypeError: __init__() got an unexpected keyword argument 'skip'`
With changes: 
No error.

Also removed dead code.