### PR TITLE
Change absolute imports to relative imports 

### DIFF
--- a/IPython/config.py
+++ b/IPython/config.py
@@ -7,7 +7,7 @@ Shim to maintain backwards compatibility with old IPython.config imports.
 import sys
 from warnings import warn
 
-from IPython.utils.shimmodule import ShimModule, ShimWarning
+from .utils.shimmodule import ShimModule, ShimWarning
 
 warn("The `IPython.config` package has been deprecated since IPython 4.0. "
      "You should import from traitlets.config instead.", ShimWarning)

--- a/IPython/conftest.py
+++ b/IPython/conftest.py
@@ -6,11 +6,11 @@ import pytest
 import pathlib
 import shutil
 
-from IPython.testing import tools
+from .testing import tools
 
 
 def get_ipython():
-    from IPython.terminal.interactiveshell import TerminalInteractiveShell
+    from .terminal.interactiveshell import TerminalInteractiveShell
     if TerminalInteractiveShell._instance:
         return TerminalInteractiveShell.instance()
 
@@ -60,7 +60,7 @@ def inject():
     builtins.ip = get_ipython()
     builtins.ip.system = types.MethodType(xsys, ip)
     builtins.ip.builtin_trap.activate()
-    from IPython.core import page
+    from .core import page
 
     page.pager_page = nopage
     # yield

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -25,7 +25,7 @@ import re
 import sys
 
 from traitlets.config.configurable import Configurable
-from IPython.core.error import UsageError
+from .error import UsageError
 
 from traitlets import List, Instance
 from logging import error

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -30,9 +30,9 @@ from time import time
 from zipimport import zipimporter
 
 # Our own imports
-from IPython.core.completer import expand_user, compress_user
-from IPython.core.error import TryNext
-from IPython.utils._process_common import arg_split
+from .completer import expand_user, compress_user
+from .error import TryNext
+from ..utils._process_common import arg_split
 
 # FIXME: this should be pulled in with the right call via the component system
 from IPython import get_ipython

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -20,10 +20,10 @@ from io import StringIO
 from decorator import decorator
 
 from traitlets.config.configurable import Configurable
-from IPython.core.getipython import get_ipython
-from IPython.utils.sentinel import Sentinel
-from IPython.utils.dir2 import get_real_method
-from IPython.lib import pretty
+from .getipython import get_ipython
+from ..utils.sentinel import Sentinel
+from ..utils.dir2 import get_real_method
+from ..lib import pretty
 from traitlets import (
     Bool, Dict, Integer, Unicode, CUnicode, ObjectName, List,
     ForwardDeclaredInstance,
@@ -1015,7 +1015,7 @@ def format_display_data(obj, include=None, exclude=None):
         data dict. If this is set all format types will be computed,
         except for those included in this argument.
     """
-    from IPython.core.interactiveshell import InteractiveShell
+    from .interactiveshell import InteractiveShell
 
     return InteractiveShell.instance().display_formatter.format(
         obj,

--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -9,9 +9,9 @@ import os
 import sqlite3
 
 from traitlets.config.application import Application
-from IPython.core.application import BaseIPythonApplication
+from .application import BaseIPythonApplication
 from traitlets import Bool, Int, Dict
-from IPython.utils.io import ask_yes_no
+from ..utils.io import ask_yes_no
 
 trim_hist_help = """Trim the IPython history database to the last 1000 entries.
 

--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -40,7 +40,7 @@ import subprocess
 import warnings
 import sys
 
-from IPython.core.error import TryNext
+from .error import TryNext
 
 # List here all the default hooks.  For now it's just the editor functions
 # but over time we'll move here all the public API for user-accessible things.
@@ -83,7 +83,7 @@ def editor(self, filename, linenum=None, wait=True):
         raise TryNext()
 
 import tempfile
-from IPython.utils.decorators import undoc
+from ..utils.decorators import undoc
 
 @undoc
 def fix_error_editor(self,filename,linenum,column,msg):
@@ -212,7 +212,7 @@ def pre_run_code_hook(self):
 def clipboard_get(self):
     """ Get text from the clipboard.
     """
-    from IPython.lib.clipboard import (
+    from ..lib.clipboard import (
         osx_clipboard_get, tkinter_clipboard_get,
         win32_clipboard_get
     )

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -17,13 +17,13 @@ import sys
 from getopt import getopt, GetoptError
 
 from traitlets.config.configurable import Configurable
-from IPython.core import oinspect
-from IPython.core.error import UsageError
-from IPython.core.inputtransformer2 import ESC_MAGIC, ESC_MAGIC2
+from . import oinspect
+from .error import UsageError
+from .inputtransformer2 import ESC_MAGIC, ESC_MAGIC2
 from decorator import decorator
-from IPython.utils.ipstruct import Struct
-from IPython.utils.process import arg_split
-from IPython.utils.text import dedent
+from ..utils.ipstruct import Struct
+from ..utils.process import arg_split
+from ..utils.text import dedent
 from traitlets import Bool, Dict, Instance, observe
 from logging import error
 

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -12,16 +12,16 @@ transforms are used to implement additional syntax such as !ls and %magic.
 from keyword import iskeyword
 import re
 
-from IPython.core.autocall import IPyAutocall
+from .autocall import IPyAutocall
 from traitlets.config.configurable import Configurable
-from IPython.core.inputtransformer2 import (
+from .inputtransformer2 import (
     ESC_MAGIC,
     ESC_QUOTE,
     ESC_QUOTE2,
     ESC_PAREN,
 )
-from IPython.core.macro import Macro
-from IPython.core.splitinput import LineInfo
+from .macro import Macro
+from .splitinput import LineInfo
 
 from traitlets import (
     List, Integer, Unicode, Bool, Instance, CRegExp

--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -9,8 +9,8 @@ import shutil
 import errno
 
 from traitlets.config.configurable import LoggingConfigurable
-from IPython.paths import get_ipython_package_dir
-from IPython.utils.path import expand_path, ensure_dir_exists
+from ..paths import get_ipython_package_dir
+from ..utils.path import expand_path, ensure_dir_exists
 from traitlets import Unicode, Bool, observe
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Change absolute imports to relative imports to facilitate processes embedding kernel or debugger

Fixes #11932 