### PR TITLE
Fix for Python 4

### DIFF
--- a/tools/gen_latex_symbols.py
+++ b/tools/gen_latex_symbols.py
@@ -11,7 +11,7 @@
 
 import os, sys
 
-if not sys.version_info[0] == 3:
+if sys.version_info[0] < 3:
     print("This script must be run with Python 3, exiting...")
     sys.exit(1)
 


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

On Python 4, this would exit:

```python
if sys.version_info[0] == 3:
    print("This script must be run with Python 3, exiting...")
    sys.exit(1)
```

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./tools/gen_latex_symbols.py:14:8: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
```