### PR TITLE
cleanup py3compact import in frame.py #11983

### DIFF
--- a/IPython/utils/frame.py
+++ b/IPython/utils/frame.py
@@ -15,7 +15,6 @@ Utilities for working with stack frames.
 #-----------------------------------------------------------------------------
 
 import sys
-from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------
 # Code

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -157,9 +157,6 @@ def isidentifier(s, dotted=False):
         return all(isidentifier(a) for a in s.split("."))
     return s.isidentifier()
 
-xrange = range
-def iteritems(d): return iter(d.items())
-def itervalues(d): return iter(d.values())
 getcwd = os.getcwd
 
 MethodType = types.MethodType


### PR DESCRIPTION
Removed `py3comapact` import from `frame.py` as it is not being used.