### PR TITLE
IPython directive: correctly clear cout

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -585,7 +585,7 @@ class EmbeddedSphinxShell(object):
                 if self.warning_is_error:
                     raise RuntimeError('Non Expected warning in `{}` line {}'.format(filename, lineno))
 
-        self.cout.truncate(0)
+        self.clear_cout()
         return (ret, input_lines, processed_output,
                 is_doctest, decorator, image_file, image_directive)
 


### PR DESCRIPTION
Closes https://github.com/ipython/ipython/issues/11904

The StringIO `cout` object was not correctly cleared (while there was actually a helper method already defined to do that), which caused those null bytes to be introduced, see explanation here https://stackoverflow.com/questions/39109068/why-does-truncating-a-bytesio-mess-it-up

(it seems there are currently no real tests for the directive, so also didn't add one (not sure directly how to do that))