### PR TITLE
%env: hide likely secrets by default

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -446,7 +446,13 @@ class OSMagics(Magics):
                     raise UsageError(err)
             if len(bits) > 1:
                 return self.set_env(parameter_s)
-        return dict(os.environ)
+        env = dict(os.environ)
+        # hide likely secrets when printing the whole environment
+        for key in list(env):
+            if any(s in key.lower() for s in ('key', 'token', 'secret')):
+                env[key] = '<hidden>'
+
+        return env
 
     @line_magic
     def set_env(self, parameter_s):

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -11,6 +11,7 @@ import sys
 import warnings
 from textwrap import dedent
 from unittest import TestCase
+from unittest import mock
 from importlib import invalidate_caches
 from io import StringIO
 
@@ -732,6 +733,24 @@ class TestEnv(TestCase):
     def test_env(self):
         env = _ip.magic("env")
         self.assertTrue(isinstance(env, dict))
+
+    def test_env_secret(self):
+        env = _ip.magic("env")
+        hidden = "<hidden>"
+        with mock.patch.dict(
+            os.environ,
+            {
+                "API_KEY": "abc123",
+                "SECRET_THING": "ssshhh",
+                "JUPYTER_TOKEN": "",
+                "VAR": "abc"
+            }
+        ):
+            env = _ip.magic("env")
+        assert env["API_KEY"] == hidden
+        assert env["SECRET_THING"] == hidden
+        assert env["JUPYTER_TOKEN"] == hidden
+        assert env["VAR"] == "abc"
 
     def test_env_get_set_simple(self):
         env = _ip.magic("env var val1")


### PR DESCRIPTION
if an environment variable contains 'KEY' or 'TOKEN' or 'SECRET' hide it when printing the whole environment with %env