### PR TITLE
Bump jedi to at least 0.16.0 and fix deprecated function usage

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -988,7 +988,8 @@ def _make_signature(completion)-> str:
 
     """
 
-    return '(%s)'% ', '.join([f for f in (_formatparamchildren(p) for p in completion.params) if f])
+    return '(%s)'% ', '.join([f for f in (_formatparamchildren(p) for signature in completion.get_signatures()
+                                          for p in signature.defined_names()) if f])
 
 class IPCompleter(Completer):
     """Extension of the completer class with IPython-specific features"""
@@ -1398,7 +1399,7 @@ class IPCompleter(Completer):
         if not try_jedi:
             return []
         try:
-            return filter(completion_filter, interpreter.completions())
+            return filter(completion_filter, interpreter.complete())
         except Exception as e:
             if self.debug:
                 return [_FakeJediCompletion('Oops Jedi has crashed, please report a bug with the following:\n"""\n%s\ns"""' % (e))]

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ extras_require = dict(
 
 install_requires = [
     'setuptools>=18.5',
-    'jedi>=0.10',
+    'jedi>=0.16',
     'decorator',
     'pickleshare',
     'traitlets>=4.2',


### PR DESCRIPTION
This should fix #12102

I ran `iptest IPython.core.tests.test_completer` and it didn't seem to give any errors. Not sure if we want to add any new tests here, or if that is good enough.

According to jedi, `Multiple signatures are typical if you use Python stubs with @overload.` I made my change to account for all signatures, but not sure how this plays out IRL since I've never seen a function with multiple signatures.
