### PR TITLE
[5.x] Use the proper python2 pygments lexer

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -45,11 +45,15 @@ from IPython.utils.signatures import signature
 from IPython.utils.colorable import Colorable
 
 from pygments import highlight
-from pygments.lexers import PythonLexer
+try:
+    # PythonLexer was renamed to Python2Lexer in pygments 2.5
+    from pygments.lexers import Python2Lexer
+except ImportError:
+    from pygments.lexers import PythonLexer as Python2Lexer
 from pygments.formatters import HtmlFormatter
 
 def pylight(code):
-    return highlight(code, PythonLexer(), HtmlFormatter(noclasses=True))
+    return highlight(code, Python2Lexer(), HtmlFormatter(noclasses=True))
 
 # builtin docstrings to ignore
 _func_call_docstring = types.FunctionType.__call__.__doc__

--- a/IPython/lib/lexers.py
+++ b/IPython/lib/lexers.py
@@ -34,7 +34,12 @@ This includes:
 import re
 
 # Third party
-from pygments.lexers import BashLexer, PythonLexer, Python3Lexer
+from pygments.lexers import BashLexer, Python3Lexer
+try:
+    # PythonLexer was renamed to Python2Lexer in pygments 2.5
+    from pygments.lexers import Python2Lexer
+except ImportError:
+    from pygments.lexers import PythonLexer as Python2Lexer
 from pygments.lexer import (
     Lexer, DelegatingLexer, RegexLexer, do_insertions, bygroups, using,
 )
@@ -87,7 +92,7 @@ def build_ipy_lexer(python3):
         aliases = ['ipython3']
         doc = """IPython3 Lexer"""
     else:
-        PyLexer = PythonLexer
+        PyLexer = Python2Lexer
         name = 'IPython'
         aliases = ['ipython2', 'ipython']
         doc = """IPython Lexer"""


### PR DESCRIPTION
Since pygments 2.5 `PythonLexer` refers to python3 [1]. We have to be
explicit if we want to use python2.

[1] https://pygments.org/docs/changelog/

Fixes #12094.