### PR TITLE
Highlight the executing node with stack_data

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -98,6 +98,7 @@ import traceback
 
 import stack_data
 from pygments.formatters.terminal256 import Terminal256Formatter
+from pygments.styles import get_style_by_name
 
 # IPython's own modules
 from IPython import get_ipython
@@ -714,7 +715,9 @@ class VerboseTB(TBTools):
         after = context // 2
         before = context - after
         if self.has_colors:
-            formatter = Terminal256Formatter()
+            style = get_style_by_name('default')
+            style = stack_data.style_with_executing_node(style, 'bg:#00005f')
+            formatter = Terminal256Formatter(style=style)
         else:
             formatter = None
         options = stack_data.Options(


### PR DESCRIPTION
Here's what it's all been about! Closes #11827 

Example script:

```python
def foo(i):
    x = [[[0]]]
    return x[0][i][0]


def bar():
    return foo(0) + foo(
        1
    ) + foo(2)


bar()
```

Output:

![Screenshot from 2020-02-27 20-51-28](https://user-images.githubusercontent.com/3627481/75476425-3e6b9280-59a3-11ea-9b6c-b9e099475a45.png)