### PR TITLE
PERF: Make unicode completions lazier.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -35,7 +35,7 @@ or using unicode completion:
 
 .. code::
 
-    \\greek small letter alpha<tab>
+    \\GREEK SMALL LETTER ALPHA<tab>
     α
 
 


### PR DESCRIPTION
This commit renames `IPCompleter._names` to ``_unicode_names`` and uses
traitlets default machinery to defer its initialization until first access.

Previously, initialization was deferred until the first call to
fwd_unicode_names, but that was still called on the first completion attempt,
which caused about a .5 second lag on the first completion attempt on
my (relatively powerful) machine.

This is based off of https://github.com/ipython/ipython/pull/12298. With profiling enabled at least, I'm seeing this as taking about half a second on the first completion attempt on each process on my machine. That's probably a bit of an overstatement, since the expensive function in question is doing a big loop in pure python, which is worst-case scenario for cProfile overhead, but we're still making over a milllion calls to unicodedata.name, which adds up whether you're profiling or not.

Example profile output:

```
(IPython) [~/projects/IPython]@(make-unicode-completions-lazier:1485049ddc)$ python -m pstats .completion_profiles/bf0a29af-7ac8-4a1d-b42d-be7eb88ea325
Welcome to the profile statistics browser.
.completion_profiles/bf0a29af-7ac8-4a1d-b42d-be7eb88ea325% sort cumtime
.completion_profiles/bf0a29af-7ac8-4a1d-b42d-be7eb88ea325% stats 20
Fri May  8 12:08:36 2020    .completion_profiles/bf0a29af-7ac8-4a1d-b42d-be7eb88ea325

         2588133 function calls (2579958 primitive calls) in 0.680 seconds

   Ordered by: cumulative time
   List reduced from 748 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      116    0.000    0.000    0.681    0.006 /home/ssanderson/projects/IPython/IPython/core/completer.py:1864(_completions)
        1    0.000    0.000    0.675    0.675 /home/ssanderson/projects/IPython/IPython/core/completer.py:1994(_complete)
        1    0.403    0.403    0.594    0.594 /home/ssanderson/projects/IPython/IPython/core/completer.py:2107(fwd_unicode_match)
  1114112    0.118    0.000    0.118    0.000 {built-in method unicodedata.name}
        1    0.000    0.000    0.079    0.079 /home/ssanderson/projects/IPython/IPython/core/completer.py:1356(_jedi_matches)
        1    0.000    0.000    0.072    0.072 /home/ssanderson/.virtualenvs/IPython/lib/python3.8/site-packages/jedi/api/__init__.py:829(__init__)
        1    0.000    0.000    0.071    0.071 /home/ssanderson/.virtualenvs/IPython/lib/python3.8/site-packages/jedi/api/__init__.py:124(__init__)
  1114112    0.067    0.000    0.067    0.000 {built-in method builtins.chr}
```