### PR TITLE
Fix handling of repeated NEWLINE tokens

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -674,8 +674,8 @@ class TransformerManager:
         while tokens_by_line[-1] and tokens_by_line[-1][-1].type in newline_types:
             tokens_by_line[-1].pop()
 
-        if len(tokens_by_line) == 1 and not tokens_by_line[-1]:
-            return 'incomplete', 0
+        if not tokens_by_line[-1]:
+            return 'incomplete', find_last_indent(lines)
 
         if tokens_by_line[-1][-1].string == ':':
             # The last line starts a block (e.g. 'if foo:')

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -265,6 +265,8 @@ def test_check_complete():
         for k in short:
             cc(c+k)
 
+    nt.assert_equal(cc("def f():\n  x=0\n  \\\n  "), ('incomplete', 2))
+
 def test_check_complete_II():
     """
     Test that multiple line strings are properly handled.


### PR DESCRIPTION
Because of [cpython's issue 37621](https://bugs.python.org/issue37621) it is possible that tokenizer will emit repeated NEWLINE tokens despite that language specification states it should never happen. 

Currently IPython doesn't handle such situation well, e.g.

```python
In [1]: def f(): 
   ...:     x = 0 
   ...:     \ 
   ...:       
```

```
Unhandled exception in event loop:
  File "/Users/dominik/src/ipython/venv/lib/python3.7/site-packages/prompt_toolkit/eventloop/posix.py", line 154, in _run_task
    t()
  File "/Users/dominik/src/ipython/venv/lib/python3.7/site-packages/prompt_toolkit/eventloop/context.py", line 115, in new_func
    return func(*a, **kw)
  File "/Users/dominik/src/ipython/venv/lib/python3.7/site-packages/prompt_toolkit/application/application.py", line 562, in read_from_input
    self.key_processor.process_keys()
  File "/Users/dominik/src/ipython/venv/lib/python3.7/site-packages/prompt_toolkit/key_binding/key_processor.py", line 273, in process_keys
    self._process_coroutine.send(key_press)
  File "/Users/dominik/src/ipython/venv/lib/python3.7/site-packages/prompt_toolkit/key_binding/key_processor.py", line 180, in _process
    self._call_handler(matches[-1], key_sequence=buffer[:])
  File "/Users/dominik/src/ipython/venv/lib/python3.7/site-packages/prompt_toolkit/key_binding/key_processor.py", line 323, in _call_handler
    handler.call(event)
  File "/Users/dominik/src/ipython/venv/lib/python3.7/site-packages/prompt_toolkit/key_binding/key_bindings.py", line 78, in call
    return self.handler(event)
  File "/Users/dominik/src/ipython/IPython/terminal/shortcuts.py", line 128, in newline_or_execute
    status, indent = shell.check_complete(check_text)
  File "/Users/dominik/src/ipython/IPython/core/interactiveshell.py", line 3361, in check_complete
    status, nspaces = self.input_transformer_manager.check_complete(code)
  File "/Users/dominik/src/ipython/IPython/core/inputtransformer2.py", line 680, in check_complete
    if tokens_by_line[-1][-1].string == ':':

Exception list index out of range
Press ENTER to continue...
```

This PR attempts to fix this issue.