### PR TITLE
Removed codepath for Python < 3.6 #11949

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -166,13 +166,7 @@ def removed_co_newlocals(function:types.FunctionType) -> types.FunctionType:
 # we still need to run things using the asyncio eventloop, but there is no
 # async integration
 from .async_helpers import (_asyncio_runner,  _asyncify, _pseudo_sync_runner)
-if sys.version_info > (3, 5):
-    from .async_helpers import _curio_runner, _trio_runner, _should_be_async
-else :
-    _curio_runner = _trio_runner = None
-
-    def _should_be_async(cell:str)->bool:
-        return False
+from .async_helpers import _curio_runner, _trio_runner, _should_be_async
 
 
 def _ast_asyncify(cell:str, wrapper_name:str) -> ast.Module:
@@ -2245,8 +2239,7 @@ class InteractiveShell(SingletonConfigurable):
             m.NamespaceMagics, m.OSMagics, m.PackagingMagics,
             m.PylabMagics, m.ScriptMagics,
         )
-        if sys.version_info >(3,5):
-            self.register_magics(m.AsyncMagics)
+        self.register_magics(m.AsyncMagics)
 
         # Register Magic Aliases
         mman = self.magics_manager

--- a/IPython/core/tests/test_async_helpers.py
+++ b/IPython/core/tests/test_async_helpers.py
@@ -14,298 +14,297 @@ from IPython.testing.decorators import skip_without
 iprc = lambda x: ip.run_cell(dedent(x)).raise_error()
 iprc_nr = lambda x: ip.run_cell(dedent(x))
 
-if sys.version_info > (3, 5):
-    from IPython.core.async_helpers import _should_be_async
+from IPython.core.async_helpers import _should_be_async
 
-    class AsyncTest(TestCase):
-        def test_should_be_async(self):
-            nt.assert_false(_should_be_async("False"))
-            nt.assert_true(_should_be_async("await bar()"))
-            nt.assert_true(_should_be_async("x = await bar()"))
-            nt.assert_false(
-                _should_be_async(
-                    dedent(
-                        """
-                async def awaitable():
-                    pass
-            """
-                    )
+class AsyncTest(TestCase):
+    def test_should_be_async(self):
+        nt.assert_false(_should_be_async("False"))
+        nt.assert_true(_should_be_async("await bar()"))
+        nt.assert_true(_should_be_async("x = await bar()"))
+        nt.assert_false(
+            _should_be_async(
+                dedent(
+                    """
+            async def awaitable():
+                pass
+        """
                 )
             )
+        )
 
-        def _get_top_level_cases(self):
-            # These are test cases that should be valid in a function
-            # but invalid outside of a function.
-            test_cases = []
-            test_cases.append(('basic', "{val}"))
+    def _get_top_level_cases(self):
+        # These are test cases that should be valid in a function
+        # but invalid outside of a function.
+        test_cases = []
+        test_cases.append(('basic', "{val}"))
 
-            # Note, in all conditional cases, I use True instead of
-            # False so that the peephole optimizer won't optimize away
-            # the return, so CPython will see this as a syntax error:
-            #
-            # while True:
-            #    break
-            #    return
-            #
-            # But not this:
-            #
-            # while False:
-            #    return
-            #
-            # See https://bugs.python.org/issue1875
+        # Note, in all conditional cases, I use True instead of
+        # False so that the peephole optimizer won't optimize away
+        # the return, so CPython will see this as a syntax error:
+        #
+        # while True:
+        #    break
+        #    return
+        #
+        # But not this:
+        #
+        # while False:
+        #    return
+        #
+        # See https://bugs.python.org/issue1875
 
-            test_cases.append(('if', dedent("""
-            if True:
-                {val}
-            """)))
+        test_cases.append(('if', dedent("""
+        if True:
+            {val}
+        """)))
 
-            test_cases.append(('while', dedent("""
+        test_cases.append(('while', dedent("""
+        while True:
+            {val}
+            break
+        """)))
+
+        test_cases.append(('try', dedent("""
+        try:
+            {val}
+        except:
+            pass
+        """)))
+
+        test_cases.append(('except', dedent("""
+        try:
+            pass
+        except:
+            {val}
+        """)))
+
+        test_cases.append(('finally', dedent("""
+        try:
+            pass
+        except:
+            pass
+        finally:
+            {val}
+        """)))
+
+        test_cases.append(('for', dedent("""
+        for _ in range(4):
+            {val}
+        """)))
+
+
+        test_cases.append(('nested', dedent("""
+        if True:
             while True:
                 {val}
                 break
-            """)))
+        """)))
 
-            test_cases.append(('try', dedent("""
-            try:
+        test_cases.append(('deep-nested', dedent("""
+        if True:
+            while True:
+                break
+                for x in range(3):
+                    if True:
+                        while True:
+                            for x in range(3):
+                                {val}
+        """)))
+
+        return test_cases
+
+    def _get_ry_syntax_errors(self):
+        # This is a mix of tests that should be a syntax error if
+        # return or yield whether or not they are in a function
+
+        test_cases = []
+
+        test_cases.append(('class', dedent("""
+        class V:
+            {val}
+        """)))
+
+        test_cases.append(('nested-class', dedent("""
+        class V:
+            class C:
                 {val}
-            except:
-                pass
-            """)))
+        """)))
 
-            test_cases.append(('except', dedent("""
-            try:
-                pass
-            except:
-                {val}
-            """)))
-
-            test_cases.append(('finally', dedent("""
-            try:
-                pass
-            except:
-                pass
-            finally:
-                {val}
-            """)))
-
-            test_cases.append(('for', dedent("""
-            for _ in range(4):
-                {val}
-            """)))
+        return test_cases
 
 
-            test_cases.append(('nested', dedent("""
-            if True:
-                while True:
-                    {val}
+    def test_top_level_return_error(self):
+        tl_err_test_cases = self._get_top_level_cases()
+        tl_err_test_cases.extend(self._get_ry_syntax_errors())
+
+        vals = ('return', 'yield', 'yield from (_ for _ in range(3))',
+                dedent('''
+                    def f():
+                        pass
+                    return
+                    '''),
+                )
+
+        for test_name, test_case in tl_err_test_cases:
+            # This example should work if 'pass' is used as the value
+            with self.subTest((test_name, 'pass')):
+                iprc(test_case.format(val='pass'))
+
+            # It should fail with all the values
+            for val in vals:
+                with self.subTest((test_name, val)):
+                    msg = "Syntax error not raised for %s, %s" % (test_name, val)
+                    with self.assertRaises(SyntaxError, msg=msg):
+                        iprc(test_case.format(val=val))
+
+    def test_in_func_no_error(self):
+        # Test that the implementation of top-level return/yield
+        # detection isn't *too* aggressive, and works inside a function
+        func_contexts = []
+
+        func_contexts.append(('func', False, dedent("""
+        def f():""")))
+
+        func_contexts.append(('method', False, dedent("""
+        class MyClass:
+            def __init__(self):
+        """)))
+
+        func_contexts.append(('async-func', True,  dedent("""
+        async def f():""")))
+
+        func_contexts.append(('async-method', True,  dedent("""
+        class MyClass:
+            async def f(self):""")))
+
+        func_contexts.append(('closure', False, dedent("""
+        def f():
+            def g():
+        """)))
+
+        def nest_case(context, case):
+            # Detect indentation
+            lines = context.strip().splitlines()
+            prefix_len = 0
+            for c in lines[-1]:
+                if c != ' ':
                     break
-            """)))
+                prefix_len += 1
 
-            test_cases.append(('deep-nested', dedent("""
-            if True:
-                while True:
-                    break
-                    for x in range(3):
-                        if True:
-                            while True:
-                                for x in range(3):
-                                    {val}
-            """)))
+            indented_case = indent(case, ' ' * (prefix_len + 4))
+            return context + '\n' + indented_case
 
-            return test_cases
+        # Gather and run the tests
 
-        def _get_ry_syntax_errors(self):
-            # This is a mix of tests that should be a syntax error if
-            # return or yield whether or not they are in a function
+        # yield is allowed in async functions, starting in Python 3.6,
+        # and yield from is not allowed in any version
+        vals = ('return', 'yield', 'yield from (_ for _ in range(3))')
+        async_safe = (True,
+                        True,
+                        False)
+        vals = tuple(zip(vals, async_safe))
 
-            test_cases = []
+        success_tests = zip(self._get_top_level_cases(), repeat(False))
+        failure_tests = zip(self._get_ry_syntax_errors(), repeat(True))
 
-            test_cases.append(('class', dedent("""
-            class V:
-                {val}
-            """)))
+        tests = chain(success_tests, failure_tests)
 
-            test_cases.append(('nested-class', dedent("""
-            class V:
-                class C:
-                    {val}
-            """)))
+        for context_name, async_func, context in func_contexts:
+            for (test_name, test_case), should_fail in tests:
+                nested_case = nest_case(context, test_case)
 
-            return test_cases
+                for val, async_safe in vals:
+                    val_should_fail = (should_fail or
+                                        (async_func and not async_safe))
 
+                    test_id = (context_name, test_name, val)
+                    cell = nested_case.format(val=val)
 
-        def test_top_level_return_error(self):
-            tl_err_test_cases = self._get_top_level_cases()
-            tl_err_test_cases.extend(self._get_ry_syntax_errors())
-
-            vals = ('return', 'yield', 'yield from (_ for _ in range(3))',
-                    dedent('''
-                        def f():
-                            pass
-                        return
-                        '''),
-                    )
-
-            for test_name, test_case in tl_err_test_cases:
-                # This example should work if 'pass' is used as the value
-                with self.subTest((test_name, 'pass')):
-                    iprc(test_case.format(val='pass'))
-
-                # It should fail with all the values
-                for val in vals:
-                    with self.subTest((test_name, val)):
-                        msg = "Syntax error not raised for %s, %s" % (test_name, val)
-                        with self.assertRaises(SyntaxError, msg=msg):
-                            iprc(test_case.format(val=val))
-
-        def test_in_func_no_error(self):
-            # Test that the implementation of top-level return/yield
-            # detection isn't *too* aggressive, and works inside a function
-            func_contexts = []
-
-            func_contexts.append(('func', False, dedent("""
-            def f():""")))
-
-            func_contexts.append(('method', False, dedent("""
-            class MyClass:
-                def __init__(self):
-            """)))
-
-            func_contexts.append(('async-func', True,  dedent("""
-            async def f():""")))
-
-            func_contexts.append(('async-method', True,  dedent("""
-            class MyClass:
-                async def f(self):""")))
-
-            func_contexts.append(('closure', False, dedent("""
-            def f():
-                def g():
-            """)))
-
-            def nest_case(context, case):
-                # Detect indentation
-                lines = context.strip().splitlines()
-                prefix_len = 0
-                for c in lines[-1]:
-                    if c != ' ':
-                        break
-                    prefix_len += 1
-
-                indented_case = indent(case, ' ' * (prefix_len + 4))
-                return context + '\n' + indented_case
-
-            # Gather and run the tests
-
-            # yield is allowed in async functions, starting in Python 3.6,
-            # and yield from is not allowed in any version
-            vals = ('return', 'yield', 'yield from (_ for _ in range(3))')
-            async_safe = (True,
-                          sys.version_info >= (3, 6),
-                          False)
-            vals = tuple(zip(vals, async_safe))
-
-            success_tests = zip(self._get_top_level_cases(), repeat(False))
-            failure_tests = zip(self._get_ry_syntax_errors(), repeat(True))
-
-            tests = chain(success_tests, failure_tests)
-
-            for context_name, async_func, context in func_contexts:
-                for (test_name, test_case), should_fail in tests:
-                    nested_case = nest_case(context, test_case)
-
-                    for val, async_safe in vals:
-                        val_should_fail = (should_fail or
-                                           (async_func and not async_safe))
-
-                        test_id = (context_name, test_name, val)
-                        cell = nested_case.format(val=val)
-
-                        with self.subTest(test_id):
-                            if val_should_fail:
-                                msg = ("SyntaxError not raised for %s" %
-                                       str(test_id))
-                                with self.assertRaises(SyntaxError, msg=msg):
-                                    iprc(cell)
-
-                                    print(cell)
-                            else:
+                    with self.subTest(test_id):
+                        if val_should_fail:
+                            msg = ("SyntaxError not raised for %s" %
+                                    str(test_id))
+                            with self.assertRaises(SyntaxError, msg=msg):
                                 iprc(cell)
 
-        def test_nonlocal(self):
-            # fails if outer scope is not a function scope or if var not defined
-            with self.assertRaises(SyntaxError):
-                iprc("nonlocal x")
-                iprc("""
-                x = 1
-                def f():
-                    nonlocal x
-                    x = 10000
-                    yield x
-                """)
-                iprc("""
-                def f():
-                    def g():
-                        nonlocal x
-                        x = 10000
-                        yield x
-                """)
+                                print(cell)
+                        else:
+                            iprc(cell)
 
-            # works if outer scope is a function scope and var exists
+    def test_nonlocal(self):
+        # fails if outer scope is not a function scope or if var not defined
+        with self.assertRaises(SyntaxError):
+            iprc("nonlocal x")
+            iprc("""
+            x = 1
+            def f():
+                nonlocal x
+                x = 10000
+                yield x
+            """)
             iprc("""
             def f():
-                x = 20
                 def g():
                     nonlocal x
                     x = 10000
                     yield x
             """)
 
-
-        def test_execute(self):
-            iprc("""
-            import asyncio
-            await asyncio.sleep(0.001)
-            """
-            )
-
-        def test_autoawait(self):
-            iprc("%autoawait False")
-            iprc("%autoawait True")
-            iprc("""
-            from asyncio import sleep
-            await sleep(0.1)
-            """
-            )
-
-        @skip_without('curio')
-        def test_autoawait_curio(self):
-            iprc("%autoawait curio")
-
-        @skip_without('trio')
-        def test_autoawait_trio(self):
-            iprc("%autoawait trio")
-
-        @skip_without('trio')
-        def test_autoawait_trio_wrong_sleep(self):
-            iprc("%autoawait trio")
-            res = iprc_nr("""
-            import asyncio
-            await asyncio.sleep(0)
-            """)
-            with nt.assert_raises(TypeError):
-                res.raise_error()
-
-        @skip_without('trio')
-        def test_autoawait_asyncio_wrong_sleep(self):
-            iprc("%autoawait asyncio")
-            res = iprc_nr("""
-            import trio
-            await trio.sleep(0)
-            """)
-            with nt.assert_raises(RuntimeError):
-                res.raise_error()
+        # works if outer scope is a function scope and var exists
+        iprc("""
+        def f():
+            x = 20
+            def g():
+                nonlocal x
+                x = 10000
+                yield x
+        """)
 
 
-        def tearDown(self):
-            ip.loop_runner = "asyncio"
+    def test_execute(self):
+        iprc("""
+        import asyncio
+        await asyncio.sleep(0.001)
+        """
+        )
+
+    def test_autoawait(self):
+        iprc("%autoawait False")
+        iprc("%autoawait True")
+        iprc("""
+        from asyncio import sleep
+        await sleep(0.1)
+        """
+        )
+
+    @skip_without('curio')
+    def test_autoawait_curio(self):
+        iprc("%autoawait curio")
+
+    @skip_without('trio')
+    def test_autoawait_trio(self):
+        iprc("%autoawait trio")
+
+    @skip_without('trio')
+    def test_autoawait_trio_wrong_sleep(self):
+        iprc("%autoawait trio")
+        res = iprc_nr("""
+        import asyncio
+        await asyncio.sleep(0)
+        """)
+        with nt.assert_raises(TypeError):
+            res.raise_error()
+
+    @skip_without('trio')
+    def test_autoawait_asyncio_wrong_sleep(self):
+        iprc("%autoawait asyncio")
+        res = iprc_nr("""
+        import trio
+        await trio.sleep(0)
+        """)
+        with nt.assert_raises(RuntimeError):
+            res.raise_error()
+
+
+    def tearDown(self):
+        ip.loop_runner = "asyncio"

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -485,10 +485,9 @@ class TestCompleter(unittest.TestCase):
                 5, 6, "real"
             )
 
-            if sys.version_info > (3, 4):
-                yield _, "a[0].from_", 10, "a[0].from_bytes", "Should have completed on a[0].from_: %s", Completion(
-                    5, 10, "from_bytes"
-                )
+            yield _, "a[0].from_", 10, "a[0].from_bytes", "Should have completed on a[0].from_: %s", Completion(
+                5, 10, "from_bytes"
+            )
 
     def test_omit__names(self):
         # also happens to test IPCompleter as a configurable

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -140,7 +140,6 @@ def pickle_get_current_class(obj):
 
 class TestAutoreload(Fixture):
 
-    @skipif(sys.version_info < (3, 6))
     def test_reload_enums(self):
         import enum
         mod_name, mod_fn = self.new_module(textwrap.dedent("""

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -99,7 +99,7 @@ __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
 MAX_SEQ_LENGTH = 1000
 # The language spec says that dicts preserve order from 3.7, but CPython
 # does so from 3.6, so it seems likely that people will expect that.
-DICT_IS_ORDERED = sys.version_info >= (3, 6)
+DICT_IS_ORDERED = True
 _re_pattern_type = type(re.compile(''))
 
 def _safe_getattr(obj, attr, default=None):

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -49,8 +49,7 @@ def test_instantiation_FileLink():
     """FileLink: Test class can be instantiated"""
     fl = display.FileLink('example.txt')
     # TODO: remove if when only Python >= 3.6 is supported
-    if sys.version_info >= (3, 6):
-        fl = display.FileLink(pathlib.PurePath('example.txt'))
+    fl = display.FileLink(pathlib.PurePath('example.txt'))
 
 def test_warning_on_non_existent_path_FileLink():
     """FileLink: Calling _repr_html_ on non-existent files returns a warning

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -424,20 +424,9 @@ class TerminalInteractiveShell(InteractiveShell):
                 **self._extra_prompt_options())
         return text
 
-    def enable_win_unicode_console(self):
-        if sys.version_info >= (3, 6):
-            # Since PEP 528, Python uses the unicode APIs for the Windows
-            # console by default, so WUC shouldn't be needed.
-            return
-
-        import win_unicode_console
-        win_unicode_console.enable()
-
     def init_io(self):
         if sys.platform not in {'win32', 'cli'}:
             return
-
-        self.enable_win_unicode_console()
 
         import colorama
         colorama.init()

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -424,6 +424,14 @@ class TerminalInteractiveShell(InteractiveShell):
                 **self._extra_prompt_options())
         return text
 
+    def enable_win_unicode_console(self):
+        # Since IPython 7.10 doesn't support python < 3.6 and PEP 528, Python uses the unicode APIs for the Windows
+        # console by default, so WUC shouldn't be needed.
+        from warnings import warn
+        warn("`enable_win_unicode_console` is deprecated since IPython 7.10, does not do anything and will be removed in the future",
+             DeprecationWarning,
+             stacklevel=2)
+
     def init_io(self):
         if sys.platform not in {'win32', 'cli'}:
             return

--- a/tools/gen_latex_symbols.py
+++ b/tools/gen_latex_symbols.py
@@ -11,10 +11,6 @@
 
 import os, sys
 
-if sys.version_info[0] < 3:
-    print("This script must be run with Python 3, exiting...")
-    sys.exit(1)
-
 # Import the Julia LaTeX symbols
 print('Importing latex_symbols.js from Julia...')
 import requests


### PR DESCRIPTION
Remove unnecessary checks for python version < 3.6  

Closes #11949