### PR TITLE
Don't nest asyncio input hooks.

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -580,11 +580,22 @@ class TerminalInteractiveShell(InteractiveShell):
         # For prompt_toolkit 3.0. We have to create an asyncio event loop with
         # this inputhook.
         if PTK3:
-            if self._inputhook:
-                from prompt_toolkit.eventloop import new_eventloop_with_inputhook
+            import asyncio
+            from prompt_toolkit.eventloop import new_eventloop_with_inputhook
+
+            if gui == 'asyncio':
+                # When we integrate the asyncio event loop, run the UI in the
+                # same event loop as the rest of the code. don't use an actual
+                # input hook. (Asyncio is not made for nesting event loops.)
+                self.pt_loop = asyncio.get_event_loop()
+
+            elif self._inputhook:
+                # If an inputhook was set, create a new asyncio event loop with
+                # this inputhook for the prompt.
                 self.pt_loop = new_eventloop_with_inputhook(self._inputhook)
             else:
-                import asyncio
+                # When there's no inputhook, run the prompt in a separate
+                # asyncio event loop.
                 self.pt_loop = asyncio.new_event_loop()
 
     # Run !system commands directly, not through pipes, so terminal programs


### PR DESCRIPTION
This fixes the "event loop already running" error.

For prompt_toolkit 2.0: this will still nest the event loops, but that's fine,
because we have the asyncio event loop running an prompt_toolkit's custom loop.
They don't interfere with each other.

For prompt_toolkit 3.0: we only use one asyncio event loop when "%gui asyncio"
is used. The terminal prompt will now use the active asyncio event loop.