### PR TITLE
Removed unused py2 compact functions #12014

### DIFF
--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -157,9 +157,6 @@ def isidentifier(s, dotted=False):
         return all(isidentifier(a) for a in s.split("."))
     return s.isidentifier()
 
-xrange = range
-def iteritems(d): return iter(d.items())
-def itervalues(d): return iter(d.values())
 getcwd = os.getcwd
 
 MethodType = types.MethodType


### PR DESCRIPTION
Removed unused functions from `IPython/utils/py3comat.py`

    xrange
    iteritems
    itervalues