### PR TITLE
Keep trailing commas for tuple subclasses of length 1

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -638,7 +638,7 @@ def _seq_pprinter_factory(start, end):
                 p.text(',')
                 p.breakable()
             p.pretty(x)
-        if len(obj) == 1 and type(obj) is tuple:
+        if len(obj) == 1 and isinstance(obj, tuple):
             # Special case for 1-item tuples.
             p.text(',')
         p.end_group(step, end)


### PR DESCRIPTION
Before this change:
```
In [38]: class T(tuple): pass

In [39]: T([1])
Out[39]: (1)
```