### PR TITLE
Run the prompt in a separate asyncio loop.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ install_requires = [
     'decorator',
     'pickleshare',
     'traitlets>=4.2',
-    'prompt_toolkit>=2.0.0,<3.1.0',
+    'prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1',
     'pygments',
     'backcall',
 ]


### PR DESCRIPTION
This requires a new prompt_toolkit 3.0.1, it does fix a little bug.

This prevents crashes from situations where the user starts scheduling new
coroutines that don't terminate. Like

    import asyncio
    async def func():
        while True:
            pass
    asyncio.ensure_future(func())

This would freeze the event loop and can't even be cancelled by pressing
control-c, because prompt_toolkit will never gain control from the event loop
to process key bindings.