### PR TITLE
Remove 'annotate' function from IPython/utils/py3compat.py

### DIFF
--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -190,20 +190,6 @@ PY2 = not PY3
 PYPY = platform.python_implementation() == "PyPy"
 
 
-def annotate(**kwargs):
-    """Python 3 compatible function annotation for Python 2."""
-    if not kwargs:
-        raise ValueError('annotations must be provided as keyword arguments')
-    def dec(f):
-        if hasattr(f, '__annotations__'):
-            for k, v in kwargs.items():
-                f.__annotations__[k] = v
-        else:
-            f.__annotations__ = kwargs
-        return f
-    return dec
-
-
 # Parts below taken from six:
 # Copyright (c) 2010-2013 Benjamin Peterson
 #


### PR DESCRIPTION
As it has been seen that the "annotate" function of the py3compat.py file in IPython/utils is a relic of Python 2 compatibility - which is no longer required as of the EOL of Python 2 in 2020 - I have removed the function and made sure that there were no uses of the function anywhere, which turned out to be the case.