### PR TITLE
Removed snip_print fn because unused. Fixes #12038

### DIFF
--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -341,32 +341,3 @@ else:
             return False
         else:
             return True
-
-
-def snip_print(str,width = 75,print_full = 0,header = ''):
-    """Print a string snipping the midsection to fit in width.
-
-    print_full: mode control:
-    
-      - 0: only snip long strings
-      - 1: send to page() directly.
-      - 2: snip long strings and ask for full length viewing with page()
-    
-    Return 1 if snipping was necessary, 0 otherwise."""
-
-    if print_full == 1:
-        page(header+str)
-        return 0
-
-    print(header, end=' ')
-    if len(str) < width:
-        print(str)
-        snip = 0
-    else:
-        whalf = int((width -5)/2)
-        print(str[:whalf] + ' <...> ' + str[-whalf:])
-        snip = 1
-    if snip and print_full == 2:
-        if py3compat.input(header+' Snipped. View (y/n)? [N]').lower() == 'y':
-            page(str)
-    return snip


### PR DESCRIPTION
Removed snip_print fn() because it is unused.

This also fixes #12045 

Signed-off-by: Naveen Honest Raj K <naveendurai19@gmail.com>