### PR TITLE
Remove Python 2 workarounds

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -361,10 +361,8 @@ class Pdb(OldPdb):
                 print("Context must be a positive integer", file=self.stdout)
         except (TypeError, ValueError):
                 print("Context must be a positive integer", file=self.stdout)
-        try:
-            import reprlib  # Py 3
-        except ImportError:
-            import repr as reprlib  # Py 2
+
+        import reprlib
 
         ret = []
 

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -43,7 +43,7 @@ class DummyDB(object):
 
 
 @decorator
-def needs_sqlite(f, self, *a, **kw):
+def only_when_enabled(f, self, *a, **kw):
     """Decorator: return an empty list in the absence of sqlite."""
     if not self.enabled:
         return []
@@ -277,7 +277,7 @@ class HistoryAccessor(HistoryAccessorBase):
             return ((ses, lin, (inp, out)) for ses, lin, inp, out in cur)
         return cur
 
-    @needs_sqlite
+    @only_when_enabled
     @catch_corrupt_db
     def get_session_info(self, session):
         """Get info about a session.
@@ -533,7 +533,7 @@ class HistoryManager(HistoryAccessor):
         profile_dir = self.shell.profile_dir.location
         return os.path.join(profile_dir, 'history.sqlite')
     
-    @needs_sqlite
+    @only_when_enabled
     def new_session(self, conn=None):
         """Get a new session number."""
         if conn is None:
@@ -744,7 +744,7 @@ class HistoryManager(HistoryAccessor):
                 conn.execute("INSERT INTO output_history VALUES (?, ?, ?)",
                                 (self.session_number,)+line)
 
-    @needs_sqlite
+    @only_when_enabled
     def writeout_cache(self, conn=None):
         """Write any entries in the cache to the database."""
         if conn is None:
@@ -793,7 +793,7 @@ class HistorySavingThread(threading.Thread):
         self.enabled = history_manager.enabled
         atexit.register(self.stop)
 
-    @needs_sqlite
+    @only_when_enabled
     def run(self):
         # We need a separate db connection per thread:
         try:

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -19,7 +19,6 @@ from traitlets import (
     Any, Bool, Dict, Instance, Integer, List, Unicode, TraitError,
     default, observe,
 )
-from warnings import warn
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -43,8 +42,14 @@ class DummyDB(object):
         pass
 
 
-DatabaseError = sqlite3.DatabaseError
-OperationalError = sqlite3.OperationalError
+@decorator
+def needs_sqlite(f, self, *a, **kw):
+    """Decorator: return an empty list in the absence of sqlite."""
+    if not self.enabled:
+        return []
+    else:
+        return f(self, *a, **kw)
+
 
 # use 16kB as threshold for whether a corrupt history db should be saved
 # that should be at least 100 entries or so
@@ -61,7 +66,7 @@ def catch_corrupt_db(f, self, *a, **kw):
     """
     try:
         return f(self, *a, **kw)
-    except (DatabaseError, OperationalError) as e:
+    except (sqlite3.DatabaseError, sqlite3.OperationalError) as e:
         self._corrupt_db_counter += 1
         self.log.error("Failed to open SQLite history %s (%s).", self.hist_file, e)
         if self.hist_file != ':memory:':
@@ -165,9 +170,7 @@ class HistoryAccessor(HistoryAccessorBase):
     def _db_changed(self, change):
         """validate the db, since it can be an Instance of two different types"""
         new = change['new']
-        connection_types = (DummyDB,)
-        if sqlite3 is not None:
-            connection_types = (DummyDB, sqlite3.Connection)
+        connection_types = (DummyDB, sqlite3.Connection)
         if not isinstance(new, connection_types):
             msg = "%s.db must be sqlite3 Connection or DummyDB, not %r" % \
                     (self.__class__.__name__, new)
@@ -197,10 +200,6 @@ class HistoryAccessor(HistoryAccessorBase):
         if self.hist_file == u'':
             # No one has set the hist_file, yet.
             self.hist_file = self._get_hist_file_name(profile)
-
-        if sqlite3 is None and self.enabled:
-            warn("IPython History requires SQLite, your history will not be saved")
-            self.enabled = False
         
         self.init_db()
     
@@ -278,6 +277,7 @@ class HistoryAccessor(HistoryAccessorBase):
             return ((ses, lin, (inp, out)) for ses, lin, inp, out in cur)
         return cur
 
+    @needs_sqlite
     @catch_corrupt_db
     def get_session_info(self, session):
         """Get info about a session.
@@ -516,7 +516,7 @@ class HistoryManager(HistoryAccessor):
         
         try:
             self.new_session()
-        except OperationalError:
+        except sqlite3.OperationalError:
             self.log.error("Failed to create history session in %s. History will not be saved.",
                 self.hist_file, exc_info=True)
             self.hist_file = ':memory:'
@@ -533,6 +533,7 @@ class HistoryManager(HistoryAccessor):
         profile_dir = self.shell.profile_dir.location
         return os.path.join(profile_dir, 'history.sqlite')
     
+    @needs_sqlite
     def new_session(self, conn=None):
         """Get a new session number."""
         if conn is None:
@@ -743,6 +744,7 @@ class HistoryManager(HistoryAccessor):
                 conn.execute("INSERT INTO output_history VALUES (?, ?, ?)",
                                 (self.session_number,)+line)
 
+    @needs_sqlite
     def writeout_cache(self, conn=None):
         """Write any entries in the cache to the database."""
         if conn is None:
@@ -791,6 +793,7 @@ class HistorySavingThread(threading.Thread):
         self.enabled = history_manager.enabled
         atexit.register(self.stop)
 
+    @needs_sqlite
     def run(self):
         # We need a separate db connection per thread:
         try:

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -173,16 +173,8 @@ class ExecutionMagics(Magics):
 
     def __init__(self, shell):
         super(ExecutionMagics, self).__init__(shell)
-        if profile is None:
-            self.prun = self.profile_missing_notice
         # Default execution function used to actually run user code.
         self.default_runner = None
-
-    def profile_missing_notice(self, *args, **kwargs):
-        error("""\
-The profile module could not be found. It has been removed from the standard
-python packages because of its non-free license. To use profiling, install the
-python-profiler package from non-free.""")
 
     @skip_doctest
     @no_var_expand

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -19,16 +19,8 @@ import math
 import re
 from pdb import Restart
 
-# cProfile was added in Python2.5
-try:
-    import cProfile as profile
-    import pstats
-except ImportError:
-    # profile isn't bundled by default in Debian for license reasons
-    try:
-        import profile, pstats
-    except ImportError:
-        profile = pstats = None
+import cProfile as profile
+import pstats
 
 from IPython.core import oinspect
 from IPython.core import magic_arguments

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -48,10 +48,7 @@ class PdbTestInput(object):
 #-----------------------------------------------------------------------------
 
 def test_longer_repr():
-    try:
-        from reprlib import repr as trepr  # Py 3
-    except ImportError:
-        from repr import repr as trepr  # Py 2
+    from reprlib import repr as trepr
     
     a = '1234567890'* 7
     ar = "'1234567890123456789012345678901234567890123456789012345678901234567890'"

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -174,7 +174,6 @@ def test_magic_parse_long_options():
     nt.assert_equal(opts['bar'], "bubble")
 
 
-@dec.skip_without('sqlite3')
 def doctest_hist_f():
     """Test %hist -f with temporary filename.
 
@@ -188,7 +187,6 @@ def doctest_hist_f():
     """
 
 
-@dec.skip_without('sqlite3')
 def doctest_hist_r():
     """Test %hist -r
 
@@ -207,7 +205,6 @@ def doctest_hist_r():
     """
 
 
-@dec.skip_without('sqlite3')
 def doctest_hist_op():
     """Test %hist -op
 
@@ -285,7 +282,6 @@ def test_hist_pof():
         assert os.path.isfile(tf)
 
 
-@dec.skip_without('sqlite3')
 def test_macro():
     ip = get_ipython()
     ip.history_manager.reset()   # Clear any existing history.
@@ -299,7 +295,6 @@ def test_macro():
     nt.assert_in("test", ip.magic("macro"))
 
 
-@dec.skip_without('sqlite3')
 def test_macro_run():
     """Test that we can run a multi-line macro successfully."""
     ip = get_ipython()

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -187,24 +187,6 @@ def doctest_hist_f():
     """
 
 
-def doctest_hist_r():
-    """Test %hist -r
-
-    XXX - This test is not recording the output correctly.  For some reason, in
-    testing mode the raw history isn't getting populated.  No idea why.
-    Disabling the output checking for now, though at least we do run it.
-
-    In [1]: 'hist' in _ip.lsmagic()
-    Out[1]: True
-
-    In [2]: x=1
-
-    In [3]: %hist -rl 2
-    x=1 # random
-    %hist -r 2
-    """
-
-
 def doctest_hist_op():
     """Test %hist -op
 

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -248,10 +248,7 @@ class TestMagicRunSimple(tt.TempFileMixin):
                "        print('object A deleted')\n"
                "a = A()\n")
         self.mktmp(src)
-        if dec.module_not_available('sqlite3'):
-            err = 'WARNING: IPython History requires SQLite, your history will not be saved\n'
-        else:
-            err = None
+        err = None
         tt.ipexec_validate(self.fname, 'object A deleted', err)
     
     def test_aggressive_namespace_cleanup(self):
@@ -306,10 +303,7 @@ ARGV 1-: ['C-third']
 tclass.py: deleting object: C-second
 tclass.py: deleting object: C-third
 """
-        if dec.module_not_available('sqlite3'):
-            err = 'WARNING: IPython History requires SQLite, your history will not be saved\n'
-        else:
-            err = None
+        err = None
         tt.ipexec_validate(self.fname, out, err)
 
     def test_run_i_after_reset(self):

--- a/IPython/core/tests/test_shellapp.py
+++ b/IPython/core/tests/test_shellapp.py
@@ -20,9 +20,6 @@ import unittest
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
 
-sqlite_err_maybe = dec.module_not_available('sqlite3')
-SQLITE_NOT_AVAILABLE_ERROR = ('WARNING: IPython History requires SQLite,'
-                              ' your history will not be saved\n')
 
 class TestFileToRun(tt.TempFileMixin, unittest.TestCase):
     """Test the behavior of the file_to_run parameter."""
@@ -32,7 +29,7 @@ class TestFileToRun(tt.TempFileMixin, unittest.TestCase):
         src = "print(__file__)\n"
         self.mktmp(src)
 
-        err = SQLITE_NOT_AVAILABLE_ERROR if sqlite_err_maybe else None
+        err = None
         tt.ipexec_validate(self.fname, self.fname, err)
 
     def test_ipy_script_file_attribute(self):
@@ -40,7 +37,7 @@ class TestFileToRun(tt.TempFileMixin, unittest.TestCase):
         src = "print(__file__)\n"
         self.mktmp(src, ext='.ipy')
 
-        err = SQLITE_NOT_AVAILABLE_ERROR if sqlite_err_maybe else None
+        err = None
         tt.ipexec_validate(self.fname, self.fname, err)
 
     # The commands option to ipexec_validate doesn't work on Windows, and it

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -266,10 +266,7 @@ class IFrame(object):
     def _repr_html_(self):
         """return the embed iframe"""
         if self.params:
-            try:
-                from urllib.parse import urlencode # Py 3
-            except ImportError:
-                from urllib import urlencode
+            from urllib.parse import urlencode
             params = "?" + urlencode(self.params)
         else:
             params = ""

--- a/IPython/lib/inputhook.py
+++ b/IPython/lib/inputhook.py
@@ -509,10 +509,7 @@ class TkInputHook(InputHookBase):
         warn("This function is deprecated since IPython 5.0 and will be removed in future versions.",
                 DeprecationWarning, stacklevel=2)
         if app is None:
-            try:
-                from tkinter import Tk  # Py 3
-            except ImportError:
-                from Tkinter import Tk  # Py 2
+            from tkinter import Tk
             app = Tk()
             app.withdraw()
             self.manager.apps[GUI_TK] = app

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -137,7 +137,7 @@ def test_for(item, min_version=None, callback=extract_version):
 # have available at test run time
 have = {'matplotlib': test_for('matplotlib'),
         'pygments': test_for('pygments'),
-        'sqlite3': test_for('sqlite3')}
+        }
 
 #-----------------------------------------------------------------------------
 # Test suite definitions
@@ -176,9 +176,6 @@ test_sections = {n:TestSection(n, ['IPython.%s' % n]) for n in test_group_names}
 
 # core:
 sec = test_sections['core']
-if not have['sqlite3']:
-    sec.exclude('tests.test_history')
-    sec.exclude('history')
 if not have['matplotlib']:
     sec.exclude('pylabtools'),
     sec.exclude('tests.test_pylabtools')

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ requires utilities which are not available under Windows."""
 #  The full license is in the file COPYING.rst, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import sys
 


### PR DESCRIPTION
I don't know if docstring changes belong in a different PR.
I'd be happy to split this one up if needed.
This also includes one or two things related to python<3.5.

One of the docstring changes I made included a note about using a context manager. Could I replace the begin/end_group pairs with a context manager in this PR?
```python
    def begin_group(self, indent=0, open=''):	
        """
        Begin a group.  If you want support for python < 2.5 which doesn't has	        Begin a group.
        the with statement this is the preferred way:	
            p.begin_group(1, '{')	
            ...	
            p.end_group(1, '}')	
        The python 2.5 expression would be this:	
            with p.group(1, '{', '}'):	
                ...	
        The first parameter specifies the indentation for the next line (usually	        The first parameter specifies the indentation for the next line (usually
        the width of the opening text), the second the opening text.  All	        the width of the opening text), the second the opening text.  All
        parameters are optional.
```

I also found this test, with a TODO related to python 3.6+ support. I'm not sure what should be removed.
```python
def test_instantiation_FileLink():
    """FileLink: Test class can be instantiated"""
    fl = display.FileLink('example.txt')
    # TODO: remove if when only Python >= 3.6 is supported
    fl = display.FileLink(pathlib.PurePath('example.txt'))
```
