### PR TITLE
use $SHELL in system_piped

### DIFF
--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -59,11 +59,12 @@ class ProcessHandler(object):
 
     @property
     def sh(self):
-        if self._sh is None:        
-            self._sh = pexpect.which('sh')
+        if self._sh is None:
+            shell_name = os.environ.get("SHELL", "sh")
+            self._sh = pexpect.which(shell_name)
             if self._sh is None:
-                raise OSError('"sh" shell not found')
-        
+                raise OSError('"{}" shell not found'.format(shell_name))
+
         return self._sh
 
     def __init__(self, logfile=None, read_timeout=None, terminate_timeout=None):


### PR DESCRIPTION
we already use this in [our call to subprocess.call](https://github.com/ipython/ipython/blob/c24e8af4bf631b51ddec077d13022aba00dcf30e/IPython/core/interactiveshell.py#L2489-L2492) in system_raw used in the terminal.

This makes kernel behavior (system_piped) better match terminal IPython (system_raw) on posix systems.

For an example that used to be different:

    !wc -l <(pwd)

with `SHELL=bash`

reported on discourse: https://discourse.jupyter.org/t/ipython-process-subsitution-and/4645