### PR TITLE
Do not exit if self.interact is True

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -418,7 +418,8 @@ class InteractiveShellApp(Configurable):
                 fname = os.path.join(fname, "__main__.py")
             if not os.path.exists(fname):
                 self.log.warning("File '%s' doesn't exist", fname)
-                self.exit(2)
+                if not self.interact:
+                    self.exit(2)
             try:
                 self._exec_file(fname, shell_futures=True)
             except:


### PR DESCRIPTION
If self.file_to_run is not a valid file, the kernel closes, but if the file is unreadable, it doesn't.
To be consistant with the other uses of exit, exit should only be called if `self.interact` is false.
See the two other occurences of exit above and below.