### PR TITLE
Handle case where the shell does not have arbitrary mimerenderer handler

### DIFF
--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -105,7 +105,7 @@ class DisplayPublisher(Configurable):
 
         handlers = {}
         if self.shell is not None:
-            handlers = self.shell.mime_renderers
+            handlers = getattr(self.shell, 'mime_renderers', {})
 
         for mime, handler in handlers.items():
             if mime in data:


### PR DESCRIPTION
That can be the case in test-suites; for example bokeh

Closes #11976