### PR TITLE
Be more explicit on how we handle osx clipboard.

### DIFF
--- a/IPython/lib/clipboard.py
+++ b/IPython/lib/clipboard.py
@@ -32,15 +32,15 @@ def win32_clipboard_get():
         win32clipboard.CloseClipboard()
     return text
 
-def osx_clipboard_get():
+def osx_clipboard_get() -> str:
     """ Get the clipboard's text on OS X.
     """
     p = subprocess.Popen(['pbpaste', '-Prefer', 'ascii'],
         stdout=subprocess.PIPE)
-    text, stderr = p.communicate()
+    bytes_, stderr = p.communicate()
     # Text comes in with old Mac \r line endings. Change them to \n.
-    text = text.replace(b'\r', b'\n')
-    text = py3compat.cast_unicode(text, py3compat.DEFAULT_ENCODING)
+    bytes_ = bytes_.replace(b'\r', b'\n')
+    text = py3compat.decode(bytes_)
     return text
 
 def tkinter_clipboard_get():


### PR DESCRIPTION
The return values can only be bytes as we do bytes manipulations before.
So if we need to return text; we always need to decode.

We can now also leave the default encoding out; as py3compat.decode
takecare of that for us