### PR TITLE
[WIP] New --return-result argument to %%capture cell magic

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1443,6 +1443,9 @@ python-profiler package from non-free.""")
     @magic_arguments.argument('--no-display', action="store_true",
         help="""Don't capture IPython's rich display."""
     )
+    @magic_arguments.argument('--return-result', action="store_true",
+        help="""Return the captured result instead of suppressing it."""
+    )
     @cell_magic
     def capture(self, line, cell):
         """run the cell, capturing stdout, stderr, and IPython's rich display() calls."""
@@ -1451,9 +1454,13 @@ python-profiler package from non-free.""")
         err = not args.no_stderr
         disp = not args.no_display
         with capture_output(out, err, disp) as io:
-            self.shell.run_cell(cell)
+            result = self.shell.run_cell(cell)
         if args.output:
             self.shell.user_ns[args.output] = io
+        if args.return_result:
+            return result
+        else:
+            return None
 
 def parse_breakpoint(text, current_file):
     '''Returns (file, line) for file:line and (current_file, line) for line'''


### PR DESCRIPTION
Intended to close #8015 by making the suppression of the captured result optional. 

I want this so that I can capture cell output and use it within the same cell, while still displaying it to the screen. I eventually want to wrap that non-suppressing capture magic within a new `%%save_output` cell magic in order to close [this jupyter issue](https://github.com/jupyter/notebook/issues/3039).

However, it's not working yet - executing this cell in jupyterlab
```python
%%capture --return-result out

x = 5
x
```
returns
```
<ExecutionResult object at 7f72d0a49f90, execution_count=None error_before_exec=None error_in_exec=None info=<ExecutionInfo object at 7f72d0a499d0, raw_cell="
x = 5
x
" store_history=False silent=False shell_futures=True> result=None>
```
which makes sense, except that the `ExecutionResult` object has attribute `result=None`. I would have expected it to have `result=5`. Obviously I can't return the result if it's always being set to `None`.

Confusingly this does work in the interactive ipython shell, just not in the notebook:
```python
In [1]: from IPython.core.interactiveshell import InteractiveShell
In [2]: InteractiveShell().run_cell(raw_cell="x=5 \nx")                                                                                                                                                                        
Out[1]: 
<ExecutionResult object at 7fd41a854210, execution_count=None error_before_exec=None error_in_exec=None info=<ExecutionInfo object at 7fd41a854e10, raw_cell="x=5 
x" store_history=False silent=False shell_futures=True> result=5>
```

This problem might be related to #12090 ?
