### PR TITLE
Add option to change HTML attributes in display.Video

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1348,17 +1348,20 @@ class Video(DisplayObject):
             If not supplied, defaults to the height of the video.
         html_attributes : str
             Attributes for the HTML `<video>` block.
-            Default: "controls" to get video controls.
-            Other examples: "controls muted" for muted video with controls,
-            "loop autoplay" for looping autoplaying video without controls.
+            Default: `"controls"` to get video controls.
+            Other examples: `"controls muted"` for muted video with controls,
+            `"loop autoplay"` for looping autoplaying video without controls.
 
         Examples
         --------
 
-        Video('https://archive.org/download/Sita_Sings_the_Blues/Sita_Sings_the_Blues_small.mp4')
-        Video('path/to/video.mp4')
-        Video('path/to/video.mp4', embed=True)
-        Video(b'raw-videodata', embed=True)
+        ::
+
+            Video('https://archive.org/download/Sita_Sings_the_Blues/Sita_Sings_the_Blues_small.mp4')
+            Video('path/to/video.mp4')
+            Video('path/to/video.mp4', embed=True)
+            Video('path/to/video.mp4', embed=True, html_attributes="controls muted autoplay")
+            Video(b'raw-videodata', embed=True)
         """
         if isinstance(data, (Path, PurePath)):
             data = str(data)

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1308,7 +1308,7 @@ class Image(DisplayObject):
 class Video(DisplayObject):
 
     def __init__(self, data=None, url=None, filename=None, embed=False,
-                 mimetype=None, width=None, height=None):
+                 mimetype=None, width=None, height=None, html_attributes="controls"):
         """Create a video object given raw data or an URL.
 
         When this object is returned by an input cell or passed to the
@@ -1346,6 +1346,11 @@ class Video(DisplayObject):
         height : int
             Height in pixels to which to constrain the video in html.
             If not supplied, defaults to the height of the video.
+        html_attributes : str
+            Attributes for the HTML `<video>` block.
+            Default: "controls" to get video controls.
+            Other examples: "controls muted" for muted video with controls,
+            "loop autoplay" for looping autoplaying video without controls.
 
         Examples
         --------
@@ -1377,6 +1382,7 @@ class Video(DisplayObject):
         self.embed = embed
         self.width = width
         self.height = height
+        self.html_attributes = html_attributes
         super(Video, self).__init__(data=data, url=url, filename=filename)
 
     def _repr_html_(self):
@@ -1390,9 +1396,9 @@ class Video(DisplayObject):
         # notebook output.
         if not self.embed:
             url = self.url if self.url is not None else self.filename
-            output = """<video src="{0}" controls {1} {2}>
+            output = """<video src="{0}" {1} {2} {3}>
       Your browser does not support the <code>video</code> element.
-    </video>""".format(url, width, height)
+    </video>""".format(url, self.html_attributes, width, height)
             return output
 
         # Embedded videos are base64-encoded.
@@ -1411,10 +1417,10 @@ class Video(DisplayObject):
         else:
             b64_video = b2a_base64(video).decode('ascii').rstrip()
 
-        output = """<video controls {0} {1}>
- <source src="data:{2};base64,{3}" type="{2}">
+        output = """<video {0} {1} {2}>
+ <source src="data:{3};base64,{4}" type="{3}">
  Your browser does not support the video tag.
- </video>""".format(width, height, mimetype, b64_video)
+ </video>""".format(self.html_attributes, width, height, mimetype, b64_video)
         return output
 
     def reload(self):

--- a/docs/source/whatsnew/pr/video-display-attributes.rst
+++ b/docs/source/whatsnew/pr/video-display-attributes.rst
@@ -1,0 +1,4 @@
+Video HTML attributes
+=====================
+
+Add an option to `IPython.display.Video` to change the attributes of the HTML display of the video.


### PR DESCRIPTION
I want to display video in a Jupyter notebook, and I would like to customize the behaviour of the video by changing some of the attributes of the HTML5 element (autoplay, loop, muted, ... see e.g. [1]) 

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video

This PR allows this by adding an option to the Video constructor:

    Video("foo.mp4", html_attributes="controls loop")


Another solution would have been to add boolean options for each properties

    Video("foo.mp4", loop=True, autoplay=False)

but that might be too cumbersome to maintain for such a specialized feature.