### PR TITLE
Fixed bug on windows where relative image path has wrong slashes

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -419,8 +419,8 @@ class EmbeddedSphinxShell(object):
         # insert relative path to image file in source 
         # as absolute path for Sphinx
         # sphinx expects a posix path, even on Windows
-        posix_path = pathlib.Path(savefig_dir,filename).as_posix()
-        outfile = '/' + os.path.relpath(posix_path, source_dir)
+        path = pathlib.Path(savefig_dir, filename)
+        outfile = '/' + path.relative_to(source_dir).as_posix()
 
         imagerows = ['.. image:: %s' % outfile]
 


### PR DESCRIPTION
On Windows, the `source_dir` is not posix and thus the call to `os.path.relpath` returns something like
'_build\\html\\_static'. This causes the image to not load as sphinx expects a posix path. Using `pathlib.Path` for all of the manipulation and calling `as_posix()` at the end ensures the value of `outfile` is always a posix string.