### PR TITLE
bugfix for 7.10.1: revert inputhook param location

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -438,7 +438,7 @@ class TerminalInteractiveShell(InteractiveShell):
                             Condition(lambda: self.highlight_matching_brackets))],
                 }
         if not PTK3:
-            options['inputhook'] = self.inputhook
+            options['inputhook'] = self.shell.inputhook
 
         return options
 


### PR DESCRIPTION
In https://github.com/ipython/ipython/pull/11979, a fix was made for `ipdb` however, the location of the param lookup was changed by accident? it is certainly breaking it for me.