### PR TITLE
Trio loop

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -695,6 +695,13 @@ class InteractiveShell(SingletonConfigurable):
         self.events.trigger('shell_initialized', self)
         atexit.register(self.atexit_operations)
 
+        # The trio runner is used for running Trio in the foreground thread. It
+        # is different from `_trio_runner(async_fn)` in `async_helpers.py`
+        # which calls `trio.run()` for every cell. This runner runs all cells
+        # inside a single Trio event loop. If used, it is set from
+        # `ipykernel.kernelapp`.
+        self.trio_runner = None
+
     def get_ipython(self):
         """Return the currently running IPython instance."""
         return self
@@ -714,6 +721,9 @@ class InteractiveShell(SingletonConfigurable):
             self.autoindent = not self.autoindent
         else:
             self.autoindent = value
+
+    def set_trio_runner(self, tr):
+        self.trio_runner = tr
 
     #-------------------------------------------------------------------------
     # init_* methods called by __init__
@@ -2865,7 +2875,9 @@ class InteractiveShell(SingletonConfigurable):
         # when this is the case, we want to run it using the pseudo_sync_runner
         # so that code can invoke eventloops (for example via the %run , and
         # `%paste` magic.
-        if self.should_run_async(raw_cell) or self.loop_runner is _trio_runner:
+        if self.trio_runner:
+            runner = self.trio_runner
+        elif self.should_run_async(raw_cell):
             runner = self.loop_runner
         else:
             runner = _pseudo_sync_runner

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2865,7 +2865,7 @@ class InteractiveShell(SingletonConfigurable):
         # when this is the case, we want to run it using the pseudo_sync_runner
         # so that code can invoke eventloops (for example via the %run , and
         # `%paste` magic.
-        if self.should_run_async(raw_cell):
+        if self.should_run_async(raw_cell) or self.loop_runner is _trio_runner:
             runner = self.loop_runner
         else:
             runner = _pseudo_sync_runner


### PR DESCRIPTION
This PR adds the foundation for running a long-lived Trio loop on the main thread. Most of the implementation is in [a PR for `ipykernel`](https://github.com/ipython/ipykernel/pull/479). All this does is add a setter for the shell's trio runner, which `ipykernel` uses to set a trio runner that interacts with a long-lived loop.