### PR TITLE
Support git blame ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# When making commits that are strictly formatting/style changes, add the
+# commit hash here, so git blame can ignore the change.
+# See docs for more details:
+# https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile
+
+# Example entries:
+# <full commit hash>  # initial black-format
+# <full commit hash>  # rename something internal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,6 +24,8 @@ graft docs
 exclude docs/\#*
 exclude docs/man/*.1.gz
 
+exclude .git-blame-ignore-revs
+
 # Examples
 graft examples
 

--- a/README.rst
+++ b/README.rst
@@ -129,3 +129,18 @@ project that you might want to use:
 - `mypython <https://www.asmeurer.com/mypython/>`_
 - `ptpython and ptipython <https://pypi.org/project/ptpython/>`
 - `xonsh <https://xon.sh/>`
+
+Ignoring commits with git blame.ignoreRevsFile
+==============================================
+
+As of git 2.23, it is possible to make formatting changes without breaking
+``git blame``. See the `git documentation
+<https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile>`_
+for more details.
+
+To use this feature you must:
+
+- Install git >= 2.23
+- Configure your local git repo by running:
+   - POSIX: ``tools\configure-git-blame-ignore-revs.sh``
+   - Windows:  ``tools\configure-git-blame-ignore-revs.bat``

--- a/tools/configure-git-blame-ignore-revs.bat
+++ b/tools/configure-git-blame-ignore-revs.bat
@@ -1,0 +1,10 @@
+rem Other config options for blame are markUnblamables and markIgnoredLines.
+rem See docs for more details:
+rem https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile
+
+rem Uncomment below and rerun script to enable an option.
+rem git config blame.markIgnoredLines
+rem git config blame.markUnblamables
+
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+git config --get blame.ignoreRevsFile

--- a/tools/configure-git-blame-ignore-revs.sh
+++ b/tools/configure-git-blame-ignore-revs.sh
@@ -1,0 +1,10 @@
+# Other config options for blame are markUnblamables and markIgnoredLines.
+# See docs for more details:
+# https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile
+
+# Uncomment below and rerun script to enable an option.
+# git config blame.markIgnoredLines
+# git config blame.markUnblamables
+
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+git config --get blame.ignoreRevsFile


### PR DESCRIPTION
In response to this [comment](https://github.com/ipython/ipython/issues/11816#issuecomment-554671200).

Please note:
- neither Github nor GitLab supports this feature.
- the IntelliJ plugin [GitToolBox](https://github.com/zielu/GitToolBox) supports this feature, so perhaps other client-side git tools do too?