### PR TITLE
Fix inability to interrupt processes on Windows

### DIFF
--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -18,6 +18,7 @@ This file is only meant to be imported by process.py, not by end-users.
 import os
 import sys
 import ctypes
+import time
 
 from ctypes import c_int, POINTER
 from ctypes.wintypes import LPCWSTR, HLOCAL
@@ -104,10 +105,11 @@ def _system_body(p):
     # wait() isn't interruptible (https://bugs.python.org/issue28168) so poll in
     # a loop instead of just doing `return p.wait()`.
     while True:
-        try:
-            return p.wait(0.01)
-        except TimeoutExpired:
-            pass
+        result = p.poll()
+        if result is None:
+            time.sleep(0.01)
+        else:
+            return result
 
 
 def system(cmd):

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -94,6 +94,7 @@ def _find_cmd(cmd):
 def _system_body(p):
     """Callback for _system."""
     enc = DEFAULT_ENCODING
+    print("READING...")
     for line in read_no_interrupt(p.stdout).splitlines():
         line = line.decode(enc, 'replace')
         print(line, file=sys.stdout)
@@ -106,6 +107,7 @@ def _system_body(p):
     # a loop instead of just doing `return p.wait()`.
     while True:
         result = p.poll()
+        print("POLLED")
         if result is None:
             time.sleep(0.01)
         else:

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -126,9 +126,7 @@ def system(cmd):
 
     Returns
     -------
-    None : we explicitly do NOT return the subprocess status code, as this
-    utility is meant to be used extensively in IPython, where any return value
-    would trigger :func:`sys.displayhook` calls.
+    int : child process' exit code.
     """
     # The controller provides interactivity with both
     # stdin and stdout

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -157,7 +157,7 @@ class SubProcessTestCase(tt.TempFileMixin):
         there is no deadlock).
         """
         with capture_output(display=False):
-            system(("%s -c 'import sys\nfor i in range(2000): " +
+            system(("%s -c 'import sys\nfor i in range(20000): " +
                     "sys.stderr.write(\" \" * 100 + \"\\n\")'") % (python,))
 
     def test_getoutput(self):

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -150,17 +150,6 @@ class SubProcessTestCase(tt.TempFileMixin):
             status, 0, "The process wasn't interrupted. Status: %s" % (status,)
         )
 
-    def test_stderr_while_stdout_open(self):
-        """
-        If lots of data is written to stderr while stdout is still open, enough
-        data to fill the pipe buffer in fact, the process still exits (i.e.
-        there is no deadlock).
-        """
-        with capture_output(display=False):
-            status = system(("%s -c \"import sys\nfor i in range(20000): " +
-                             "sys.stderr.write('b' * 100)\"") % (python,))
-        self.assertEqual(status, 0)
-
     def test_getoutput(self):
         out = getoutput('%s "%s"' % (python, self.fname))
         # we can't rely on the order the line buffered streams are flushed
@@ -168,17 +157,6 @@ class SubProcessTestCase(tt.TempFileMixin):
             self.assertEqual(out, 'on stderron stdout')
         except AssertionError:
             self.assertEqual(out, 'on stdouton stderr')
-
-    def test_getoutput_interrupt(self):
-        """
-        When interrupted in the way ipykernel interrupts IPython, the
-        subprocess is interrupted.
-        """
-        raise SkipTest("This fails on POSIX too, revisit in future.")
-        def command():
-            return getoutput('%s -c "import time; time.sleep(5)"' % (python, ))
-
-        self.assert_interrupts(command)
 
     def test_getoutput_quoted(self):
         out = getoutput('%s -c "print (1)"' % python)

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -26,6 +26,7 @@ import nose.tools as nt
 from IPython.utils.process import (find_cmd, FindCmdError, arg_split,
                                    system, getoutput, getoutputerror,
                                    get_output_error_code)
+from IPython.utils.capture import capture_output
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
 
@@ -148,6 +149,16 @@ class SubProcessTestCase(tt.TempFileMixin):
         self.assertNotEqual(
             status, 0, "The process wasn't interrupted. Status: %s" % (status,)
         )
+
+    def test_stderr_while_stdout_open(self):
+        """
+        If lots of data is written to stderr while stdout is still open, enough
+        data to fill the pipe buffer in fact, the process still exits (i.e.
+        there is no deadlock).
+        """
+        with capture_output(display=False):
+            system(("%s -c 'import sys\nfor i in range(2000): " +
+                    "sys.stderr.write(\" \" * 100 + \"\\n\")'") % (python,))
 
     def test_getoutput(self):
         out = getoutput('%s "%s"' % (python, self.fname))

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -157,8 +157,9 @@ class SubProcessTestCase(tt.TempFileMixin):
         there is no deadlock).
         """
         with capture_output(display=False):
-            system(("%s -c 'import sys\nfor i in range(20000): " +
-                    "sys.stderr.write(\" \" * 100 + \"\\n\")'") % (python,))
+            status = system(("%s -c \"import sys\nfor i in range(20000): " +
+                             "sys.stderr.write('b' * 100)\"") % (python,))
+        self.assertEqual(status, 0)
 
     def test_getoutput(self):
         out = getoutput('%s "%s"' % (python, self.fname))

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -115,8 +115,8 @@ class SubProcessTestCase(tt.TempFileMixin):
         When interrupted in the way ipykernel interrupts IPython, the
         subprocess is interrupted.
         """
-        raise RuntimeError("Is this even being run on Windows?")
         if threading.main_thread() != threading.current_thread():
+            raise RuntimeEror("Not in main thread")
             raise nt.SkipTest("Can't run this test if not in main thread.")
 
         def interrupt():

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -115,6 +115,7 @@ class SubProcessTestCase(tt.TempFileMixin):
         When interrupted in the way ipykernel interrupts IPython, the
         subprocess is interrupted.
         """
+        raise RuntimeError("Is this even being run on Windows?")
         if threading.main_thread() != threading.current_thread():
             raise nt.SkipTest("Can't run this test if not in main thread.")
 

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -116,7 +116,6 @@ class SubProcessTestCase(tt.TempFileMixin):
         subprocess is interrupted.
         """
         if threading.main_thread() != threading.current_thread():
-            raise RuntimeEror("Not in main thread")
             raise nt.SkipTest("Can't run this test if not in main thread.")
 
         def interrupt():
@@ -125,13 +124,18 @@ class SubProcessTestCase(tt.TempFileMixin):
             interrupt_main()
 
         threading.Thread(target=interrupt).start()
+        start = time.time()
         try:
             status = system('%s -c "import time; time.sleep(5)"' % python)
         except KeyboardInterrupt:
             # Success!
             return
+        end = time.time()
         self.assertNotEqual(
             status, 0, "The process wasn't interrupted. Status: %s" % (status,)
+        )
+        self.assertTrue(
+            end - start < 2, "Process didn't die quickly: %s" % (end - start)
         )
 
     def test_getoutput(self):

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -15,6 +15,7 @@ Tests for platutils.py
 #-----------------------------------------------------------------------------
 
 import sys
+import signal
 import os
 import time
 from _thread import interrupt_main  # Py 3
@@ -119,6 +120,11 @@ class SubProcessTestCase(tt.TempFileMixin):
         if threading.main_thread() != threading.current_thread():
             raise nt.SkipTest("Can't run this test if not in main thread.")
 
+        # Some tests can overwrite SIGINT handler (by using pdb for example),
+        # which then breaks this test, so just make sure it's operating
+        # normally.
+        signal.signal(signal.SIGINT, signal.default_int_handler)
+
         def interrupt():
             # Wait for subprocess to start:
             time.sleep(0.5)
@@ -130,7 +136,7 @@ class SubProcessTestCase(tt.TempFileMixin):
             result = command()
         except KeyboardInterrupt:
             # Success!
-            return
+            pass
         end = time.time()
         self.assertTrue(
             end - start < 2, "Process didn't die quickly: %s" % (end - start)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,3 +36,4 @@ install:
   - "%CMD_IN_ENV%  cd results"
 test_script:
   - "%CMD_IN_ENV%  iptest --coverage xml"
+  - "%CMD_IN_ENV%  pytest IPython"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,3 @@ install:
   - "%CMD_IN_ENV%  cd results"
 test_script:
   - "%CMD_IN_ENV%  iptest --coverage xml"
-  - "%CMD_IN_ENV%  pytest IPython"


### PR DESCRIPTION
Fixes #3400 

(or at least fixes the Windows subprocesses variant; there's a bunch of stuff in there that is probably separate tickets—at least pdb was moved out into its own).

It appears that in addition to wait() being uninterruptible (https://bugs.python.org/issue28168), so is read()ing from the subprocess.

Reading is therefore pushed off to threads, and `wait()` replaced with the equivalent `poll()`-based loop. If the user interrupts the process, it is killed.

This is demonstrated by a unit test that previously failed, and now passes. Still remaining for me to do is actually test this fix on Windows from Jupyter; I'm waiting for a VM to unpack. If a reviewer wants to try this out themselves, by all means do so :)