### PR TITLE
Catch ValueError

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -620,7 +620,11 @@ class Pdb(OldPdb):
         Take a number as argument as an (optional) number of context line to
         print"""
         if arg:
-            context = int(arg)
+            try:
+                context = int(arg)
+            except ValueError:
+                self.stdout.write('\n' + self.shell.get_exception_only())
+                return
             self.print_stack_trace(context)
         else:
             self.print_stack_trace()

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -622,8 +622,8 @@ class Pdb(OldPdb):
         if arg:
             try:
                 context = int(arg)
-            except ValueError:
-                self.stdout.write('\n' + self.shell.get_exception_only())
+            except ValueError as err:
+                self.error(err)
                 return
             self.print_stack_trace(context)
         else:


### PR DESCRIPTION
Typing "w = 1" in the debugger crashes the debugger

example:
```
In[1]: %debug print()
ipdb> w = 1
```