### PR TITLE
Fix DeprecationWarning on autocompletion with jedi 0.17.0

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1371,7 +1371,7 @@ class IPCompleter(Completer):
                 else:
                     raise ValueError("Don't understand self.omit__names == {}".format(self.omit__names))
 
-        script = jedi.Script(text[:offset])
+        script = jedi.Interpreter(text[:offset],namespaces)
         try_jedi = True
 
         try:

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1371,15 +1371,14 @@ class IPCompleter(Completer):
                 else:
                     raise ValueError("Don't understand self.omit__names == {}".format(self.omit__names))
 
-        interpreter = jedi.Interpreter(
-            text[:offset], namespaces, column=cursor_column, line=cursor_line + 1)
+        script = jedi.Script(code=text[:offset])
         try_jedi = True
 
         try:
             # find the first token in the current tree -- if it is a ' or " then we are in a string
             completing_string = False
             try:
-                first_child = next(c for c in interpreter._get_module().tree_node.children if hasattr(c, 'value'))
+                first_child = next(c for c in script._get_module().tree_node.children if hasattr(c, 'value'))
             except StopIteration:
                 pass
             else:
@@ -1399,7 +1398,7 @@ class IPCompleter(Completer):
         if not try_jedi:
             return []
         try:
-            return filter(completion_filter, interpreter.complete())
+            return filter(completion_filter, script.complete(column=cursor_column, line=cursor_line + 1))
         except Exception as e:
             if self.debug:
                 return [_FakeJediCompletion('Oops Jedi has crashed, please report a bug with the following:\n"""\n%s\ns"""' % (e))]

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1371,7 +1371,7 @@ class IPCompleter(Completer):
                 else:
                     raise ValueError("Don't understand self.omit__names == {}".format(self.omit__names))
 
-        script = jedi.Script(code=text[:offset])
+        script = jedi.Script(text[:offset])
         try_jedi = True
 
         try:

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1371,14 +1371,14 @@ class IPCompleter(Completer):
                 else:
                     raise ValueError("Don't understand self.omit__names == {}".format(self.omit__names))
 
-        script = jedi.Interpreter(text[:offset],namespaces)
+        interpreter = jedi.Interpreter(text[:offset],namespaces)
         try_jedi = True
 
         try:
             # find the first token in the current tree -- if it is a ' or " then we are in a string
             completing_string = False
             try:
-                first_child = next(c for c in script._get_module().tree_node.children if hasattr(c, 'value'))
+                first_child = next(c for c in interpreter._get_module().tree_node.children if hasattr(c, 'value'))
             except StopIteration:
                 pass
             else:
@@ -1398,7 +1398,7 @@ class IPCompleter(Completer):
         if not try_jedi:
             return []
         try:
-            return filter(completion_filter, script.complete(column=cursor_column, line=cursor_line + 1))
+            return filter(completion_filter, interpreter.complete(column=cursor_column, line=cursor_line + 1))
         except Exception as e:
             if self.debug:
                 return [_FakeJediCompletion('Oops Jedi has crashed, please report a bug with the following:\n"""\n%s\ns"""' % (e))]


### PR DESCRIPTION
with jedi 0.17.0

```
In [1]: import warnings
In [2]: warnings.filters.remove(('ignore', None, DeprecationWarning, None, 0))
In [3]: a=0
In [4]: a.<TAB>
```

throws a deprecation warning below

DeprecationWarning: Providing the column is now done in the functions themselves like `Script(...).complete(line, column)`

So, I fixed it.