### PR TITLE
Fix compatibility with the latest release of Sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,6 @@ matrix:
       python: "3.7"
       dist: xenial
       sudo: true
-    - arch: arm64
-      python: "3.7"
-      dist: xenial
-      env: ARM64=True IPYTHON_TESTING_TIMEOUT_SCALE=2
-      sudo: true
     - arch: amd64
       python: "3.8"
       dist: xenial

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,6 +121,29 @@ numpydoc_show_class_members = False # Otherwise Sphinx emits thousands of warnin
 numpydoc_class_members_toctree = False
 warning_is_error = True
 
+import logging
+
+class ConfigtraitFilter(logging.Filter):
+    """
+    This is a filter to remove in sphinx 3+ the error about config traits being duplicated. 
+
+    As we autogenerate configuration traits from, subclasses have lots of
+    duplication and we want to silence them. Indeed we build on travis with
+    warnings-as-error set to True, so those duplicate items make the build fail.
+    """
+
+    def filter(self, record):
+        if record.args and record.args[0] == 'configtrait' and 'duplicate' in record.msg:
+            return False
+        return True
+
+ct_filter = ConfigtraitFilter()
+
+import sphinx.util
+logger = sphinx.util.logging.getLogger('sphinx.domains.std').logger
+
+logger.addFilter(ct_filter)
+
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 #

--- a/docs/source/development/wrapperkernels.rst
+++ b/docs/source/development/wrapperkernels.rst
@@ -116,7 +116,7 @@ You can override a number of other methods to improve the functionality of your
 kernel. All of these methods should return a dictionary as described in the
 relevant section of the :doc:`messaging spec <messaging>`.
 
-.. class:: MyKernel
+.. class:: MyBetterKernel
 
    .. method:: do_complete(code, cusor_pos)
 

--- a/docs/sphinxext/configtraits.py
+++ b/docs/sphinxext/configtraits.py
@@ -8,8 +8,7 @@
 
     Cross reference like this: :configtrait:`Application.log_datefmt`.
 """
-from sphinx.locale import l_
-from sphinx.util.docfields import Field
+
 
 def setup(app):
     app.add_object_type('configtrait', 'configtrait', objname='Config option')


### PR DESCRIPTION
`l_` from sphinx.locale has been deprecated for a long time.
`_` is the new name for the same function but it seems that the
imports there are useless.

https://github.com/sphinx-doc/sphinx/commit/8d653a406dc0dc6c2632176ab4757ca15474b10f

Let's see what CI thinks about this change.