### PR TITLE
Adopt NEP 29, Drop Python 3.5 and Numpy <1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
 
 python:
     - 3.6
-    - 3.5
 
 sudo: false
 

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -27,12 +27,13 @@ import sys
 #-----------------------------------------------------------------------------
 
 # Don't forget to also update setup.py when this changes!
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 6):
     raise ImportError(
 """
-IPython 7.0+ supports Python 3.5 and above.
+IPython 7.10+ supports Python 3.6 and above.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
 Python 3.3 and 3.4 were supported up to IPython 6.x.
+Python 3.5 was supported with IPython 7.0 to 7.9.
 
 See IPython `README.rst` file for more information:
 

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@
 .. image:: https://www.codetriage.com/ipython/ipython/badges/users.svg
     :target: https://www.codetriage.com/ipython/ipython/
 
+.. image:: https://raster.shields.io/badge/Follows-NEP29-brightgreen.png
+    :target: https://numpy.org/neps/nep-0029-deprecation_policy.html
+
+
 ===========================================
  IPython: Productive Interactive Computing
 ===========================================
@@ -22,6 +26,10 @@ Welcome to IPython.  Our full documentation is available on `ipython.readthedocs
 contribute to the project.
 
 **IPython versions and Python Support**
+
+Starting with IPython 7.10, IPython follows `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_
+
+**IPython 7.10+** requires Python version 3.6 and above.
 
 **IPython 7.0** requires Python version 3.5 and above.
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ import sys
 #
 # This check is also made in IPython/__init__, don't forget to update both when
 # changing Python version requirements.
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 6):
     pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
     try:
         import pip
@@ -42,9 +42,10 @@ if sys.version_info < (3, 5):
 
 
     error = """
-IPython 7.0+ supports Python 3.5 and above.
+IPython 7.10+ supports Python 3.6 and above, following NEP 29.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
 Python 3.3 and 3.4 were supported up to IPython 6.x.
+Python 3.5 was supported with IPython 7.0 to 7.9.
 
 See IPython `README.rst` file for more information:
 
@@ -175,7 +176,7 @@ extras_require = dict(
     parallel = ['ipyparallel'],
     qtconsole = ['qtconsole'],
     doc = ['Sphinx>=1.3'],
-    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel', 'numpy'],
+    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel', 'numpy>=1.14'],
     terminal = [],
     kernel = ['ipykernel'],
     nbformat = ['nbformat'],
@@ -199,11 +200,9 @@ install_requires = [
 # but requires pip >= 6. pip < 6 ignores these.
 
 extras_require.update({
-    ':python_version == "3.4"': ['typing'],
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],
     ':sys_platform == "win32"': ['colorama'],
-    ':sys_platform == "win32" and python_version < "3.6"': ['win_unicode_console>=0.5'],
 })
 # FIXME: re-specify above platform dependencies for pip < 6
 # These would result in non-portable bdists.
@@ -229,7 +228,7 @@ for key, deps in extras_require.items():
 extras_require['all'] = everything
 
 if 'setuptools' in sys.modules:
-    setuptools_extra_args['python_requires'] = '>=3.5'
+    setuptools_extra_args['python_requires'] = '>=3.6'
     setuptools_extra_args['zip_safe'] = False
     setuptools_extra_args['entry_points'] = {
         'console_scripts': find_entry_points(),


### PR DESCRIPTION
This lays out the foundation of adopting NEP29 in IPython,
And drop support for older versions of Python in the metadata, setup.py
and __init__.

This does not yet remove any codepath from within IPython.