### PR TITLE
Reenable non-text formatter on terminal.

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -274,8 +274,6 @@ class TerminalInteractiveShell(InteractiveShell):
         super(TerminalInteractiveShell, self).init_display_formatter()
         # terminal only supports plain text
         self.display_formatter.active_types = ['text/plain']
-        # disable `_ipython_display_`
-        self.display_formatter.ipython_display_formatter.enabled = False
 
     def init_prompt_toolkit_cli(self):
         if self.simple_prompt:

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -273,7 +273,7 @@ class TerminalInteractiveShell(InteractiveShell):
     def init_display_formatter(self):
         super(TerminalInteractiveShell, self).init_display_formatter()
         # terminal only supports plain text
-        self.display_formatter.active_types = ['text/plain']
+        self.display_formatter.active_types = ["text/plain"]
 
     def init_prompt_toolkit_cli(self):
         if self.simple_prompt:

--- a/IPython/terminal/tests/test_interactivshell.py
+++ b/IPython/terminal/tests/test_interactivshell.py
@@ -135,11 +135,14 @@ class InteractiveShellTestCase(unittest.TestCase):
         finally:
             ip.input_transformers_post.remove(syntax_error_transformer)
 
-    def test_plain_text_only(self):
+    def test_repl_not_plain_text(self):
         ip = get_ipython()
         formatter = ip.display_formatter
         assert formatter.active_types == ['text/plain']
-        assert not formatter.ipython_display_formatter.enabled
+
+        # terminal may have arbitrary mimetype handler to open external viewer
+        # or inline images.
+        assert formatter.ipython_display_formatter.enabled
 
         class Test(object):
             def __repr__(self):
@@ -155,16 +158,27 @@ class InteractiveShellTestCase(unittest.TestCase):
 
         class Test2(Test):
             def _ipython_display_(self):
-                from IPython.display import display
-                display('<custom>')
+                from IPython.display import display, HTML
+                display(HTML('<custom>'))
 
-        # verify that _ipython_display_ shortcut isn't called
-        obj = Test2()
-        with capture_output() as captured:
-            data, _ = formatter.format(obj)
+        # verify that mimehandlers are called
+        called = False
 
-        self.assertEqual(data, {'text/plain': repr(obj)})
-        assert captured.stdout == ''
+        def handler(data, metadata):
+            print('Handler called')
+            nonlocal called
+            called = True
+
+        ip.display_formatter.active_types.append("text/html")
+        ip.display_formatter.formatters["text/html"].enabled = True
+        ip.mime_renderers["text/html"] = handler
+
+
+        obj = Test()
+        display(obj)
+
+        assert called == True
+        
 
 def syntax_error_transformer(lines):
     """Transformer that throws SyntaxError if 'syntaxerror' is in the code."""


### PR DESCRIPTION
In many terminal it is possible to display images, and terminal IPython
now have the ability to register arbitrary mimehandler.