### PR TITLE
Fix GUI inputhook for qt 5.15.0

### DIFF
--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -45,7 +45,7 @@ def inputhook(context):
                                           QtCore.QSocketNotifier.Read)
         try:
             # connect the callback we care about before we turn it on
-            notifier.activated.connect(event_loop.exit)
+            notifier.activated.connect(lambda: event_loop.exit())
             notifier.setEnabled(True)
             # only start the event loop we are not already flipped
             if not context.input_is_ready():


### PR DESCRIPTION
this fixes #12350

minimal code that reproduces the error:
```python
import asyncio
from prompt_toolkit.eventloop import new_eventloop_with_inputhook
from IPython.terminal.pt_inputhooks.qt import inputhook

async def simple():
    await asyncio.sleep(0.1)

pt_loop = new_eventloop_with_inputhook(inputhook)
asyncio.set_event_loop(pt_loop)
for i in range(10):
    pt_loop.run_until_complete(simple())
```

If you run that script on it's own, you get to see the error that PySide is throwing, which is:
```
TypeError: Can't call meta function because I have no idea how to handle QSocketDescriptor
```
(in a normal `ipython --gui qt` session, the error is not invisible... the interpreter just doesn't accept any input)

changing the way `notifier.activated` is connected to `event_loop.exit` fixes the issue.  I can't say I completely understand _why_ `event_loop.exit` is no longer a valid callback for the connection in `5.15` ... (though I have seen this seemingly unnecessary lambda help in the past with Qt)

I'm not sure how to add a test for this, as it seems inputhooks in general aren't being tested?