### PR TITLE
Pop the last if path ends with slash

### DIFF
--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -42,7 +42,8 @@ def _elide(string, *, min_elide=30):
 
     object_parts = string.split('.')
     file_parts = string.split(os.sep)
-    file_parts.pop() if file_parts[-1] == '' else None
+    if file_parts[-1] == '':
+        file_parts.pop()
 
     if len(object_parts) > 3:
         return '{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}'.format(object_parts[0], object_parts[1][0], object_parts[-2][-1], object_parts[-1])

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -42,6 +42,7 @@ def _elide(string, *, min_elide=30):
 
     object_parts = string.split('.')
     file_parts = string.split(os.sep)
+    file_parts.pop() if file_parts[-1] == '' else None
 
     if len(object_parts) > 3:
         return '{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}'.format(object_parts[0], object_parts[1][0], object_parts[-2][-1], object_parts[-1])

--- a/IPython/terminal/tests/test_interactivshell.py
+++ b/IPython/terminal/tests/test_interactivshell.py
@@ -5,6 +5,7 @@
 
 import sys
 import unittest
+import os
 
 from IPython.core.inputtransformer import InputTransformer
 from IPython.testing import tools as tt
@@ -19,6 +20,10 @@ class TestElide(unittest.TestCase):
         _elide('concatenate((a1, a2, ...), axis') # do not raise
         _elide('concatenate((a1, a2, ..), . axis') # do not raise
         nt.assert_equal(_elide('aaaa.bbbb.ccccc.dddddd.eeeee.fffff.gggggg.hhhhhh'), 'aaaa.b…g.hhhhhh')
+        
+        test_string = os.sep.join(['', 10*'a', 10*'b', 10*'c', ''])
+        expect_stirng = os.sep + 'a' + '\N{HORIZONTAL ELLIPSIS}' + 'b' + os.sep + 10*'c'
+        nt.assert_equal(_elide(test_string), expect_stirng)
 
 
 class TestContextAwareCompletion(unittest.TestCase):


### PR DESCRIPTION
Hi, I made some changes on the _elide() function in ptutils.py and the test_elide() in test_interactiveshell.py:

1. Pop the last empty string of the "file_parts" list if the input folder path ends with a slash.
2. Add the test to this situation, but I am not sure it's ok to use os.sep?

#12105 