### PR TITLE
Enable plotting in same notebook cell which imports matplotlib.pyplot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - pip install pip --upgrade
   - pip install setuptools --upgrade
   - pip install -e file://$PWD#egg=ipython[test] --upgrade
-  - pip install trio curio
+  - pip install trio curio --upgrade --upgrade-strategy eager
   - pip install 'pytest<4' matplotlib
   - pip install codecov check-manifest --upgrade
 

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -310,12 +310,12 @@ def activate_matplotlib(backend):
     # magic of switch_backend().
     matplotlib.rcParams['backend'] = backend
 
-    import matplotlib.pyplot
-    matplotlib.pyplot.switch_backend(backend)
+    # Due to circular imports, pyplot may be only partially initialised
+    # when this function runs.
+    # So avoid needing matplotlib attribute-lookup to access pyplot.
+    from matplotlib import pyplot as plt
 
-    # This must be imported last in the matplotlib series, after
-    # backend/interactivity choices have been made
-    import matplotlib.pyplot as plt
+    plt.switch_backend(backend)
 
     plt.show._needmain = False
     # We need to detect at runtime whether show() is called by the user.


### PR DESCRIPTION
This fixes a bug for Jupyter notebooks, that plot commands often do not display until the second time their cell is executed. https://github.com/jupyter/notebook/issues/3691

Specifically, inline display of plots was broken for the first cell which imports `matplotlib.pyplot`, but does works in subsequent cells (or even if the same cell is evaluated a second time). This particularly affected libraries that lazily import matplotlib, such as xarray:
```python
In [1]: import xarray, numpy as np
In [2]: x = xarray.DataArray(np.random.random((5,5)))
In [3]: x.plot() # did not work
In [4]: x.plot() # did work
```

The problem related to circular imports between matplotlib and ipython. The import of the `matplotlib.pyplot` module executes a call to `IPython.core.pylabtools:activate_matplotlib` which in turn imports `matplotlib.pyplot` (while it is still only partially initialised e.g. the `matplotlib` module may not yet have a `pyplot` attribute). By using a slightly different import syntax it is possible to avoid causing an exception here.

Note, there is also a partial work-around in `ipykernel.pylab.backend_inline:_enable_matplotlib_integration` which catches the import/attribute error and in that case reschedules `activate_matplotlib` until after the cell finishes executing (i.e. after import completes). The problem was that it was late to schedule `flush_figures` (as the event is already triggering before the callback gets registered), which is why plotting only worked in subsequent cell evaluations.

Tested on python 3.6.7.