### PR TITLE
VI-mode in prompt

### DIFF
--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -7,6 +7,7 @@ from IPython.core.displayhook import DisplayHook
 
 from prompt_toolkit.formatted_text import fragment_list_width, PygmentsTokens
 from prompt_toolkit.shortcuts import print_formatted_text
+from prompt_toolkit.enums import EditingMode
 
 
 class Prompts(object):
@@ -14,7 +15,7 @@ class Prompts(object):
         self.shell = shell
 
     def vi_mode(self):
-        if (getattr(self.shell.pt_app, 'editing_mode', None) == 'VI'
+        if (getattr(self.shell.pt_app, 'editing_mode', None) == EditingMode.VI
                 and self.shell.prompt_includes_vi_mode):
             return '['+str(self.shell.pt_app.app.vi_state.input_mode)[3:6]+'] '
         return ''

--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -17,7 +17,12 @@ class Prompts(object):
     def vi_mode(self):
         if (getattr(self.shell.pt_app, 'editing_mode', None) == EditingMode.VI
                 and self.shell.prompt_includes_vi_mode):
-            return '['+str(self.shell.pt_app.app.vi_state.input_mode)[3:6]+'] '
+            mode = str(self.shell.pt_app.app.vi_state.input_mode)
+            if mode.startswith('InputMode.'):
+                mode = mode[10:13].lower()
+            elif mode.startswith('vi-'):
+                mode = mode[3:6]
+            return '['+mode+'] '
         return ''
 
 


### PR DESCRIPTION
From the code it is apparent that if vi-mode is enabled, it should
display in the prompt. Both in insert and navigation mode:

    [ins] In [1]:
    [nav] In [1]:

However, as a compare is done between an Enum instance and a string, it will always return False, irrespectively of the value.

The solution is either to access the Enum's `.value` attribute, or to
compare it to the declared Enum value directly. The latter is likely
more readable.

I have also added support for `InputMode.INSERT` and `InputMode.NAVIGATION` which the shell provides when I install from source.