### PR TITLE
[WIP] - Set up automatic release notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,16 @@
+# Trigger the workflow on milestone events
+on: 
+  milestone:
+    types: [closed]
+name: New Release
+jobs:
+  create-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Create Release Notes
+      uses: docker://decathlon/release-notes-generator-action:2.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_NOTES_TOKEN }}
+        OUTPUT_FOLDER: temp_release_notes
+        USE_MILESTONE_TITLE: "true"


### PR DESCRIPTION
@Carreau Recently I've got to know about automating release notes using GitHub actions.
Based on what we discussed a long ago, this is something you or someone else needs to take care of every month. 

Are you interested in automating that?

I'm playing around with this action specifically, but there are many other options:
https://github.com/marketplace/actions/release-notes-generator-action