### PR TITLE
Enable high DPI scaling in qt.py

### DIFF
--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -25,6 +25,7 @@ def inputhook(context):
                         'variable. Deactivate Qt5 code.'
                     )
                 return
+        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
         _appref = app = QtGui.QApplication([" "])
     event_loop = QtCore.QEventLoop(app)
 


### PR DESCRIPTION
This enables automatic scaling for the qt5 GUI backend based on the monitor's pixel density.
I haven't yet been able to find a case (on mac/linux/windows) in which this didn't just "do the right thing" depending on pixel density ... but let me know if someone here has already considered and rejected this approach (couldn't find anything in the issues).

It _is_ possible for the end-user to enable this themselves with the `QT_ENABLE_HIGHDPI_SCALING` environment variable, but if the user doesn't know to do that, any downstream Qt-based application that runs in the IPython event loop will not be able to correct scaling on a high DPI monitor, since it has to be set before creating the `QApplication`  (we're running into this with [napari](https://github.com/napari/napari))

Reference: https://doc.qt.io/qt-5/highdpi.html