### PR TITLE
Fix exception causes in debugger.py

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -220,8 +220,8 @@ class Pdb(OldPdb):
             self.context = int(context)
             if self.context <= 0:
                 raise ValueError("Context must be a positive integer")
-        except (TypeError, ValueError):
-                raise ValueError("Context must be a positive integer")
+        except (TypeError, ValueError) as e:
+                raise ValueError("Context must be a positive integer") from e
 
         # `kwargs` ensures full compatibility with stdlib's `pdb.Pdb`.
         OldPdb.__init__(self, completekey, stdin, stdout, **kwargs)
@@ -326,8 +326,8 @@ class Pdb(OldPdb):
             context=int(context)
             if context <= 0:
                 raise ValueError("Context must be a positive integer")
-        except (TypeError, ValueError):
-                raise ValueError("Context must be a positive integer")
+        except (TypeError, ValueError) as e:
+                raise ValueError("Context must be a positive integer") from e
         try:
             for frame_lineno in self.stack:
                 self.print_stack_entry(frame_lineno, context=context)
@@ -342,8 +342,8 @@ class Pdb(OldPdb):
             context=int(context)
             if context <= 0:
                 raise ValueError("Context must be a positive integer")
-        except (TypeError, ValueError):
-                raise ValueError("Context must be a positive integer")
+        except (TypeError, ValueError) as e:
+                raise ValueError("Context must be a positive integer") from e
         print(self.format_stack_entry(frame_lineno, '', context), file=self.stdout)
 
         # vds: >>


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 