### PR TITLE
ensure SVG(url=...) is set correctly

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -752,6 +752,11 @@ class Latex(TextDisplayObject):
 
 
 class SVG(DisplayObject):
+    """Embed an SVG into the display.
+
+    Note if you just want to view a svg image via a URL use `:class:Image` with
+    a url=URL keyword argument.
+    """
 
     _read_flags = 'rb'
     # wrap data in a property, which extracts the <svg> tag, discarding

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -661,12 +661,21 @@ class DisplayObject(object):
             data = response.read()
             # extract encoding from header, if there is one:
             encoding = None
-            if "content-type" in response.headers:
+            if 'content-type' in response.headers:
                 for sub in response.headers['content-type'].split(';'):
                     sub = sub.strip()
                     if sub.startswith('charset'):
                         encoding = sub.split('=')[-1].strip()
                         break
+            if 'content-encoding' in response.headers:
+                # TODO: do deflate?
+                if 'gzip' in response.headers['content-encoding']:
+                    import gzip
+                    from io import BytesIO
+                    with gzip.open(BytesIO(data), 'rt', encoding=encoding) as fp:
+                        encoding = None
+                        data = fp.read()
+                    
             # decode data, if an encoding was specified
             # We only touch self.data once since
             # subclasses such as SVG have @data.setter methods

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -73,11 +73,44 @@ def test_retina_png():
     nt.assert_equal(md['height'], 1)
 
 def test_embed_svg_url():
-    # 6.1kB of data
+    import gzip
+    from io import BytesIO
+    svg_data = b'<svg><circle x="0" y="0" r="1"/></svg>'
+    url = 'http://test.com/circle.svg'
+    
+    gzip_svg = BytesIO()
+    with gzip.open(gzip_svg, 'wb') as fp:
+        fp.write(svg_data)
+    gzip_svg = gzip_svg.getvalue()
+    
+    def mocked_urlopen(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, svg):
+                self._svg_data = svg
+                self.headers = {'content-type': 'image/svg+xml'}
+
+            def read(self):
+                return self._svg_data
+
+        if args[0] == url:
+            return MockResponse(svg_data)
+        elif args[0] == url + 'z':          
+            ret= MockResponse(gzip_svg)
+            ret.headers['content-encoding']= 'gzip'
+            return ret
+        return MockResponse(None)
+
+    with mock.patch('urllib.request.urlopen', side_effect=mocked_urlopen):
+        svg = display.SVG(url=url)
+        nt.assert_true(svg._repr_svg_().startswith('<svg'))
+        svg = display.SVG(url=url + 'z')
+        nt.assert_true(svg._repr_svg_().startswith('<svg'))
+
+    # do it for real: 6.1kB of data
     url = "https://upload.wikimedia.org/wikipedia/commons/3/30/Vector-based_example.svg"
     svg = display.SVG(url=url)
-    nt.assert_true(svg._repr_svg_().startswith('<svg '))
-
+    nt.assert_true(svg._repr_svg_().startswith('<svg'))
+    
 def test_retina_jpeg():
     here = os.path.dirname(__file__)
     img = display.Image(os.path.join(here, "2x2.jpg"), retina=True)

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -72,6 +72,12 @@ def test_retina_png():
     nt.assert_equal(md['width'], 1)
     nt.assert_equal(md['height'], 1)
 
+def test_embed_svg_url():
+    # 6.1kB of data
+    url = "https://upload.wikimedia.org/wikipedia/commons/3/30/Vector-based_example.svg"
+    svg = display.SVG(url=url)
+    nt.assert_true(svg._repr_svg_().startswith('<svg '))
+
 def test_retina_jpeg():
     here = os.path.dirname(__file__)
     img = display.Image(os.path.join(here, "2x2.jpg"), retina=True)


### PR DESCRIPTION
I removed the try/except block in DisplayObject too since,  if you misspecify a filename you get a
FileNotFoundException I think the user should get a URLError or similar if they misspecify
a URL. I was quite mystified when the SVG(url...) seemed to "work" but nothing was displayed
in the notebook.

> 

> Also added gzip decompression for .svgz files