### PR TITLE
Fix auto formatting to be called only once.

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -130,8 +130,10 @@ def newline_or_execute_outer(shell):
         # if all we have after the cursor is whitespace: reformat current text
         # before cursor
         after_cursor = d.text[d.cursor_position:]
+        reformatted = False
         if not after_cursor.strip():
             reformat_text_before_cursor(b, d, shell)
+            reformatted = True
         if not (d.on_last_line or
                 d.cursor_position_row >= d.line_count - d.empty_line_count_at_the_end()
                 ):
@@ -142,7 +144,8 @@ def newline_or_execute_outer(shell):
             return
 
         if (status != 'incomplete') and b.accept_handler:
-            reformat_text_before_cursor(b, d, shell)
+            if not reformatted:
+                reformat_text_before_cursor(b, d, shell)
             b.validate_and_handle()
         else:
             if shell.autoindent:


### PR DESCRIPTION
There seem to be a small race-condition when trying to reformat the text
twice in a short amount of time where some of the non-changed test
diapear. For example

    async def b():pass

Lead to two reformatting where one does not see the `async` keyword
anymore., and would thus dedent the def by 1 space.