### PR TITLE
Silence pager stderr

### DIFF
--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -210,7 +210,7 @@ def pager_page(strng, start=0, screen_lines=0, pager_cmd=None):
                 retval = None
                 # if I use popen4, things hang. No idea why.
                 #pager,shell_out = os.popen4(pager_cmd)
-                pager = os.popen(pager_cmd, 'w')
+                pager = os.popen(pager_cmd + ' 2>/dev/null', 'w')
                 try:
                     pager_encoding = pager.encoding or sys.stdout.encoding
                     pager.write(strng)


### PR DESCRIPTION
This is run as a test to determine if a pager is available. If there is
no pager, there is a fallback. Therefore, I think it is a bug that in
the no-pager case ipython will print

 sh: less not found

To stderr.

I encountered this when running the sagemath testsuite on a machine without less and got surprised by the error messages.