### PR TITLE
DOC: Fix --matplotlib class name

### DIFF
--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -54,7 +54,7 @@ Indicate that the following::
 
 is equivalent to::
 
-   $ ipython --TerminalIPythonApp.matplotlib='qt'
+   $ ipython --InteractiveShellApp.matplotlib='qt'
 
 Note that in the second form, you *must* use the equal sign, as the expression
 is evaluated as an actual Python assignment.  While in the above example the


### PR DESCRIPTION
I'm just reading these docs for the first time, and not familiar with ipython yet, but given that `TerminalIPythonApp` doesn't show up in the `--help-all` output for `--matplotlib` but `InteractiveShellApp` does, I believe the latter was intended in this section of `reference.rst`:

```
    $ ipython --help-all
    <...snip...>
    --matplotlib=<CaselessStrEnum> (InteractiveShellApp.matplotlib)
        Default: None
        Choices: ['auto', 'gtk', 'gtk3', 'inline', 'nbagg', 'notebook', 'osx', 'qt', 'qt4', 'qt5', 'tk', 'wx']
        Configure matplotlib for interactive use with the default matplotlib
        backend.
    <...snip...>


Indicate that the following::

   $ ipython --matplotlib qt


is equivalent to::

   $ ipython --TerminalIPythonApp.matplotlib='qt'
```