### PR TITLE
Show make sure to flush hidden exception to screen.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -718,7 +718,13 @@ class VerboseTB(TBTools):
                 )
                 skipped = 0
             frames.append(self.format_record(r))
-
+        if skipped:
+            Colors = self.Colors  # just a shorthand + quicker name lookup
+            ColorsNormal = Colors.Normal  # used a lot
+            frames.append(
+                "    %s[... skipping hidden %s frame]%s\n"
+                % (Colors.excName, skipped, ColorsNormal)
+            )
 
         formatted_exception = self.format_exception(etype, evalue)
         if records:


### PR DESCRIPTION
This is really unlikely but can happen if the exception is raised from
within a stack of hidden frame, in which case we do want to say there
were some hidden frames.

I guess in that case we actually really want to not hide that last one,
but this might really be a rare case.

This is already fixed in the backport to 7.x