### PR TITLE
Fix ipython#11508: check if line_buffer is None

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2021,8 +2021,8 @@ class IPCompleter(Completer):
         # if text is either None or an empty string, rely on the line buffer
         if (not line_buffer) and full_text:
             line_buffer = full_text.split('\n')[cursor_line]
-        if not text:
-            text = self.splitter.split_line(line_buffer, cursor_pos)
+        if not text: # issue #11508: check line_buffer before calling split_line
+            text = self.splitter.split_line(line_buffer, cursor_pos)  if line_buffer else ''
 
         if self.backslash_combining_completions:
             # allow deactivation of these on windows.


### PR DESCRIPTION
There are situations where def _complete() is called and text, full_text and line_buffer arguments are all None. This leads to `text = self.splitter.split_line(line_buffer, cursor_pos)` being called with a None argument, causing an exception. The added check will default to an empty text, thereby avoiding the exception.