### PR TITLE
Easier empty, updatable display

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -296,6 +296,13 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
     if transient:
         kwargs['transient'] = transient
 
+    if not objs and display_id:
+        # if given no objects, but still a request for a display_id,
+        # we assume the user wants to insert an empty output that
+        # can be updated later
+        objs = [{}]
+        raw = True
+
     if not raw:
         format = InteractiveShell.instance().display_formatter.format
 


### PR DESCRIPTION
Given the following code:
```python
[1]: from IPython.display import display
[2]: handle = display(display_id=True)
[3]: handle.update('world')
```

Currently, `[2]` produces no output (no `display_data` message sent), but still gives a handle that silently fails to update.

This PR changes `[2]` to be equivalent to:
```python
handle = display({}, raw=True, display_id=True)
```
Note that this only happens when the output list is empty *and* a `display_id` is given (either string or `True`).