### PR TITLE
WIP: Return proxy object from magic_arguments.

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -21,6 +21,7 @@ from . import oinspect
 from .error import UsageError
 from .inputtransformer2 import ESC_MAGIC, ESC_MAGIC2
 from decorator import decorator
+from .magic_arguments import MagicArgumentDecoratedFunction
 from ..utils.ipstruct import Struct
 from ..utils.process import arg_split
 from ..utils.text import dedent
@@ -186,7 +187,10 @@ def _method_magic_marker(magic_kind):
     def magic_deco(arg):
         call = lambda f, *a, **k: f(*a, **k)
 
-        if callable(arg):
+        if isinstance(arg, MagicArgumentDecoratedFunction):
+            record_magic(magics, magic_kind, arg.__name__, arg.__name__)
+            retval = arg
+        elif callable(arg):
             # "Naked" decorator call (just @foo, no args)
             func = arg
             name = func.__name__


### PR DESCRIPTION
This changes the @magic_arguments decorator to return a proxy wrapper around
the decorated function instead of repeatedly mutating the underlying function
in place.

Based on Twitter conversation with @Carreau here:
https://twitter.com/scottbsanderson/status/1260280451710795777.

**NOTE**: A bunch of the changes here are made solely to appease the test suite
of test_magic_arguments, which makes a bunch of assertions about attributes
that do or don't get set on the decorated function (e.g., it asserts that
has_arguments gets set, and that argcmd_name sometimes gets set and sometimes
doesn't). I don't think any external code actually depends on these behaviors,
so the code could almost certainly be cleaned up after changing the tests to
not depend on implementation details. I chose to defer that change in this
commit so that there's a clean separation between internal refactoring and
behavior changes.