### PR TITLE
Remove unchanging boolean DICT_IS_ORDERED and dependent unreachable code

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -97,9 +97,6 @@ __all__ = ['pretty', 'pprint', 'PrettyPrinter', 'RepresentationPrinter',
 
 
 MAX_SEQ_LENGTH = 1000
-# The language spec says that dicts preserve order from 3.7, but CPython
-# does so from 3.6, so it seems likely that people will expect that.
-DICT_IS_ORDERED = True
 _re_pattern_type = type(re.compile(''))
 
 def _safe_getattr(obj, attr, default=None):
@@ -606,11 +603,6 @@ def _dict_pprinter_factory(start, end):
         step = len(start)
         p.begin_group(step, start)
         keys = obj.keys()
-        # if dict isn't large enough to be truncated, sort keys before displaying
-        # From Python 3.7, dicts preserve order by definition, so we don't sort.
-        if not DICT_IS_ORDERED \
-                and not (p.max_seq_length and len(obj) >= p.max_seq_length):
-            keys = _sorted_for_pprint(keys)
         for idx, key in p._enumerate(keys):
             if idx:
                 p.text(',')


### PR DESCRIPTION
This PR fixes issue #11955 by removing `DICT_IS_ORDERED` and removing the one if-statement that it relies on.

Since this is such a small change I'm not sure if this needs much explanation, but if there's any documentation that should be included I can do that as well.