### PR TITLE
Handle non-hashable types in printing/formatting

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -422,9 +422,11 @@ class BaseFormatter(Configurable):
                 return self.deferred_printers[typ_key]
         else:
             for cls in pretty._get_mro(typ):
-                if cls in self.type_printers or self._in_deferred_types(cls):
+                try:
                     return self.type_printers[cls]
-        
+                except (KeyError, TypeError):
+                    pass
+
         # If we have reached here, the lookup failed.
         raise KeyError("No registered printer for {0!r}".format(typ))
 

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -388,10 +388,9 @@ class RepresentationPrinter(PrettyPrinter):
             #   1) a registered printer
             #   2) a _repr_pretty_ method
             for cls in _get_mro(obj_class):
-                if cls in self.type_pprinters:
-                    # printer registered in self.type_pprinters
-                    return self.type_pprinters[cls](obj, self, cycle)
-                else:
+                try:
+                    printer = self.type_pprinters[cls]
+                except (KeyError, TypeError):
                     # deferred printer
                     printer = self._in_deferred_types(cls)
                     if printer is not None:
@@ -408,6 +407,9 @@ class RepresentationPrinter(PrettyPrinter):
                         if cls is not object \
                                 and callable(cls.__dict__.get('__repr__')):
                             return _repr_pprint(obj, self, cycle)
+                else:
+                    # printer registered in self.type_pprinters
+                    return printer(obj, self, cycle)
 
             return _default_pprint(obj, self, cycle)
         finally:

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -470,3 +470,39 @@ def test_custom_repr():
     nt.assert_in("OrderedCounter(OrderedDict", pretty.pretty(oc))
 
     nt.assert_equal(pretty.pretty(MySet()), 'mine')
+
+
+def test_nonhashable_type():
+    """Test pretty printing of objects of non-hashable type
+
+    See: https://github.com/ipython/ipython/issues/12320
+
+    """
+
+    # Non-hashable by having None hash
+    class Meta1(type):
+        __hash__ = None
+
+    class Case1(metaclass=Meta1):
+        pass
+
+    unittest.TestCase().assertRegex(
+        pretty.pretty(Case1()),
+        r"<IPython.lib.tests.test_pretty.test_nonhashable_type.<locals>.Case1 at 0x\S+>"
+    )
+
+    # Non-hashable because the hash function raises TypeError
+    class Meta2(type):
+
+        def __hash__(self):
+            raise TypeError()
+
+    class Case2(metaclass=Meta2):
+        pass
+
+    unittest.TestCase().assertRegex(
+        pretty.pretty(Case2()),
+        r"<IPython.lib.tests.test_pretty.test_nonhashable_type.<locals>.Case2 at 0x\S+>"
+    )
+
+    return


### PR DESCRIPTION
Fix #12320

For more information, see: https://github.com/ipython/ipython/issues/12320