### PR TITLE
Make IPython.core.debugger interruptible by KeyboardInterrupt

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -290,7 +290,7 @@ class Pdb(OldPdb):
         try:
             OldPdb.interaction(self, frame, traceback)
         except KeyboardInterrupt:
-            raise
+            self.stdout.write('\n' + self.shell.get_exception_only())
 
     def new_do_up(self, arg):
         OldPdb.do_up(self, arg)
@@ -627,8 +627,22 @@ class Pdb(OldPdb):
 
     do_w = do_where
 
+
+class InterruptiblePdb(Pdb):
+    """Version of debugger where KeyboardInterrupt exits the debugger altogether."""
+
+    def cmdloop(self):
+        """Wrap cmdloop() such that KeyboardInterrupt stops the debugger."""
+        try:
+            return OldPdb.cmdloop(self)
+        except KeyboardInterrupt:
+            self.stop_here = lambda frame: False
+            self.do_quit("")
+            sys.settrace(None)
+            self.quitting = False
+            raise
+
     def _cmdloop(self):
-        # Variant that doesn't catch KeyboardInterrupts.
         while True:
             try:
                 # keyboard interrupts allow for an easy way to cancel
@@ -638,6 +652,7 @@ class Pdb(OldPdb):
                 self.allow_kbdint = False
                 break
             except KeyboardInterrupt:
+                self.message('--KeyboardInterrupt--')
                 raise
 
 

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -648,10 +648,3 @@ def set_trace(frame=None):
     If frame is not specified, debugging starts from caller's frame.
     """
     Pdb().set_trace(frame or sys._getframe().f_back)
-
-
-# Override built-in Pdb, since that version doesn't allow interrupting:
-import pdb
-pdb.set_trace = set_trace
-pdb.Pdb = Pdb
-del pdb

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -239,7 +239,10 @@ threading.Thread(target=interrupt).start()
 
 # Timeout if the interrupt doesn't happen:
 def interrupt():
-    time.sleep(2)
+    try:
+        time.sleep(2)
+    except KeyboardInterrupt:
+        return
     _exit(7)
 threading.Thread(target=interrupt, daemon=True).start()
 
@@ -248,9 +251,14 @@ def main():
 
 if __name__ == '__main__':
     try:
+        print("Starting debugger...")
         main()
+        print("Debugger exited without error.")
     except KeyboardInterrupt:
-        print("PASSED")
+        print("Caught KeyboardInterrupt, PASSED")
+    except Exception as e:
+        print("Got wrong exception...")
+        raise e
 """
 
 

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -225,6 +225,7 @@ def can_exit():
 
 
 interruptible_debugger = """\
+import sys
 import threading
 import time
 from os import _exit
@@ -233,9 +234,14 @@ from bdb import BdbQuit
 from IPython.core.debugger import set_trace
 
 def interrupt():
+    # Try to emulate the way interruption works in ipykernel
     time.sleep(0.1)
-    import os, signal
-    os.kill(os.getpid(), signal.SIGINT)
+    if sys.platform == "win32":
+        from _thread import interrupt_main
+        interrupt_main()
+    else:
+        import os, signal
+        os.kill(os.getpid(), signal.SIGINT)
 threading.Thread(target=interrupt).start()
 
 # Timeout if the interrupt doesn't happen:

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -265,10 +265,10 @@ if __name__ == '__main__':
 
 def test_interruptible_core_debugger():
     """The debugger can be interrupted."""
-    with NamedTemporaryFile("w") as f:
+    with NamedTemporaryFile("w", delete=False) as f:
         f.write(interruptible_debugger)
         f.flush()
-        result = check_output([sys.executable, f.name],
-                              encoding=sys.getdefaultencoding())
-        # Wait for it to start:
-        assert "PASSED" in result
+    result = check_output([sys.executable, f.name],
+                          encoding=sys.getdefaultencoding())
+    # Wait for it to start:
+    assert "PASSED" in result

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -7,7 +7,7 @@
 import sys
 import warnings
 from tempfile import NamedTemporaryFile
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 
 import nose.tools as nt
 
@@ -268,7 +268,12 @@ def test_interruptible_core_debugger():
     with NamedTemporaryFile("w", delete=False) as f:
         f.write(interruptible_debugger)
         f.flush()
-    result = check_output([sys.executable, f.name],
-                          encoding=sys.getdefaultencoding())
+    try:
+        result = check_output([sys.executable, f.name],
+                              encoding=sys.getdefaultencoding())
+    except CalledProcessError as e:
+        print("STDOUT FROM SUBPROCESS:\n{}\n".format(e.stdout),
+              file=sys.stderr)
+        raise
     # Wait for it to start:
     assert "PASSED" in result

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -228,6 +228,7 @@ interruptible_debugger = """\
 import threading
 import time
 from os import _exit
+from bdb import BdbQuit
 
 from IPython.core.debugger import set_trace
 
@@ -251,11 +252,11 @@ def main():
 
 if __name__ == '__main__':
     try:
-        print("Starting debugger...")
+        #print("Starting debugger...")
         main()
         print("Debugger exited without error.")
-    except KeyboardInterrupt:
-        print("Caught KeyboardInterrupt, PASSED")
+    except (KeyboardInterrupt, BdbQuit):
+        print("Caught KeyboardInterrupt or BdbQuit, PASSED")
     except Exception as e:
         print("Got wrong exception...")
         raise e

--- a/docs/source/whatsnew/pr/interruptible-debugger.rst
+++ b/docs/source/whatsnew/pr/interruptible-debugger.rst
@@ -1,0 +1,4 @@
+IPython.core.debugger.Pdb is now interruptible
+==============================================
+
+A ``KeyboardInterrupt`` will now interrupt IPython's extended debugger, in order to make Jupyter able to interrupt it.


### PR DESCRIPTION
Together with a number of other PRs, this is a step towards addressing #10516 

There are three issues:

1. `IPython.core.debugger` would swallow KeyboardInterrupts and not let them get raised. This fixes that issue in a new class, `InterruptiblePdb`, so as not to change existing behavior.
2. `pdb` had the same issue, and by default all debuggers in Jupyter kernel usage need to be interruptible by KeyboardInterrupt to fix this bug. https://github.com/ipython/ipykernel/pull/490 overrides pdb and the default debugger to use the new `InterruptiblePdb`.
3. Finally, ipykernel's mechanism for interrupting subprocesses doesn't raise KeyboardInterrupt on Windows when waiting for `input()`. Fixed by https://github.com/ipython/ipykernel/pull/498