### PR TITLE
Set .py tempfile suffix when using vi/emacs editor shortcuts.

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -322,6 +322,7 @@ class TerminalInteractiveShell(InteractiveShell):
                             mouse_support=self.mouse_support,
                             enable_open_in_editor=self.extra_open_editor_shortcuts,
                             color_depth=self.color_depth,
+                            tempfile_suffix=".py",
                             **self._extra_prompt_options())
 
     def _make_style_from_name_or_cls(self, name_or_cls):

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -250,7 +250,6 @@ def newline_autoindent_outer(inputsplitter) -> Callable[..., None]:
 
 
 def open_input_in_editor(event):
-    event.app.current_buffer.tempfile_suffix = ".py"
     event.app.current_buffer.open_in_editor()
 
 


### PR DESCRIPTION
Since the vi keybinding (v) and emacs mode keybinding (c-x c-e) are handled by prompt_toolkit directly, and the tempfile_suffix argument was not provided to prompt_toolkit, the tempfile created when the editor was opened via these keybindings was a .txt file, breaking syntax highlighting in some editors. 

By passing the tempfile_suffix=".py" argument to the PromptSession constructor, this ensures that when the open_in_editor() method of the current buffer is called, the tempfile opened in the editor will always have a .py extension.

The open_input_in_editor(event) function associated with the f2 keybinding manually set the tempfile_suffix property of the current buffer before calling the buffer's open_in_editor() method.  Passing the tempfile_suffix argument to the PromptSession constructor ensures that .py extension is always used, so setting the attribute manually is no longer required.

With these small changes, vi and emacs open_in_editor shortcuts produce a tempfile with the correct extension, and F2 continues to work correctly.