### PR TITLE
Use Pygments instead of PyColorize to syntax highlight tracebacks

### DIFF
--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -348,14 +348,14 @@ def r3o2():
         with tt.AssertNotPrints("skipping similar frames"):
             ip.run_cell("non_recurs()")
 
-    @recursionlimit(150)
+    @recursionlimit(200)
     def test_recursion_one_frame(self):
         with tt.AssertPrints(re.compile(
-            r"\[\.\.\. skipping similar frames: r1 at line 5 \(\d{2} times\)\]")
+            r"\[\.\.\. skipping similar frames: r1 at line 5 \(\d{2,3} times\)\]")
         ):
             ip.run_cell("r1()")
 
-    @recursionlimit(150)
+    @recursionlimit(200)
     def test_recursion_three_frames(self):
         with tt.AssertPrints("[... skipping similar frames: "), \
                 tt.AssertPrints(re.compile(r"r3a at line 8 \(\d{2} times\)"), suppress=False), \

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -97,13 +97,13 @@ import time
 import traceback
 
 import stack_data
+from pygments.formatters.terminal import TerminalFormatter
 
 # IPython's own modules
 from IPython import get_ipython
 from IPython.core import debugger
 from IPython.core.display_trap import DisplayTrap
 from IPython.core.excolors import exception_colors
-from IPython.utils import PyColorize
 from IPython.utils import path as util_path
 from IPython.utils import py3compat
 from IPython.utils.terminal import get_terminal_size
@@ -129,7 +129,7 @@ DEFAULT_SCHEME = 'NoColor'
 # (SyntaxErrors have to be treated specially because they have no traceback)
 
 
-def _format_traceback_lines(lines, Colors, lvals, _line_format):
+def _format_traceback_lines(lines, Colors, lvals):
     """
     Format tracebacks lines with pointing arrow, leading numbers...
 
@@ -141,8 +141,6 @@ def _format_traceback_lines(lines, Colors, lvals, _line_format):
         ColorScheme used.
     lvals: str
         Values of local variables, already colored, to inject just after the error line.
-    _line_format: f (str) -> (str, bool)
-        return (colorized version of str, failure to do so)
     """
     numbers_width = INDENT_SIZE - 1
     res = []
@@ -152,23 +150,18 @@ def _format_traceback_lines(lines, Colors, lvals, _line_format):
             res.append('%s   (...)%s\n' % (Colors.linenoEm, Colors.Normal))
             continue
 
-        line = stack_line.text.rstrip('\n') + '\n'
-
-        new_line, err = _line_format(line, 'str')
-        if not err:
-            line = new_line
-
+        line = stack_line.render(pygmented=True).rstrip('\n') + '\n'
         lineno = stack_line.lineno
         if stack_line.is_current:
             # This is the line with the error
             pad = numbers_width - len(str(lineno))
             num = '%s%s' % (debugger.make_arrow(pad), str(lineno))
-            line = '%s%s%s %s%s' % (Colors.linenoEm, num,
-                                    Colors.line, line, Colors.Normal)
+            start_color = Colors.linenoEm
         else:
             num = '%*s' % (numbers_width, lineno)
-            line = '%s%s%s %s' % (Colors.lineno, num,
-                                  Colors.Normal, line)
+            start_color = Colors.lineno
+        
+        line = '%s%s%s %s' % (start_color, num, Colors.Normal, line)
 
         res.append(line)
         if lvals and stack_line.is_current:
@@ -591,7 +584,6 @@ class VerboseTB(TBTools):
             return '    %s[... skipping similar frames: %s]%s\n' % (
                 Colors.excName, frame_info.description, ColorsNormal)
 
-        col_scheme = self.color_scheme_table.active_scheme_name
         indent = ' ' * INDENT_SIZE
         em_normal = '%s\n%s%s' % (Colors.valEm, indent, ColorsNormal)
         tpl_link = '%s%%s%s' % (Colors.filenameEm, ColorsNormal)
@@ -646,8 +638,7 @@ class VerboseTB(TBTools):
 
         result = '%s %s\n' % (link, call)
 
-        _line_format = PyColorize.Parser(style=col_scheme, parent=self).format2
-        result += ''.join(_format_traceback_lines(frame_info.lines, Colors, lvals, _line_format))
+        result += ''.join(_format_traceback_lines(frame_info.lines, Colors, lvals))
         return result
 
     def prepare_header(self, etype, long_version=False):
@@ -718,7 +709,7 @@ class VerboseTB(TBTools):
         context = number_of_lines_of_context - 1
         after = context // 2
         before = context - after
-        options = stack_data.Options(before=before, after=after)
+        options = stack_data.Options(before=before, after=after, pygments_formatter=TerminalFormatter())
         return list(stack_data.FrameInfo.stack_data(etb, options=options))[tb_offset:]
 
     def structured_traceback(self, etype, evalue, etb, tb_offset=None,


### PR DESCRIPTION
To start with I've just stuck in `TerminalFormatter()`. @Carreau How do I insert the correct formatter and style based on user configuration?