### PR TITLE
Exit non-zero when ipython is given a file path to run that doesn't exist

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -404,6 +404,9 @@ class InteractiveShellApp(Configurable):
             fname = self.file_to_run
             if os.path.isdir(fname):
                 fname = os.path.join(fname, "__main__.py")
+            if not os.path.exists(fname):
+                self.log.warning("File '%s' doesn't exist", fname)
+                self.exit(2)
             try:
                 self._exec_file(fname, shell_futures=True)
             except:


### PR DESCRIPTION
Simple PR to update the exit code for ipython when given a file that doesn't exist from 0 ("success") to 2 (matches python's behavior for this condition).

Currently, running ipython with a file argument that does not exist causes a zero exit code. This can cause problems in automation, i.e. bash scripts that have `-e` set and have an invalid file path.

```
$ ./venv/bin/ipython no-such-file.py
[TerminalIPythonApp] WARNING | File not found: 'foo.py'
$ echo $?
0
```

This PR changes the behavior to:
```
$ ./venv/bin/ipython no-such-file.py
[TerminalIPythonApp] WARNING | File 'no-such-file.py' doesn't exist
$ echo $?
2
```

