### PR TITLE
Delete 109-112 for removing external test

### DIFF
--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -105,11 +105,6 @@ def test_embed_svg_url():
         nt.assert_true(svg._repr_svg_().startswith('<svg'))
         svg = display.SVG(url=url + 'z')
         nt.assert_true(svg._repr_svg_().startswith('<svg'))
-
-    # do it for real: 6.1kB of data
-    url = "https://upload.wikimedia.org/wikipedia/commons/3/30/Vector-based_example.svg"
-    svg = display.SVG(url=url)
-    nt.assert_true(svg._repr_svg_().startswith('<svg'))
     
 def test_retina_jpeg():
     here = os.path.dirname(__file__)


### PR DESCRIPTION
#12281 

Delete the 109~112 lines in core/tests/test_display.py to remove the external test.