### PR TITLE
BF: wx inputhook

### DIFF
--- a/IPython/terminal/pt_inputhooks/wx.py
+++ b/IPython/terminal/pt_inputhooks/wx.py
@@ -177,11 +177,13 @@ def inputhook_wxphoenix(context):
 
     # Use a wx.Timer to periodically check whether input is ready - as soon as
     # it is, we exit the main loop
+    timer = wx.Timer()
+
     def poll(ev):
         if context.input_is_ready():
+            timer.Stop()
             app.ExitMainLoop()
 
-    timer = wx.Timer()
     timer.Start(poll_interval)
     timer.Bind(wx.EVT_TIMER, poll)
 


### PR DESCRIPTION
This PR contains a small, obvious bug fix to the `IPython.terminal.pt_inputhooks.wx` module. The bug does not cause any adverse behaviour when using `prompt_toolkit < 3`, but interferes with GUI integration when using `prompt_toolkit >= 3`.

