### PR TITLE
Fix locals collisions with shell variables

### DIFF
--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -149,7 +149,7 @@ class ConfigMagics(Magics):
         # leave quotes on args when splitting, because we want
         # unquoted args to eval in user_ns
         cfg = Config()
-        exec("cfg."+line, locals(), self.shell.user_ns)
+        exec("cfg."+line, self.shell.user_ns, locals())
 
         for configurable in configurables:
             try:


### PR DESCRIPTION
Fixes issues with namespace collisions, e.g. :
```python
cfg = 'trap'
%config IPCompleter.use_jedi = False
```
Causes: `AttributeError: 'str' object has no attribute 'IPCompleter'`

fixes https://github.com/ipython/ipython/issues/11835