### PR TITLE
Fix restoring more than 2 variables and support storing multiple variables %storemagic

### DIFF
--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -10,29 +10,42 @@ def setup_module():
 def test_store_restore():
     assert 'bar' not in ip.user_ns, "Error: some other test leaked `bar` in user_ns"
     assert 'foo' not in ip.user_ns, "Error: some other test leaked `foo` in user_ns"
+    assert 'foobar' not in ip.user_ns, "Error: some other test leaked `foobar` in user_ns"
+    assert 'foobaz' not in ip.user_ns, "Error: some other test leaked `foobaz` in user_ns"
     ip.user_ns['foo'] = 78
     ip.magic('alias bar echo "hello"')
+    ip.user_ns['foobar'] = 79
+    ip.user_ns['foobaz'] = '80'
     tmpd = tempfile.mkdtemp()
     ip.magic('cd ' + tmpd)
     ip.magic('store foo')
     ip.magic('store bar')
-    
+    ip.magic('store foobar foobaz')
+
     # Check storing
     nt.assert_equal(ip.db['autorestore/foo'], 78)
     nt.assert_in('bar', ip.db['stored_aliases'])
-    
+    nt.assert_equal(ip.db['autorestore/foobar'], 79)
+    nt.assert_equal(ip.db['autorestore/foobaz'], '80')
+
     # Remove those items
     ip.user_ns.pop('foo', None)
+    ip.user_ns.pop('foobar', None)
+    ip.user_ns.pop('foobaz', None)
     ip.alias_manager.undefine_alias('bar')
     ip.magic('cd -')
     ip.user_ns['_dh'][:] = []
-    
+
     # Check restoring
-    ip.magic('store -r')
+    ip.magic('store -r foo bar foobar foobaz')
     nt.assert_equal(ip.user_ns['foo'], 78)
     assert ip.alias_manager.is_alias('bar')
+    nt.assert_equal(ip.user_ns['foobar'], 79)
+    nt.assert_equal(ip.user_ns['foobaz'], '80')
+
+    ip.magic('store -r') # restores _dh too
     nt.assert_in(os.path.realpath(tmpd), ip.user_ns['_dh'])
-    
+
     os.rmdir(tmpd)
 
 def test_autorestore():


### PR DESCRIPTION
Currently `%store -r a b c` doesn't restore `c` because argument splitting is not performed correctly (see `args = argsl.split(None,1)` below). This is now fixed. `%store a b c` was not supported before, now it is working well. I also extended the tests to cover all scenarios.