### PR TITLE
PR: fix chained syntax error

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -627,6 +627,12 @@ class ListTB(TBTools):
         self.ostream.write(self.text(etype, value, elist))
         self.ostream.write('\n')
 
+    def _extract_tb(self, tb):
+        if tb:
+            return traceback.extract_tb(tb)
+        else:
+            return None
+
     def structured_traceback(self, etype, evalue, etb=None, tb_offset=None,
                              context=5):
         """Return a color formatted string with the traceback info.
@@ -1303,12 +1309,6 @@ class FormattedTB(VerboseTB, ListTB):
         # set_mode also sets the tb_join_char attribute
         self.set_mode(mode)
 
-    def _extract_tb(self, tb):
-        if tb:
-            return traceback.extract_tb(tb)
-        else:
-            return None
-
     def structured_traceback(self, etype, value, tb, tb_offset=None, number_of_lines_of_context=5):
         tb_offset = self.tb_offset if tb_offset is None else tb_offset
         mode = self.mode
@@ -1409,7 +1409,10 @@ class AutoFormattedTB(FormattedTB):
                              tb_offset=None, number_of_lines_of_context=5):
         if etype is None:
             etype, value, tb = sys.exc_info()
-        self.tb = tb
+        if not isinstance(tb, tuple):
+            # tb is a tuple if this is a chained exception.
+            # We keep first traceback.
+            self.tb = tb
         return FormattedTB.structured_traceback(
             self, etype, value, tb, tb_offset, number_of_lines_of_context)
 

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -1409,9 +1409,10 @@ class AutoFormattedTB(FormattedTB):
                              tb_offset=None, number_of_lines_of_context=5):
         if etype is None:
             etype, value, tb = sys.exc_info()
-        if not isinstance(tb, tuple):
+        if isinstance(tb, tuple):
             # tb is a tuple if this is a chained exception.
-            # We keep first traceback.
+            self.tb = tb[0]
+        else:
             self.tb = tb
         return FormattedTB.structured_traceback(
             self, etype, value, tb, tb_offset, number_of_lines_of_context)


### PR DESCRIPTION
Fix this code:
```python
%xmode plain
try:
    1/0
except:
    compile(".a", '', 'exec')
```
Before:
```python
In [1]: %xmode plain 
   ...: try: 
   ...:     1/0 
   ...: except: 
   ...:     compile(".a", '', 'exec') 
   ...:                                                                                                               
Exception reporting mode: Plain
Traceback (most recent call last):
  File "<ipython-input-1-b4b8fb77252f>", line 3, in <module>
    1/0
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/interactiveshell.py", line 3319, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-b4b8fb77252f>", line 5, in <module>
    compile(".a", '', 'exec')
  File "<string>", line 1
    .a
    ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/interactiveshell.py", line 3336, in run_code
    self.showtraceback(running_compiled_code=True)
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/interactiveshell.py", line 2020, in showtraceback
    self.showsyntaxerror(filename, running_compiled_code)
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/interactiveshell.py", line 2082, in showsyntaxerror
    stb = self.SyntaxTB.structured_traceback(etype, value, elist)
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/ultratb.py", line 1454, in structured_traceback
    tb_offset=tb_offset, context=context)
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/ultratb.py", line 699, in structured_traceback
    + out_list)
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/ultratb.py", line 1454, in structured_traceback
    tb_offset=tb_offset, context=context)
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/ultratb.py", line 667, in structured_traceback
    elist = self._extract_tb(etb)
AttributeError: 'SyntaxTB' object has no attribute '_extract_tb'


In [2]:   
```

After:
```python
In [1]: %xmode plain 
   ...: try: 
   ...:     1/0 
   ...: except: 
   ...:     compile(".a", '', 'exec') 
   ...:                                                                                                               
Exception reporting mode: Plain
Traceback (most recent call last):
  File "<ipython-input-1-b4b8fb77252f>", line 3, in <module>
    1/0
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/quentinpeter/pyscripts/ipython/IPython/core/interactiveshell.py", line 3319, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-b4b8fb77252f>", line 5, in <module>
    compile(".a", '', 'exec')
  File "<string>", line 1
    .a
    ^
SyntaxError: invalid syntax


In [2]:       
```