### PR TITLE
catch `MemoryError` raised by `compile`

### DIFF
--- a/IPython/core/async_helpers.py
+++ b/IPython/core/async_helpers.py
@@ -146,20 +146,20 @@ def _should_be_async(cell: str) -> bool:
 
     If it works, assume it should be async. Otherwise Return False.
 
-    Not handled yet: If the block of code has a return statement as  the top
+    Not handled yet: If the block of code has a return statement as the top
     level, it will be seen as async. This is a know limitation.
     """
     if sys.version_info > (3, 8):
         try:
             code = compile(cell, "<>", "exec", flags=getattr(ast,'PyCF_ALLOW_TOP_LEVEL_AWAIT', 0x0))
             return inspect.CO_COROUTINE & code.co_flags == inspect.CO_COROUTINE
-        except SyntaxError:
+        except (SyntaxError, MemoryError):
             return False
     try:
         # we can't limit ourself to ast.parse, as it __accepts__ to parse on
         # 3.7+, but just does not _compile_
         code = compile(cell, "<>", "exec")
-    except SyntaxError:
+    except (SyntaxError, MemoryError):
         try:
             parse_tree = _async_parse_cell(cell)
 
@@ -167,7 +167,7 @@ def _should_be_async(cell: str) -> bool:
             v = _AsyncSyntaxErrorVisitor()
             v.visit(parse_tree)
 
-        except SyntaxError:
+        except (SyntaxError, MemoryError):
             return False
         return True
     return False

--- a/IPython/core/tests/test_async_helpers.py
+++ b/IPython/core/tests/test_async_helpers.py
@@ -276,6 +276,10 @@ class AsyncTest(TestCase):
         """
         )
 
+    def test_memory_error(self):
+        with self.assertRaises(MemoryError):
+            iprc("(" * 200 + ")" * 200)
+
     @skip_without('curio')
     def test_autoawait_curio(self):
         iprc("%autoawait curio")

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -253,6 +253,13 @@ bar()
                 ip.showsyntaxerror()
 
 
+class MemoryErrorTest(unittest.TestCase):
+    def test_memoryerror(self):
+        memoryerror_code = "(" * 200 + ")" * 200
+        with tt.AssertPrints("MemoryError"):
+            ip.run_cell(memoryerror_code)
+
+
 class Python3ChainedExceptionsTest(unittest.TestCase):
     DIRECT_CAUSE_ERROR_CODE = """
 try:


### PR DESCRIPTION
`compile` could raise `MemoryError` besides `SyntaxError` and we should also catch them.
At present, ipython crashes on this case.
```
In [3]: ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
   ...: (((())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
   ...: ))))))))                                                                                                                                                                                            
s_push: parser stack overflow
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.8.0/bin/ipython", line 10, in <module>
    sys.exit(start_ipython())
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/__init__.py", line 126, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/traitlets/config/application.py", line 664, in launch_instance
    app.start()
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/terminal/ipapp.py", line 356, in start
    self.shell.mainloop()
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/terminal/interactiveshell.py", line 558, in mainloop
    self.interact()
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/terminal/interactiveshell.py", line 549, in interact
    self.run_cell(code, store_history=True)
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 2847, in run_cell
    result = self._run_cell(
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 2868, in _run_cell
    if self.should_run_async(raw_cell):
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 2906, in should_run_async
    return _should_be_async(cell)
  File "/root/.pyenv/versions/3.8.0/lib/python3.8/site-packages/IPython/core/async_helpers.py", line 154, in _should_be_async
    code = compile(cell, "<>", "exec", flags=getattr(ast,'PyCF_ALLOW_TOP_LEVEL_AWAIT', 0x0))
MemoryError

If you suspect this is an IPython 7.11.1 bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@python.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True

sys:1: RuntimeWarning: coroutine 'InteractiveShell.run_cell_async' was never awaited
```