### PR TITLE
Unify API between completers.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1708,8 +1708,6 @@ class IPCompleter(Completer):
         u"""Match Latex syntax for unicode characters.
 
         This does both ``\\alp`` -> ``\\alpha`` and ``\\alpha`` -> ``α``
-
-        Used on Python 3 only.
         """
         slashpos = text.rfind('\\')
         if slashpos > -1:
@@ -1722,7 +1720,8 @@ class IPCompleter(Completer):
                 # If a user has partially typed a latex symbol, give them
                 # a full list of options \al -> [\aleph, \alpha]
                 matches = [k for k in latex_symbols if k.startswith(s)]
-                return s, matches
+                if matches:
+                    return s, matches
         return u'', []
 
     def dispatch_custom_completer(self, text):

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -224,20 +224,27 @@ class TestCompleter(unittest.TestCase):
         nt.assert_in("\\alpha", matches)
         nt.assert_in("\\aleph", matches)
 
+    def test_latex_no_results(self):
+        """
+        forward latex should really return nothing in either field if nothing is found.
+        """
+        ip = get_ipython()
+        text, matches = ip.Completer.latex_matches("\\really_i_should_match_nothing")
+        nt.assert_equal(text, "")
+        nt.assert_equal(matches, [])
+
     def test_back_latex_completion(self):
         ip = get_ipython()
 
         # do not return more than 1 matches fro \beta, only the latex one.
         name, matches = ip.complete("\\β")
-        nt.assert_equal(len(matches), 1)
-        nt.assert_equal(matches[0], "\\beta")
+        nt.assert_equal(matches, ['\\beta'])
 
     def test_back_unicode_completion(self):
         ip = get_ipython()
 
         name, matches = ip.complete("\\Ⅴ")
-        nt.assert_equal(len(matches), 1)
-        nt.assert_equal(matches[0], "\\ROMAN NUMERAL FIVE")
+        nt.assert_equal(matches, ["\\ROMAN NUMERAL FIVE"])
 
     def test_forward_unicode_completion(self):
         ip = get_ipython()


### PR DESCRIPTION
Forward latex seem to be the only one that return a text match  when no
completions is provided.

In particular this leads to custom logins in other places.

Should close #12279