### PR TITLE
MNT: ensure we can show un-pickled figures

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -123,14 +123,18 @@ def print_figure(fig, fmt='png', bbox_inches='tight', **kwargs):
     }
     # **kwargs get higher priority
     kw.update(kwargs)
-    
+
     bytes_io = BytesIO()
+    if fig.canvas is None:
+        from matplotlib.backend_bases import FigureCanvasBase
+        FigureCanvasBase(fig)
+
     fig.canvas.print_figure(bytes_io, **kw)
     data = bytes_io.getvalue()
     if fmt == 'svg':
         data = data.decode('utf-8')
     return data
-    
+
 def retina_figure(fig, **kwargs):
     """format a figure as a pixel-doubled (retina) PNG"""
     pngdata = print_figure(fig, fmt='retina', **kwargs)

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -248,3 +248,9 @@ class TestPylabSwitch(object):
 def test_no_gui_backends():
     for k in ['agg', 'svg', 'pdf', 'ps']:
         assert k not in pt.backend2gui
+
+
+def test_figure_no_canvas():
+    fig = Figure()
+    fig.canvas = None
+    pt.print_figure(fig)


### PR DESCRIPTION
For Matplotlib < 3.2 inline figures maybe re-hydrated with the canvas attribute as None.  If that is true, then `print_figure` will fail.

There is a PR into Matplotlib (https://github.com/matplotlib/matplotlib/pull/16189) to fix this going forward, but opening this as a belt-and-suspenders approach.