### PR TITLE
Remove one appveyor test on win32.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,6 @@ environment:
      PYTHON_VERSION: "3.6.x"
      PYTHON_ARCH: "64"
 
-   - PYTHON: "C:\\Python37"
-     PYTHON_VERSION: "3.7.x"
-     PYTHON_ARCH: "32"
-
    - PYTHON: "C:\\Python37-x64"
      PYTHON_VERSION: "3.7.x"
      PYTHON_ARCH: "64"


### PR DESCRIPTION
Appveyor is often the limiting CI.

Keep both 64 and 32 on both max/min version of Python supported