### PR TITLE
Start multi-line __repr__s on their own line

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -206,7 +206,7 @@ class PrettyPrinter(_PrettyPrinterBase):
             self.output_width = x.output(self.output, self.output_width)
             self.buffer_width -= x.width
 
-    def _break_outer_groups(self, force=):
+    def _break_outer_groups(self):
         while self.max_width < self.output_width + self.buffer_width:
             group = self.group_queue.deq()
             if not group:

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -687,7 +687,11 @@ def _repr_pprint(obj, p, cycle):
     """A pprint that just redirects to the normal repr function."""
     # Find newlines and replace them with p.break_()
     output = repr(obj)
-    for idx,output_line in enumerate(output.splitlines()):
+    lines = output.splitlines()
+    # insert a leading newline for multi-line objects that are indented
+    if len(lines) > 1 and p.indentation != p.output_width:
+        p.break_()
+    for idx, output_line in enumerate(lines):
         if idx:
             p.break_()
         p.text(output_line)

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -68,11 +68,6 @@ class BreakingRepr(object):
     def __repr__(self):
         return "Breaking(\n)"
 
-class BreakingReprParent(object):
-    def _repr_pretty_(self, p, cycle):
-        with p.group(4,"TG: ",":"):
-            p.pretty(BreakingRepr())
-
 class BadRepr(object):
     
     def __repr__(self):
@@ -151,8 +146,12 @@ def test_pprint_break_repr():
     """
     Test that p.break_ is used in repr
     """
-    output = pretty.pretty(BreakingReprParent())
-    expected = "TG: Breaking(\n    ):"
+    output = pretty.pretty([[BreakingRepr()]])
+    expected = "[[Breaking(\n  )]]"
+    nt.assert_equal(output, expected)
+
+    output = pretty.pretty([[BreakingRepr()]*2])
+    expected = "[[Breaking(\n  ),\n  Breaking(\n  )]]"
     nt.assert_equal(output, expected)
 
 def test_bad_repr():


### PR DESCRIPTION
Fixes gh-12098, by producing the output in the second code-block on that page:
```
In [115]: [Rectangle(3, 4), Rectangle(6, 2), 0, 1]
Out[115]:
[+---+
 |###|
 |###|
 +---+,
 +-+
 |#|
 |#|
 |#|
 |#|
 |#|
 +-+, 0, 1]
```

Related to gh-3851