### PR TITLE
Update intro.rst

### DIFF
--- a/docs/source/config/intro.rst
+++ b/docs/source/config/intro.rst
@@ -93,12 +93,14 @@ hierarchy represent the value you would normally set on the ``c`` object of
     {
         "InteractiveShell": {
             "colors": "LightBG",
-            "editor": "nano"
         },
         "InteractiveShellApp": {
             "extensions": [
                 "myextension"
             ]
+        },
+        "TerminalInteractiveShell": {
+            "editor": "nano"
         }
     }
 
@@ -109,7 +111,7 @@ Is equivalent to the following ``ipython_config.py``::
     ]
 
     c.InteractiveShell.colors = 'LightBG'
-    c.InteractiveShell.editor = 'nano'
+    c.TerminalInteractiveShell.editor = 'nano'
 
 
 Command line arguments

--- a/docs/source/config/intro.rst
+++ b/docs/source/config/intro.rst
@@ -69,9 +69,9 @@ Example configuration file
         'fancy.ipy'
     ]
     c.InteractiveShell.colors = 'LightBG'
-    c.InteractiveShell.confirm_exit = False
-    c.InteractiveShell.editor = 'nano'
     c.InteractiveShell.xmode = 'Context'
+    c.TerminalInteractiveShell.confirm_exit = False
+    c.TerminalInteractiveShell.editor = 'nano'
 
     c.PrefilterManager.multi_line_specials = True
 


### PR DESCRIPTION
I searched in the ipython_config.py created by `ipython profile create` at this time, and I think some of the apis seems to be changed.

Questions:

1. I can't find similar items with `c.PrefilterManager.multi_line_specials` and `c.AliasManager.user_aliases` in my config. Don't know if they are still usable. I didn't edit them.
2. how to get the current value of magic commands? for example `%pbd`. If I directly type it, it will run and toggle the value.