### PR TITLE
Remove deprecated and ignored travis.ci keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
 python:
     - 3.6
 
-sudo: false
-
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
@@ -71,20 +69,16 @@ matrix:
     - arch: amd64
       python: "3.7"
       dist: xenial
-      sudo: true
     - arch: amd64
       python: "3.8"
       dist: xenial
-      sudo: true
     - arch: amd64
       python: "nightly"
       dist: xenial
-      sudo: true
     - arch: arm64
       python: "nightly"
       dist: bionic
       env: ARM64=True
-      sudo: true
     - os: osx
       language: generic
       python: 3.6
@@ -107,7 +101,7 @@ deploy:
     secure: Y/Ae9tYs5aoBU8bDjN2YrwGG6tCbezj/h3Lcmtx8HQavSbBgXnhnZVRb2snOKD7auqnqjfT/7QMm4ZyKvaOEgyggGktKqEKYHC8KOZ7yp8I5/UMDtk6j9TnXpSqqBxPiud4MDV76SfRYEQiaDoG4tGGvSfPJ9KcNjKrNvSyyxns=
   file: dist/*
   file_glob: true
-  skip_cleanup: true
+  cleanup: false
   on:
     repo: ipython/ipython
     all_branches: true  # Backports are released from e.g. 5.x branch


### PR DESCRIPTION
If you head to any success ding build and look at the config tab. travis
issue a few warnings that the sudo keys have no effect, and that
skip_cleanup is deprecated and replaced by "cleanup"