### PR TITLE
Exceptions raised when executing notebooks via the %run magic command

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -701,7 +701,7 @@ class ExecutionMagics(Magics):
         if filename.lower().endswith(('.ipy', '.ipynb')):
             with preserve_keys(self.shell.user_ns, '__file__'):
                 self.shell.user_ns['__file__'] = filename
-                self.shell.safe_execfile_ipy(filename)
+                self.shell.safe_execfile_ipy(filename, raise_exceptions=True)
             return
 
         # Control the response to exit() calls made by the script being run

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -672,8 +672,8 @@ class ExecutionMagics(Magics):
             modulename = opts["m"][0]
             modpath = find_mod(modulename)
             if modpath is None:
-                warn('%r is not a valid modulename on sys.path'%modulename)
-                return
+                msg = '%r is not a valid modulename on sys.path'%modulename
+                raise Exception(msg)
             arg_lst = [modpath] + arg_lst
         try:
             fpath = None # initialize to make sure fpath is in scope later

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -680,9 +680,8 @@ class ExecutionMagics(Magics):
             fpath = arg_lst[0]
             filename = file_finder(fpath)
         except IndexError:
-            warn('you must provide at least a filename.')
-            print('\n%run:\n', oinspect.getdoc(self.run))
-            return
+            msg = 'you must provide at least a filename.'
+            raise Exception(msg)
         except IOError as e:
             try:
                 msg = str(e)
@@ -690,8 +689,7 @@ class ExecutionMagics(Magics):
                 msg = e.message
             if os.name == 'nt' and re.match(r"^'.*'$",fpath):
                 warn('For Windows, use double quotes to wrap a filename: %run "mypath\\myfile.py"')
-            error(msg)
-            return
+            raise Exception(msg)
         except TypeError:
             if fpath in sys.meta_path:
                 filename = ""

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -396,6 +396,25 @@ tclass.py: deleting object: C-third
         
         nt.assert_equal(_ip.user_ns['answer'], 42)
 
+    def test_run_nb_error(self):
+        """Test %run notebook.ipynb error"""
+        from nbformat import v4, writes
+        # %run when a file name isn't provided
+        nt.assert_raises(Exception, _ip.magic, "run")
+
+        # %run when a file doesn't exist
+        nt.assert_raises(Exception, _ip.magic, "run foobar.ipynb")
+
+        # %run on a notebook with an error
+        nb = v4.new_notebook(
+           cells=[
+                v4.new_code_cell("0/0")
+            ]
+        )
+        src = writes(nb, version=4)
+        self.mktmp(src, ext='.ipynb')
+        nt.assert_raises(Exception, _ip.magic, "run %s" % self.fname)
+
     def test_file_options(self):
         src = ('import sys\n'
                'a = " ".join(sys.argv[1:])\n')


### PR DESCRIPTION
A first step toward fixing #12291. I only addressed the execution of ipynb files because I lacked the confidence to edit the complex shell operations below.

It's unclear to me if you would want the ultimate solution to be this narrowly tailored, or if you'd prefer other elements of this function to change behavior as well. If you let me know what you'd like, I can attempt to implement it.

I can verify that this modest patch did in fact work in my notebook testing.