### PR TITLE
start using .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,4 @@
 #
 # <full commit hash>  # initial black-format 
 # <full commit hash>  # rename something internal
+6e748726282d1acb9a4f9f264ee679c474c4b8f5  # Apply pygrade --36plus on IPython/core/tests/test_inputtransformer.py.

--- a/tools/configure-git-blame-ignore-revs.sh
+++ b/tools/configure-git-blame-ignore-revs.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Other config options for blame are markUnblamables and markIgnoredLines.
 # See docs for more details:
 # https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile


### PR DESCRIPTION
We merged a pyupgrade commit back in #12261, but I didn't realize @Carreau added machinery to help local `git blame` to ignore such stylistic change commits. So we might as well start doing that now. Thanks Matthias!