### PR TITLE
restore terminal title on exit (xterm)

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -8,7 +8,7 @@ from warnings import warn
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
 from IPython.utils import io
 from IPython.utils.py3compat import input
-from IPython.utils.terminal import toggle_set_term_title, set_term_title
+from IPython.utils.terminal import toggle_set_term_title, set_term_title, restore_term_title
 from IPython.utils.process import abbrev_cwd
 from traitlets import (
     Bool, Unicode, Dict, Integer, observe, Instance, Type, default, Enum, Union,
@@ -237,6 +237,10 @@ class TerminalInteractiveShell(InteractiveShell):
             set_term_title(self.term_title_format.format(cwd=abbrev_cwd()))
         else:
             toggle_set_term_title(False)
+
+    def restore_term_title(self):
+        if self.term_title:
+            restore_term_title()
 
     def init_display_formatter(self):
         super(TerminalInteractiveShell, self).init_display_formatter()
@@ -506,6 +510,9 @@ class TerminalInteractiveShell(InteractiveShell):
                 # https://github.com/ipython/ipython/pull/9867
                 if hasattr(self, '_eventloop'):
                     self._eventloop.stop()
+
+                self.restore_term_title()
+
 
     _inputhook = None
     def inputhook(self, context):

--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -58,14 +58,26 @@ def _set_term_title(*args,**kw):
     pass
 
 
+def _restore_term_title():
+    pass
+
+
 def _set_term_title_xterm(title):
     """ Change virtual terminal title in xterm-workalikes """
+    # save the current title to the xterm "stack"
+    sys.stdout.write('\033[22;0t') 
     sys.stdout.write('\033]0;%s\007' % title)
+
+
+def _restore_term_title_xterm():
+    sys.stdout.write('\033[23;0t') 
+
 
 if os.name == 'posix':
     TERM = os.environ.get('TERM','')
     if TERM.startswith('xterm'):
         _set_term_title = _set_term_title_xterm
+        _restore_term_title = _restore_term_title_xterm
 elif sys.platform == 'win32':
     try:
         import ctypes
@@ -98,6 +110,13 @@ def set_term_title(title):
     if ignore_termtitle:
         return
     _set_term_title(title)
+
+
+def restore_term_title():
+    """Restore, if possible, terminal title to the original state"""
+    if ignore_termtitle:
+        return
+    _restore_term_title()
 
 
 def freeze_term_title():


### PR DESCRIPTION
issue #11909 

On xterm, there is a terminal "stack" that allows to save and then restore the current terminal title. It allows to reset title to the original value on exit in case it was changed.