### PR TITLE
Stop testing on -dev, they are broken on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,7 @@ matrix:
       env: ARM64=True
       sudo: true
     - arch: amd64
-      python: "3.8-dev"
-      dist: xenial
-      sudo: true
-    - arch: amd64
-      python: "3.7-dev"
+      python: "3.8"
       dist: xenial
       sudo: true
     - arch: amd64


### PR DESCRIPTION
pip is missing on recent builds; and remove duplicate 3.7 testing if we
drop -dev suffix