### PR TITLE
add configuration controlling whether the CWD gets added to sys.path

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -60,6 +60,10 @@ addflag('color-info', 'InteractiveShell.color_info',
     colours.""",
     "Disable using colors for info related things."
 )
+addflag('ignore-cwd', 'InteractiveShellApp.ignore_cwd',
+        "Exclude the current working directory from sys.path",
+        "Include the current working directory in sys.path",
+)
 nosep_config = Config()
 nosep_config.InteractiveShell.separate_in = ''
 nosep_config.InteractiveShell.separate_out = ''
@@ -168,6 +172,12 @@ class InteractiveShellApp(Configurable):
         When False, pylab mode should not import any names into the user namespace.
         """
     ).tag(config=True)
+    ignore_cwd = Bool(
+        False,
+        help="""If True, IPython will not add the current working directory to sys.path.
+        When False, the current working directory is added to sys.path, allowing imports
+        of modules defined in the current directory."""
+    ).tag(config=True)
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC',
                      allow_none=True)
     # whether interact-loop should start
@@ -189,8 +199,10 @@ class InteractiveShellApp(Configurable):
 
         .. versionchanged:: 7.2
             Try to insert after the standard library, instead of first.
+        .. versionchanged:: 8.0
+            Allow optionally not including the current directory in sys.path
         """
-        if '' in sys.path:
+        if '' in sys.path or self.ignore_cwd:
             return
         for idx, path in enumerate(sys.path):
             parent, last_part = os.path.split(path)


### PR DESCRIPTION
As of IPython 7.2 (see #11502), the CWD comes after standard library paths in sys.path by default. This fixes local files shadowing the standard library, a common footgun (e.g. having `email.py` in the CWD). However in some cases it's desirable for reproducibility, [security](https://bugs.python.org/issue16202) and [usability](https://bugs.python.org/issue946373) purposes for all imports to either come from installed packages or the standard library.

This adds a new configuration option, `ignore_cwd`, that tells IPython not to include the current directory in sys.path.

I'm happy to bikeshed on the name, `ignore_cwd` was the best I could come up with but I'm not totally happy with it. It wasn't clear to me how to test this so I haven't included any new tests. Tips in that direction are very much appreciated.