### PR TITLE
Fixed objs in the display.py docstrings.

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -57,7 +57,7 @@ def _display_mimetype(mimetype, objs, raw=False, metadata=None):
     ----------
     mimetype : str
         The mimetype to be published (e.g. 'image/png')
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw text data to
         display.
     raw : bool
@@ -139,7 +139,7 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display.
     raw : bool, optional
         Are the objects to be displayed already mimetype-keyed dicts of raw display data,
@@ -398,7 +398,7 @@ def display_pretty(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw text data to
         display.
     raw : bool
@@ -418,7 +418,7 @@ def display_html(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw HTML data to
         display.
     raw : bool
@@ -435,7 +435,7 @@ def display_markdown(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw markdown data to
         display.
     raw : bool
@@ -453,7 +453,7 @@ def display_svg(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw svg data to
         display.
     raw : bool
@@ -470,7 +470,7 @@ def display_png(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw png data to
         display.
     raw : bool
@@ -487,7 +487,7 @@ def display_jpeg(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw JPEG data to
         display.
     raw : bool
@@ -504,7 +504,7 @@ def display_latex(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw latex data to
         display.
     raw : bool
@@ -523,7 +523,7 @@ def display_json(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw json data to
         display.
     raw : bool
@@ -540,7 +540,7 @@ def display_javascript(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw javascript data to
         display.
     raw : bool
@@ -557,7 +557,7 @@ def display_pdf(*objs, **kwargs):
 
     Parameters
     ----------
-    objs : tuple of objects
+    *objs : object
         The Python objects to display, or if raw=True raw javascript data to
         display.
     raw : bool


### PR DESCRIPTION
Improves the docstring for `display.py` while also resolving warnings that are generated by IntelliSense due to the [docstring issue](https://github.com/ipython/ipython/issues/12182).

I changed the docstring for star args (i.e. `*objs`) from `objs : tuple of objects` to `*objs : object`. While the [numpydoc documentation](https://numpydoc.readthedocs.io/en/latest/) is silent on how to handle star args other documentation like [napoleon example of NumPy style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html) is in line with the changes that I suggest. 

Therefore, this change improves readability (due to being in line with expected practices) as well as providing the proper IntelliSense suggestions.