### PR TITLE
Add more windows ci

### DIFF
--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -108,9 +108,9 @@ def make_label_dec(label, ds=None):
     >>> slow = make_label_dec('slow')
     >>> slow.__doc__
     "Labels a test as 'slow'."
-    
+
     And one that uses multiple labels and a custom docstring:
-    
+
     >>> rare = make_label_dec(['slow','hard'],
     ... "Mix labels 'slow' and 'hard' for rare tests.")
     >>> rare.__doc__
@@ -280,7 +280,7 @@ def module_not_available(module):
 
 def decorated_dummy(dec, name):
     """Return a dummy function decorated with dec, with the given name.
-    
+
     Examples
     --------
     import IPython.testing.decorators as dec
@@ -317,6 +317,11 @@ _x11_skip_cond = (sys.platform not in ('darwin', 'win32') and
 _x11_skip_msg = "Skipped under *nix when X11/XOrg not available"
 
 skip_if_no_x11 = skipif(_x11_skip_cond, _x11_skip_msg)
+
+
+# Decorators to skip certain tests on specific platform/python combinations
+skip_win32_py38 = skipif(sys.version_info > (3,8) and os.name == 'nt')
+
 
 # not a decorator itself, returns a dummy function to be used as setup
 def skip_file_no_x11(name):

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -175,7 +175,8 @@ def get_home_dir(require_writable=False):
     Uses os.path.expanduser('~'), and checks for writability.
 
     See stdlib docs for how this is determined.
-    $HOME is first priority on *ALL* platforms.
+    For Python <3.8, $HOME is first priority on *ALL* platforms.
+    For Python >=3.8 on Windows, %HOME% is no longer considered.
 
     Parameters
     ----------

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -21,10 +21,12 @@ import IPython
 from IPython import paths
 from IPython.testing import decorators as dec
 from IPython.testing.decorators import (skip_if_not_win32, skip_win32,
-                                        onlyif_unicode_paths,)
+                                        onlyif_unicode_paths, skipif,
+                                        skip_win32_py38,)
 from IPython.testing.tools import make_tempfile, AssertPrints
 from IPython.utils import path
 from IPython.utils.tempdir import TemporaryDirectory
+
 
 # Platform-dependent imports
 try:
@@ -128,7 +130,7 @@ def test_get_home_dir_2():
     nt.assert_equal(home_dir, unfrozen)
 
 
-@skipif(sys.version_info > (3,8) and os.name == 'nt')
+@skip_win32_py38
 @with_environment
 def test_get_home_dir_3():
     """get_home_dir() uses $HOME if set"""
@@ -146,6 +148,7 @@ def test_get_home_dir_4():
     # this should still succeed, but we don't care what the answer is
     home = path.get_home_dir(False)
 
+@skip_win32_py38
 @with_environment
 def test_get_home_dir_5():
     """raise HomeDirError if $HOME is specified, but not a writable dir"""

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -28,7 +28,7 @@ from IPython.utils.tempdir import TemporaryDirectory
 
 # Platform-dependent imports
 try:
-    import winreg as wreg  
+    import winreg as wreg
 except ImportError:
     #Fake _winreg module on non-windows platforms
     import types
@@ -128,6 +128,7 @@ def test_get_home_dir_2():
     nt.assert_equal(home_dir, unfrozen)
 
 
+@skipif(sys.version_info > (3,8) and os.name == 'nt')
 @with_environment
 def test_get_home_dir_3():
     """get_home_dir() uses $HOME if set"""
@@ -247,7 +248,7 @@ def test_filefind():
 def test_get_long_path_name_win32():
     with TemporaryDirectory() as tmpdir:
 
-        # Make a long path. Expands the path of tmpdir prematurely as it may already have a long 
+        # Make a long path. Expands the path of tmpdir prematurely as it may already have a long
         # path component, so ensure we include the long form of it
         long_path = os.path.join(path.get_long_path_name(tmpdir), 'this is my long path name')
         os.makedirs(long_path)
@@ -311,7 +312,7 @@ def test_get_py_filename():
 def test_unicode_in_filename():
     """When a file doesn't exist, the exception raised should be safe to call
     str() on - i.e. in Python 2 it must only have ASCII characters.
-    
+
     https://github.com/ipython/ipython/issues/875
     """
     try:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,9 +36,9 @@ install:
       Set-PSDebug -Trace 1
       if ($Env:PYTHON_VERSION.StartsWith("3.8")) {
         if ($Env:PYTHON_ARCH -eq "64") {
-          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON_HOME"
+          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON"
         } else {
-          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON_HOME --x86"
+          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON --x86"
         }
       }
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,15 +32,6 @@ init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
 install:
-  - ps: |
-      Set-PSDebug -Trace 1
-      if ($Env:PYTHON_VERSION.StartsWith("3.8")) {
-        if ($Env:PYTHON_ARCH -eq "64") {
-          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON"
-        } else {
-          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON --x86"
-        }
-      }
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "%CMD_IN_ENV%  python -m pip install --upgrade setuptools pip"
   - "%CMD_IN_ENV%  pip install nose coverage"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,35 @@ environment:
      PYTHON_VERSION: "3.6.x"
      PYTHON_ARCH: "64"
 
+   - PYTHON: "C:\\Python37"
+     PYTHON_VERSION: "3.7.x"
+     PYTHON_ARCH: "32"
+
+   - PYTHON: "C:\\Python37-x64"
+     PYTHON_VERSION: "3.7.x"
+     PYTHON_ARCH: "64"
+
+   - PYTHON: "C:\\Python38"
+     PYTHON_VERSION: "3.8.x"
+     PYTHON_ARCH: "32"
+
+   - PYTHON: "C:\\Python38-x64"
+     PYTHON_VERSION: "3.8.x"
+     PYTHON_ARCH: "64"
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
 install:
+  - ps: |
+      Set-PSDebug -Trace 1
+      if ($Env:PYTHON_VERSION.StartsWith("3.8")) {
+        if ($Env:PYTHON_ARCH -eq "64") {
+          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON_HOME"
+        } else {
+          iex "choco install python3 --version=3.8 --no-progress --params /InstallDir:$Env:PYTHON_HOME --x86"
+        }
+      }
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "%CMD_IN_ENV%  python -m pip install --upgrade setuptools pip"
   - "%CMD_IN_ENV%  pip install nose coverage"
@@ -24,4 +49,3 @@ install:
   - "%CMD_IN_ENV%  cd results"
 test_script:
   - "%CMD_IN_ENV%  iptest --coverage xml"
-  


### PR DESCRIPTION
This adds python 3.7 and 3.8 excursions on appveyor, using `choco` to get 3.8 for the time being.

We were seeing some stuff with `$HOME` handling, but otherwise was apparently mostly working.

Happy to tone it down to just x64, i guess, but we need to get some better understanding of some of the issues.

ref https://github.com/conda-forge/ipython-feedstock/pull/82