### PR TITLE
Improves detection of whether tab-completion is in a string and suppresses Jedi

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1371,18 +1371,18 @@ class IPCompleter(Completer):
         try_jedi = True
 
         try:
-            # should we check the type of the node is Error ?
-            try:
-                # jedi < 0.11
-                from jedi.parser.tree import ErrorLeaf
-            except ImportError:
-                # jedi >= 0.11
-                from parso.tree import ErrorLeaf
-
-            next_to_last_tree = interpreter._get_module().tree_node.children[-2]
+            # find the first token in the current tree -- if it is a ' or " then we are in a string
             completing_string = False
-            if isinstance(next_to_last_tree, ErrorLeaf):
-                completing_string = next_to_last_tree.value.lstrip()[0] in {'"', "'"}
+            try:
+                first_child = next(c for c in interpreter._get_module().tree_node.children if hasattr(c, 'value'))
+            except StopIteration:
+                pass
+            else:
+                # note the value may be ', ", or it may also be ''' or """, or
+                # in some cases, """what/you/typed..., but all of these are
+                # strings.
+                completing_string = len(first_child.value) > 0 and first_child.value[0] in {"'", '"'}
+
             # if we are in a string jedi is likely not the right candidate for
             # now. Skip it.
             try_jedi = not completing_string


### PR DESCRIPTION

Refs #10926 and #11530

Jedi results swamp file_matches and dict_key_matches in
tab-completion, which is a real nuisance.  The logic in the jedi
completor tried to catch cases where it was "in a string", but that
logic only looked at the last child in the current token, which was a little fragile,
breaking in lots of cases such as:

    './<tab>
    "mypath/<tab>

etc.

This seems a bit more robust in that it searchs for the first character in
the current parser tree and checks if its value starts with ' or ".

This detection of "in a string" then turns off jedi and returns some
sanity to the set of matches.

Note I have developed this with jedi 0.13.2 -- not sure if it is different logic in older versions.