### PR TITLE
Attempt global reformatting of 1 file; and add ignored revisions.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -11,3 +11,4 @@
 # <full commit hash>  # rename something internal
 557591a1cd9f0d8264a8ded4b964c64bc03eb38f # apply pyupgrade to setupbase.py
 53d7fe3082213f31c89f2c16b39920fb4c7097ce # apply black to setupbase.py
+4bfc78fb0f881f29183a2699653fad3d7b607ed3 # apply pyupgrade to setup.py

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,4 @@
 # Example entries:
 # <full commit hash>  # initial black-format
 # <full commit hash>  # rename something internal
+557591a1cd9f0d8264a8ded4b964c64bc03eb38f # apply pyupgrade to setupbase.py

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,4 @@
 557591a1cd9f0d8264a8ded4b964c64bc03eb38f # apply pyupgrade to setupbase.py
 53d7fe3082213f31c89f2c16b39920fb4c7097ce # apply black to setupbase.py
 4bfc78fb0f881f29183a2699653fad3d7b607ed3 # apply pyupgrade to setup.py
+23f9124073154ec3f552ef9b9d0cb465ea274b0e # apply black to setup.py

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,4 @@
 # <full commit hash>  # initial black-format
 # <full commit hash>  # rename something internal
 557591a1cd9f0d8264a8ded4b964c64bc03eb38f # apply pyupgrade to setupbase.py
+53d7fe3082213f31c89f2c16b39920fb4c7097ce # apply black to setupbase.py

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,7 +2,10 @@
 # commit hash here, so git blame can ignore the change.
 # See docs for more details:
 # https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile
-
+# 
+# You should be able to execute either configure-git-blame-ignore-revs.bat or configure-git-blame-ignore-revs.sh
+# to configure git-blame to ignore the following revisions.
+#
 # Example entries:
 # <full commit hash>  # initial black-format
 # <full commit hash>  # rename something internal

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Setup script for IPython.
 
 Under Posix environments it works like a typical setup.py script.
@@ -17,7 +16,6 @@ requires utilities which are not available under Windows."""
 #  The full license is in the file COPYING.rst, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import print_function
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ Under Posix environments it works like a typical setup.py script.
 Under Windows, the command sdist is not supported, since IPython
 requires utilities which are not available under Windows."""
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Copyright (c) 2008-2011, IPython Development Team.
 #  Copyright (c) 2001-2007, Fernando Perez <fernando.perez@colorado.edu>
 #  Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
@@ -14,7 +14,7 @@ requires utilities which are not available under Windows."""
 #  Distributed under the terms of the Modified BSD License.
 #
 #  The full license is in the file COPYING.rst, distributed with this software.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 import os
@@ -25,19 +25,23 @@ import sys
 # This check is also made in IPython/__init__, don't forget to update both when
 # changing Python version requirements.
 if sys.version_info < (3, 6):
-    pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
+    pip_message = (
+        "This may be due to an out of date pip. Make sure you have pip >= 9.0.1."
+    )
     try:
         import pip
-        pip_version = tuple([int(x) for x in pip.__version__.split('.')[:3]])
-        if pip_version < (9, 0, 1) :
-            pip_message = 'Your pip version is out of date, please install pip >= 9.0.1. '\
-            'pip {} detected.'.format(pip.__version__)
+
+        pip_version = tuple([int(x) for x in pip.__version__.split(".")[:3]])
+        if pip_version < (9, 0, 1):
+            pip_message = (
+                "Your pip version is out of date, please install pip >= 9.0.1. "
+                "pip {} detected.".format(pip.__version__)
+            )
         else:
             # pip is new enough - it must be something else
-            pip_message = ''
+            pip_message = ""
     except Exception:
         pass
-
 
     error = """
 IPython 7.10+ supports Python 3.6 and above, following NEP 29.
@@ -51,7 +55,9 @@ See IPython `README.rst` file for more information:
 
 Python {py} detected.
 {pip}
-""".format(py=sys.version_info, pip=pip_message )
+""".format(
+        py=sys.version_info, pip=pip_message
+    )
 
     print(error, file=sys.stderr)
     sys.exit(1)
@@ -60,7 +66,8 @@ Python {py} detected.
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
-if os.path.exists('MANIFEST'): os.remove('MANIFEST')
+if os.path.exists("MANIFEST"):
+    os.remove("MANIFEST")
 
 from distutils.core import setup
 
@@ -85,81 +92,91 @@ from setupbase import (
 isfile = os.path.isfile
 pjoin = os.path.join
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Handle OS specific things
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
-if os.name in ('nt','dos'):
-    os_name = 'windows'
+if os.name in ("nt", "dos"):
+    os_name = "windows"
 else:
     os_name = os.name
 
 # Under Windows, 'sdist' has not been supported.  Now that the docs build with
 # Sphinx it might work, but let's not turn it on until someone confirms that it
 # actually works.
-if os_name == 'windows' and 'sdist' in sys.argv:
-    print('The sdist command is not available under Windows.  Exiting.')
+if os_name == "windows" and "sdist" in sys.argv:
+    print("The sdist command is not available under Windows.  Exiting.")
     sys.exit(1)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Things related to the IPython documentation
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 # update the manuals when building a source dist
-if len(sys.argv) >= 2 and sys.argv[1] in ('sdist','bdist_rpm'):
+if len(sys.argv) >= 2 and sys.argv[1] in ("sdist", "bdist_rpm"):
 
     # List of things to be updated. Each entry is a triplet of args for
     # target_update()
     to_update = [
-                 ('docs/man/ipython.1.gz',
-                  ['docs/man/ipython.1'],
-                  'cd docs/man && gzip -9c ipython.1 > ipython.1.gz'),
-                 ]
+        (
+            "docs/man/ipython.1.gz",
+            ["docs/man/ipython.1"],
+            "cd docs/man && gzip -9c ipython.1 > ipython.1.gz",
+        ),
+    ]
 
+    [target_update(*t) for t in to_update]
 
-    [ target_update(*t) for t in to_update ]
-
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Find all the packages, package data, and data_files
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 packages = find_packages()
 package_data = find_package_data()
 
 data_files = find_data_files()
 
-setup_args['packages'] = packages
-setup_args['package_data'] = package_data
-setup_args['data_files'] = data_files
+setup_args["packages"] = packages
+setup_args["package_data"] = package_data
+setup_args["data_files"] = data_files
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # custom distutils commands
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # imports here, so they are after setuptools import if there was one
 from distutils.command.sdist import sdist
 
-setup_args['cmdclass'] = {
-    'build_py': \
-            check_package_data_first(git_prebuild('IPython')),
-    'sdist' : git_prebuild('IPython', sdist),
-    'symlink': install_symlinked,
-    'install_lib_symlink': install_lib_symlink,
-    'install_scripts_sym': install_scripts_for_symlink,
-    'unsymlink': unsymlink,
+setup_args["cmdclass"] = {
+    "build_py": check_package_data_first(git_prebuild("IPython")),
+    "sdist": git_prebuild("IPython", sdist),
+    "symlink": install_symlinked,
+    "install_lib_symlink": install_lib_symlink,
+    "install_scripts_sym": install_scripts_for_symlink,
+    "unsymlink": unsymlink,
 }
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Handle scripts, dependencies, and setuptools specific things
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 # For some commands, use setuptools.  Note that we do NOT list install here!
 # If you want a setuptools-enhanced install, just run 'setupegg.py install'
-needs_setuptools = {'develop', 'release', 'bdist_egg', 'bdist_rpm',
-           'bdist', 'bdist_dumb', 'bdist_wininst', 'bdist_wheel',
-           'egg_info', 'easy_install', 'upload', 'install_egg_info',
-          }
+needs_setuptools = {
+    "develop",
+    "release",
+    "bdist_egg",
+    "bdist_rpm",
+    "bdist",
+    "bdist_dumb",
+    "bdist_wininst",
+    "bdist_wheel",
+    "egg_info",
+    "easy_install",
+    "upload",
+    "install_egg_info",
+}
 
 if len(needs_setuptools.intersection(sys.argv)) > 0:
     import setuptools
@@ -171,91 +188,103 @@ setuptools_extra_args = {}
 # setuptools requirements
 
 extras_require = dict(
-    parallel = ['ipyparallel'],
-    qtconsole = ['qtconsole'],
-    doc = ['Sphinx>=1.3'],
-    test = ['nose>=0.10.1', 'requests', 'testpath', 'pygments', 'nbformat', 'ipykernel', 'numpy>=1.14'],
-    terminal = [],
-    kernel = ['ipykernel'],
-    nbformat = ['nbformat'],
-    notebook = ['notebook', 'ipywidgets'],
-    nbconvert = ['nbconvert'],
+    parallel=["ipyparallel"],
+    qtconsole=["qtconsole"],
+    doc=["Sphinx>=1.3"],
+    test=[
+        "nose>=0.10.1",
+        "requests",
+        "testpath",
+        "pygments",
+        "nbformat",
+        "ipykernel",
+        "numpy>=1.14",
+    ],
+    terminal=[],
+    kernel=["ipykernel"],
+    nbformat=["nbformat"],
+    notebook=["notebook", "ipywidgets"],
+    nbconvert=["nbconvert"],
 )
 
 install_requires = [
-    'setuptools>=18.5',
-    'jedi>=0.10',
-    'decorator',
-    'pickleshare',
-    'traitlets>=4.2',
-    'prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1',
-    'pygments',
-    'backcall',
-    'stack_data',
+    "setuptools>=18.5",
+    "jedi>=0.10",
+    "decorator",
+    "pickleshare",
+    "traitlets>=4.2",
+    "prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1",
+    "pygments",
+    "backcall",
+    "stack_data",
 ]
 
 # Platform-specific dependencies:
 # This is the correct way to specify these,
 # but requires pip >= 6. pip < 6 ignores these.
 
-extras_require.update({
-    ':sys_platform != "win32"': ['pexpect'],
-    ':sys_platform == "darwin"': ['appnope'],
-    ':sys_platform == "win32"': ['colorama'],
-})
+extras_require.update(
+    {
+        ':sys_platform != "win32"': ["pexpect"],
+        ':sys_platform == "darwin"': ["appnope"],
+        ':sys_platform == "win32"': ["colorama"],
+    }
+)
 # FIXME: re-specify above platform dependencies for pip < 6
 # These would result in non-portable bdists.
-if not any(arg.startswith('bdist') for arg in sys.argv):
-    if sys.platform == 'darwin':
-        install_requires.extend(['appnope'])
+if not any(arg.startswith("bdist") for arg in sys.argv):
+    if sys.platform == "darwin":
+        install_requires.extend(["appnope"])
 
-    if not sys.platform.startswith('win'):
-        install_requires.append('pexpect')
+    if not sys.platform.startswith("win"):
+        install_requires.append("pexpect")
 
     # workaround pypa/setuptools#147, where setuptools misspells
     # platform_python_implementation as python_implementation
-    if 'setuptools' in sys.modules:
+    if "setuptools" in sys.modules:
         for key in list(extras_require):
-            if 'platform_python_implementation' in key:
-                new_key = key.replace('platform_python_implementation', 'python_implementation')
+            if "platform_python_implementation" in key:
+                new_key = key.replace(
+                    "platform_python_implementation", "python_implementation"
+                )
                 extras_require[new_key] = extras_require.pop(key)
 
 everything = set()
 for key, deps in extras_require.items():
-    if ':' not in key:
+    if ":" not in key:
         everything.update(deps)
-extras_require['all'] = everything
+extras_require["all"] = everything
 
-if 'setuptools' in sys.modules:
-    setuptools_extra_args['python_requires'] = '>=3.6'
-    setuptools_extra_args['zip_safe'] = False
-    setuptools_extra_args['entry_points'] = {
-        'console_scripts': find_entry_points(),
-        'pygments.lexers': [
-            'ipythonconsole = IPython.lib.lexers:IPythonConsoleLexer',
-            'ipython = IPython.lib.lexers:IPythonLexer',
-            'ipython3 = IPython.lib.lexers:IPython3Lexer',
+if "setuptools" in sys.modules:
+    setuptools_extra_args["python_requires"] = ">=3.6"
+    setuptools_extra_args["zip_safe"] = False
+    setuptools_extra_args["entry_points"] = {
+        "console_scripts": find_entry_points(),
+        "pygments.lexers": [
+            "ipythonconsole = IPython.lib.lexers:IPythonConsoleLexer",
+            "ipython = IPython.lib.lexers:IPythonLexer",
+            "ipython3 = IPython.lib.lexers:IPython3Lexer",
         ],
     }
-    setup_args['extras_require'] = extras_require
-    setup_args['install_requires'] = install_requires
+    setup_args["extras_require"] = extras_require
+    setup_args["install_requires"] = install_requires
 
 else:
     # scripts has to be a non-empty list, or install_scripts isn't called
-    setup_args['scripts'] = [e.split('=')[0].strip() for e in find_entry_points()]
+    setup_args["scripts"] = [e.split("=")[0].strip() for e in find_entry_points()]
 
-    setup_args['cmdclass']['build_scripts'] = build_scripts_entrypt
+    setup_args["cmdclass"]["build_scripts"] = build_scripts_entrypt
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Do the actual setup now
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 setup_args.update(setuptools_extra_args)
-
 
 
 def main():
     setup(**setup_args)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/setupbase.py
+++ b/setupbase.py
@@ -26,23 +26,25 @@ from glob import glob
 
 from setupext import install_data_ext
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Useful globals and utility functions
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 # A few handy globals
 isfile = os.path.isfile
 pjoin = os.path.join
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
+
 def execfile(fname, globs, locs=None):
     locs = locs or globs
     with open(fname) as f:
         exec(compile(f.read(), fname, "exec"), globs, locs)
 
+
 # A little utility we'll need below, since glob() does NOT allow you to do
 # exclusion on multiple endings!
-def file_doesnt_endwith(test,endings):
+def file_doesnt_endwith(test, endings):
     """Return true if test is a file and its name does NOT end with any
     of the strings listed in endings."""
     if not isfile(test):
@@ -52,61 +54,65 @@ def file_doesnt_endwith(test,endings):
             return False
     return True
 
-#---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Basic project information
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 # release.py contains version, authors, license, url, keywords, etc.
-execfile(pjoin(repo_root, 'IPython','core','release.py'), globals())
+execfile(pjoin(repo_root, "IPython", "core", "release.py"), globals())
 
 # Create a dict with the basic information
 # This dict is eventually passed to setup after additional keys are added.
 setup_args = dict(
-      name             = name,
-      version          = version,
-      description      = description,
-      long_description = long_description,
-      author           = author,
-      author_email     = author_email,
-      url              = url,
-      license          = license,
-      platforms        = platforms,
-      keywords         = keywords,
-      classifiers      = classifiers,
-      cmdclass         = {'install_data': install_data_ext},
-      project_urls={
-          'Documentation': 'https://ipython.readthedocs.io/',
-          'Funding'      : 'https://numfocus.org/',
-          'Source'       : 'https://github.com/ipython/ipython',
-          'Tracker'      : 'https://github.com/ipython/ipython/issues',
-      }
-      )
+    name=name,
+    version=version,
+    description=description,
+    long_description=long_description,
+    author=author,
+    author_email=author_email,
+    url=url,
+    license=license,
+    platforms=platforms,
+    keywords=keywords,
+    classifiers=classifiers,
+    cmdclass={"install_data": install_data_ext},
+    project_urls={
+        "Documentation": "https://ipython.readthedocs.io/",
+        "Funding": "https://numfocus.org/",
+        "Source": "https://github.com/ipython/ipython",
+        "Tracker": "https://github.com/ipython/ipython/issues",
+    },
+)
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Find packages
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
 
 def find_packages():
     """
     Find all of IPython's packages.
     """
-    excludes = ['deathrow', 'quarantine']
+    excludes = ["deathrow", "quarantine"]
     packages = []
-    for dir,subdirs,files in os.walk('IPython'):
-        package = dir.replace(os.path.sep, '.')
-        if any(package.startswith('IPython.'+exc) for exc in excludes):
+    for dir, subdirs, files in os.walk("IPython"):
+        package = dir.replace(os.path.sep, ".")
+        if any(package.startswith("IPython." + exc) for exc in excludes):
             # package is to be excluded (e.g. deathrow)
             continue
-        if '__init__.py' not in files:
+        if "__init__.py" not in files:
             # not a package
             continue
         packages.append(package)
     return packages
 
-#---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Find package data
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
 
 def find_package_data():
     """
@@ -114,14 +120,14 @@ def find_package_data():
     """
     # This is not enough for these things to appear in an sdist.
     # We need to muck with the MANIFEST to get this to work
-    
+
     package_data = {
-        'IPython.core' : ['profile/README*'],
-        'IPython.core.tests' : ['*.png', '*.jpg', 'daft_extension/*.py'],
-        'IPython.lib.tests' : ['*.wav'],
-        'IPython.testing.plugin' : ['*.txt'],
+        "IPython.core": ["profile/README*"],
+        "IPython.core.tests": ["*.png", "*.jpg", "daft_extension/*.py"],
+        "IPython.lib.tests": ["*.wav"],
+        "IPython.testing.plugin": ["*.txt"],
     }
-    
+
     return package_data
 
 
@@ -129,10 +135,10 @@ def check_package_data(package_data):
     """verify that package_data globs make sense"""
     print("checking package data")
     for pkg, data in package_data.items():
-        pkg_root = pjoin(*pkg.split('.'))
+        pkg_root = pjoin(*pkg.split("."))
         for d in data:
             path = pjoin(pkg_root, d)
-            if '*' in path:
+            if "*" in path:
                 assert len(glob(path)) > 0, "No files match pattern %s" % path
             else:
                 assert os.path.exists(path), "Missing package data: %s" % path
@@ -143,16 +149,19 @@ def check_package_data_first(command):
     
     Probably only needs to wrap build_py
     """
+
     class DecoratedCommand(command):
         def run(self):
             check_package_data(self.package_data)
             command.run(self)
+
     return DecoratedCommand
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Find data files
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
 
 def find_data_files():
     """
@@ -162,18 +171,18 @@ def find_data_files():
     """
 
     if "freebsd" in sys.platform:
-        manpagebase = pjoin('man', 'man1')
+        manpagebase = pjoin("man", "man1")
     else:
-        manpagebase = pjoin('share', 'man', 'man1')
+        manpagebase = pjoin("share", "man", "man1")
 
     # Simple file lists can be made by hand
-    manpages = [f for f in glob(pjoin('docs','man','*.1.gz')) if isfile(f)]
+    manpages = [f for f in glob(pjoin("docs", "man", "*.1.gz")) if isfile(f)]
     if not manpages:
         # When running from a source tree, the manpages aren't gzipped
-        manpages = [f for f in glob(pjoin('docs','man','*.1')) if isfile(f)]
+        manpages = [f for f in glob(pjoin("docs", "man", "*.1")) if isfile(f)]
 
     # And assemble the entire output list
-    data_files = [ (manpagebase, manpages) ]
+    data_files = [(manpagebase, manpages)]
 
     return data_files
 
@@ -181,7 +190,8 @@ def find_data_files():
 # The two functions below are copied from IPython.utils.path, so we don't need
 # to import IPython during setup, which fails on Python 3.
 
-def target_outdated(target,deps):
+
+def target_outdated(target, deps):
     """Determine whether a target is out of date.
 
     target_outdated(target,deps) -> 1/0
@@ -199,13 +209,13 @@ def target_outdated(target,deps):
     for dep in deps:
         dep_time = os.path.getmtime(dep)
         if dep_time > target_time:
-            #print "For target",target,"Dep failed:",dep # dbg
-            #print "times (dep,tar):",dep_time,target_time # dbg
+            # print "For target",target,"Dep failed:",dep # dbg
+            # print "times (dep,tar):",dep_time,target_time # dbg
             return 1
     return 0
 
 
-def target_update(target,deps,cmd):
+def target_update(target, deps, cmd):
     """Update a target with a given command given a list of dependencies.
 
     target_update(target,deps,cmd) -> runs cmd if target is outdated.
@@ -213,12 +223,14 @@ def target_update(target,deps,cmd):
     This is just a wrapper around target_outdated() which calls the given
     command if target is outdated."""
 
-    if target_outdated(target,deps):
+    if target_outdated(target, deps):
         os.system(cmd)
 
-#---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Find scripts
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+
 
 def find_entry_points():
     """Defines the command line entry points for IPython
@@ -231,11 +243,12 @@ def find_entry_points():
     suffixed with the Python major version number, e.g. ipython3. 
     """
     ep = [
-            'ipython%s = IPython:start_ipython',
-            'iptest%s = IPython.testing.iptestcontroller:main',
-        ]
+        "ipython%s = IPython:start_ipython",
+        "iptest%s = IPython.testing.iptestcontroller:main",
+    ]
     suffix = str(sys.version_info[0])
-    return [e % '' for e in ep] + [e % suffix for e in ep]
+    return [e % "" for e in ep] + [e % suffix for e in ep]
+
 
 script_src = """#!{executable}
 # This script was automatically generated by setup.py
@@ -243,6 +256,7 @@ if __name__ == '__main__':
     from {mod} import {func}
     {func}()
 """
+
 
 class build_scripts_entrypt(build_scripts):
     """Build the command line scripts
@@ -253,99 +267,109 @@ class build_scripts_entrypt(build_scripts):
     On Windows, this also creates .cmd wrappers for the scripts so that you can
     easily launch them from a command line.
     """
+
     def run(self):
         self.mkpath(self.build_dir)
         outfiles = []
         for script in find_entry_points():
-            name, entrypt = script.split('=')
+            name, entrypt = script.split("=")
             name = name.strip()
             entrypt = entrypt.strip()
             outfile = os.path.join(self.build_dir, name)
             outfiles.append(outfile)
-            print('Writing script to', outfile)
+            print("Writing script to", outfile)
 
-            mod, func = entrypt.split(':')
-            with open(outfile, 'w') as f:
-                f.write(script_src.format(executable=sys.executable,
-                                          mod=mod, func=func))
-            
-            if sys.platform == 'win32':
+            mod, func = entrypt.split(":")
+            with open(outfile, "w") as f:
+                f.write(
+                    script_src.format(executable=sys.executable, mod=mod, func=func)
+                )
+
+            if sys.platform == "win32":
                 # Write .cmd wrappers for Windows so 'ipython' etc. work at the
                 # command line
-                cmd_file = os.path.join(self.build_dir, name + '.cmd')
+                cmd_file = os.path.join(self.build_dir, name + ".cmd")
                 cmd = r'@"{python}" "%~dp0\{script}" %*\r\n'.format(
-                        python=sys.executable, script=name)
+                    python=sys.executable, script=name
+                )
                 log.info("Writing %s wrapper script" % cmd_file)
-                with open(cmd_file, 'w') as f:
+                with open(cmd_file, "w") as f:
                     f.write(cmd)
 
         return outfiles, outfiles
 
+
 class install_lib_symlink(Command):
     user_options = [
-        ('install-dir=', 'd', "directory to install to"),
-        ]
+        ("install-dir=", "d", "directory to install to"),
+    ]
 
     def initialize_options(self):
         self.install_dir = None
 
     def finalize_options(self):
-        self.set_undefined_options('symlink',
-                                   ('install_lib', 'install_dir'),
-                                  )
+        self.set_undefined_options(
+            "symlink", ("install_lib", "install_dir"),
+        )
 
     def run(self):
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
             raise Exception("This doesn't work on Windows.")
-        pkg = os.path.join(os.getcwd(), 'IPython')
-        dest = os.path.join(self.install_dir, 'IPython')
+        pkg = os.path.join(os.getcwd(), "IPython")
+        dest = os.path.join(self.install_dir, "IPython")
         if os.path.islink(dest):
-            print('removing existing symlink at %s' % dest)
+            print("removing existing symlink at %s" % dest)
             os.unlink(dest)
-        print(f'symlinking {pkg} -> {dest}')
+        print(f"symlinking {pkg} -> {dest}")
         os.symlink(pkg, dest)
+
 
 class unsymlink(install):
     def run(self):
-        dest = os.path.join(self.install_lib, 'IPython')
+        dest = os.path.join(self.install_lib, "IPython")
         if os.path.islink(dest):
-            print('removing symlink at %s' % dest)
+            print("removing symlink at %s" % dest)
             os.unlink(dest)
         else:
-            print('No symlink exists at %s' % dest)
+            print("No symlink exists at %s" % dest)
+
 
 class install_symlinked(install):
     def run(self):
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
             raise Exception("This doesn't work on Windows.")
 
         # Run all sub-commands (at least those that need to be run)
         for cmd_name in self.get_sub_commands():
             self.run_command(cmd_name)
-    
+
     # 'sub_commands': a list of commands this command might have to run to
     # get its work done.  See cmd.py for more info.
-    sub_commands = [('install_lib_symlink', lambda self:True),
-                    ('install_scripts_sym', lambda self:True),
-                   ]
+    sub_commands = [
+        ("install_lib_symlink", lambda self: True),
+        ("install_scripts_sym", lambda self: True),
+    ]
+
 
 class install_scripts_for_symlink(install_scripts):
     """Redefined to get options from 'symlink' instead of 'install'.
     
     I love distutils almost as much as I love setuptools.
     """
+
     def finalize_options(self):
-        self.set_undefined_options('build', ('build_scripts', 'build_dir'))
-        self.set_undefined_options('symlink',
-                                   ('install_scripts', 'install_dir'),
-                                   ('force', 'force'),
-                                   ('skip_build', 'skip_build'),
-                                  )
+        self.set_undefined_options("build", ("build_scripts", "build_dir"))
+        self.set_undefined_options(
+            "symlink",
+            ("install_scripts", "install_dir"),
+            ("force", "force"),
+            ("skip_build", "skip_build"),
+        )
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # VCS related
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 
 def git_prebuild(pkg_dir, build_cmd=build_py):
@@ -355,52 +379,59 @@ def git_prebuild(pkg_dir, build_cmd=build_py):
     
     for use in IPython.utils.sysinfo.sys_info() calls after installation.
     """
-    
+
     class MyBuildPy(build_cmd):
-        ''' Subclass to write commit data into installation tree '''
+        """ Subclass to write commit data into installation tree """
+
         def run(self):
             # loose as `.dev` is suppose to be invalid
             print("check version number")
-            loose_pep440re = re.compile(r'^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$')
+            loose_pep440re = re.compile(
+                r"^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$"
+            )
             if not loose_pep440re.match(version):
-                raise ValueError("Version number '%s' is not valid (should match [N!]N(.N)*[{a|b|rc}N][.postN][.devN])" % version)
-
+                raise ValueError(
+                    "Version number '%s' is not valid (should match [N!]N(.N)*[{a|b|rc}N][.postN][.devN])"
+                    % version
+                )
 
             build_cmd.run(self)
             # this one will only fire for build commands
-            if hasattr(self, 'build_lib'):
+            if hasattr(self, "build_lib"):
                 self._record_commit(self.build_lib)
-        
+
         def make_release_tree(self, base_dir, files):
             # this one will fire for sdist
             build_cmd.make_release_tree(self, base_dir, files)
             self._record_commit(base_dir)
-        
+
         def _record_commit(self, base_dir):
             import subprocess
-            proc = subprocess.Popen('git rev-parse --short HEAD',
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    shell=True)
+
+            proc = subprocess.Popen(
+                "git rev-parse --short HEAD",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=True,
+            )
             repo_commit, _ = proc.communicate()
             repo_commit = repo_commit.strip().decode("ascii")
-            
-            out_pth = pjoin(base_dir, pkg_dir, 'utils', '_sysinfo.py')
+
+            out_pth = pjoin(base_dir, pkg_dir, "utils", "_sysinfo.py")
             if os.path.isfile(out_pth) and not repo_commit:
                 # nothing to write, don't clobber
                 return
-            
+
             print(f"writing git commit '{repo_commit}' to {out_pth}")
-            
+
             # remove to avoid overwriting original via hard link
             try:
                 os.remove(out_pth)
             except OSError:
                 pass
-            with open(out_pth, 'w') as out_file:
-                out_file.writelines([
-                    '# GENERATED BY setup.py\n',
-                    'commit = u"%s"\n' % repo_commit,
-                ])
-    return MyBuildPy
+            with open(out_pth, "w") as out_file:
+                out_file.writelines(
+                    ["# GENERATED BY setup.py\n", 'commit = u"%s"\n' % repo_commit,]
+                )
 
+    return MyBuildPy

--- a/setupbase.py
+++ b/setupbase.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 This module defines the things that are used in setup.py for building IPython
 
@@ -303,7 +302,7 @@ class install_lib_symlink(Command):
         if os.path.islink(dest):
             print('removing existing symlink at %s' % dest)
             os.unlink(dest)
-        print('symlinking %s -> %s' % (pkg, dest))
+        print(f'symlinking {pkg} -> {dest}')
         os.symlink(pkg, dest)
 
 class unsymlink(install):
@@ -391,12 +390,12 @@ def git_prebuild(pkg_dir, build_cmd=build_py):
                 # nothing to write, don't clobber
                 return
             
-            print("writing git commit '%s' to %s" % (repo_commit, out_pth))
+            print(f"writing git commit '{repo_commit}' to {out_pth}")
             
             # remove to avoid overwriting original via hard link
             try:
                 os.remove(out_pth)
-            except (IOError, OSError):
+            except OSError:
                 pass
             with open(out_pth, 'w') as out_file:
                 out_file.writelines([


### PR DESCRIPTION
This is more interesting to look at on a per commit basis.

It runs some auto-reformatting; and then add the commits hash to a list of hashes to ignore.
It is not (yet) suported by github/gitlab, but works great locally where blame is not screwed up.

The goal would be to always automatically reformat the source code.