### PR TITLE
[Feature] tuple completion

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -780,14 +780,20 @@ def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], pre
     """
     prefix_tuple = extra_prefix if extra_prefix else ()
     Nprefix = len(prefix_tuple)
-    def filter_by_prefix_tuple(key):
+    def filter_prefix_tuple(key):
+        # Reject too short keys
         if len(key) <= Nprefix:
             return False
+        # Reject keys with non str/bytes in it
+        for k in key:
+            if not isinstance(k, (str, bytes)):
+                return False
+        # Reject keys that do not match the prefix
         for k, pt in zip(key, prefix_tuple):
             if k != pt:
                 return False
-        else:
-            return True
+        # All checks passed!
+        return True
 
     filtered_keys:List[Union[str,bytes]] = []
     def _add_to_filtered_keys(key):
@@ -796,7 +802,7 @@ def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], pre
 
     for k in keys:
         if isinstance(k, tuple):
-            if filter_by_prefix_tuple(k):
+            if filter_prefix_tuple(k):
                 _add_to_filtered_keys(k[Nprefix])
         else:
             _add_to_filtered_keys(k)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1641,6 +1641,14 @@ class IPCompleter(Completer):
             )
             \[   # open bracket
             \s*  # and optional whitespace
+            ((?:[uUbB]?  # string prefix (r not handled)
+                (?:
+                    '(?:[^']|(?<!\\)\\')*'
+                |
+                    "(?:[^"]|(?<!\\)\\")*"
+                )
+                \s*,\s*
+            )*)
             ([uUbB]?  # string prefix (r not handled)
                 (?:   # unclosed string
                     '(?:[^']|(?<!\\)\\')*

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -754,7 +754,7 @@ def get__all__entries(obj):
 
 
 def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], prefix: str, delims: str,
-                    prefix_tuple: Tuple[str, bytes]=()) -> Tuple[str, int, List[str]]:
+                    extra_prefix: Optional[Tuple[str, bytes]]=None) -> Tuple[str, int, List[str]]:
     """Used by dict_key_matches, matching the prefix to a list of keys
 
     Parameters
@@ -765,7 +765,7 @@ def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], pre
         Part of the text already typed by the user. E.g. `mydict[b'fo`
     delims:
         String of delimiters to consider when finding the current key.
-    prefix_tuple: optional
+    extra_prefix: optional
         Part of the text already typed in multi-key index cases. E.g. for 
         `mydict['foo', "bar", 'b`, this would be `('foo', 'bar')`.
 
@@ -778,6 +778,7 @@ def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], pre
     ``matches`` a list of replacement/completion
 
     """
+    prefix_tuple = extra_prefix if extra_prefix else ()
     Nprefix = len(prefix_tuple)
     def filter_by_prefix_tuple(key):
         if len(key) < Nprefix:
@@ -1708,12 +1709,9 @@ class IPCompleter(Completer):
         if not keys:
             return keys
 
-        if prefix0 != '':
-            tuple_prefix = eval(prefix0)
-        else:
-            tuple_prefix = tuple()
+        extra_prefix = eval(prefix0) if prefix0 != '' else None
 
-        closing_quote, token_offset, matches = match_dict_keys(keys, tuple_prefix, prefix, self.splitter.delims)
+        closing_quote, token_offset, matches = match_dict_keys(keys, prefix, self.splitter.delims, extra_prefix=extra_prefix)
         if not matches:
             return matches
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -786,19 +786,23 @@ def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], pre
         for k, pt in zip(key, prefix_tuple):
             if k != pt:
                 return False
-        return True
+        else:
+            return True
 
-    new_keys = []
+    filtered_keys:List[Union[str,bytes]] = []
+    def _add_to_filtered_keys(key):
+        if isinstance(key, (str, bytes)):
+            filtered_keys.append(key)
+
     for k in keys:
-        if isinstance(k, (str, bytes)):
-            new_keys.append(k)
-        elif isinstance(k, tuple) and filter_by_prefix_tuple(k):
-            new_keys.append(k[Nprefix])
+        if isinstance(k, tuple):
+            if filter_by_prefix_tuple(k):
+                _add_to_filtered_keys(k[Nprefix])
+        else:
+            _add_to_filtered_keys(k)
 
-    keys = new_keys
     if not prefix:
-        return '', 0, [repr(k) for k in keys
-                      if isinstance(k, (str, bytes))]
+        return '', 0, [repr(k) for k in filtered_keys]
     quote_match = re.search('["\']', prefix)
     assert quote_match is not None # silence mypy
     quote = quote_match.group()
@@ -814,7 +818,7 @@ def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], pre
     token_prefix = token_match.group()
 
     matched:List[str] = []
-    for key in keys:
+    for key in filtered_keys:
         try:
             if not key.startswith(prefix_str):
                 continue

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -781,7 +781,7 @@ def match_dict_keys(keys: List[Union[str, bytes, Tuple[Union[str, bytes]]]], pre
     prefix_tuple = extra_prefix if extra_prefix else ()
     Nprefix = len(prefix_tuple)
     def filter_by_prefix_tuple(key):
-        if len(key) < Nprefix:
+        if len(key) <= Nprefix:
             return False
         for k, pt in zip(key, prefix_tuple):
             if k != pt:

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -846,6 +846,35 @@ class TestCompleter(unittest.TestCase):
 
         match_dict_keys
 
+    def test_match_dict_keys_tuple(self):
+        """
+        Test that match_dict_keys called with extra prefix works on a couple of use case,
+        does return what expected, and does not crash.
+        """
+        delims = " \t\n`!@#$^&*()=+[{]}\\|;:'\",<>?"
+        
+        keys = [("foo", "bar"), ("foo", "oof"), ("foo", b"bar"), ('other', 'test')]
+
+        # Completion on first key == "foo"
+        assert match_dict_keys(keys, "'", delims=delims, extra_prefix=("foo",)) == ("'", 1, ["bar", "oof"])
+        assert match_dict_keys(keys, "\"", delims=delims, extra_prefix=("foo",)) == ("\"", 1, ["bar", "oof"])
+        assert match_dict_keys(keys, "'o", delims=delims, extra_prefix=("foo",)) == ("'", 1, ["oof"])
+        assert match_dict_keys(keys, "\"o", delims=delims, extra_prefix=("foo",)) == ("\"", 1, ["oof"])
+        assert match_dict_keys(keys, "b'", delims=delims, extra_prefix=("foo",)) == ("'", 2, ["bar"])
+        assert match_dict_keys(keys, "b\"", delims=delims, extra_prefix=("foo",)) == ("\"", 2, ["bar"])
+        assert match_dict_keys(keys, "b'b", delims=delims, extra_prefix=("foo",)) == ("'", 2, ["bar"])
+        assert match_dict_keys(keys, "b\"b", delims=delims, extra_prefix=("foo",)) == ("\"", 2, ["bar"])
+
+        # No Completion
+        assert match_dict_keys(keys, "'", delims=delims, extra_prefix=("no_foo",)) == ("'", 1, [])
+        assert match_dict_keys(keys, "'", delims=delims, extra_prefix=("fo",)) == ("'", 1, [])
+
+        keys = [('foo1', 'foo2', 'foo3', 'foo4'), ('foo1', 'foo2', 'bar', 'foo4')]
+        assert match_dict_keys(keys, "'foo", delims=delims, extra_prefix=('foo1',)) == ("'", 1, ["foo2", "foo2"])
+        assert match_dict_keys(keys, "'foo", delims=delims, extra_prefix=('foo1', 'foo2')) == ("'", 1, ["foo3"])
+        assert match_dict_keys(keys, "'foo", delims=delims, extra_prefix=('foo1', 'foo2', 'foo3')) == ("'", 1, ["foo4"])
+        assert match_dict_keys(keys, "'foo", delims=delims, extra_prefix=('foo1', 'foo2', 'foo3', 'foo4')) == ("'", 1, [])
+
     def test_dict_key_completion_string(self):
         """Test dictionary key completion for string keys"""
         ip = get_ipython()

--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -920,12 +920,16 @@ class TestCompleter(unittest.TestCase):
             "bad": None,
             object(): None,
             5: None,
+            ("abe", None): None,
+            (None, "abf"): None
         }
 
         _, matches = complete(line_buffer="d['a")
         nt.assert_in("abc", matches)
         nt.assert_in("abd", matches)
         nt.assert_not_in("bad", matches)
+        nt.assert_not_in("abe", matches)
+        nt.assert_not_in("abf", matches)
         assert not any(m.endswith(("]", '"', "'")) for m in matches), matches
 
         # check escaping and whitespace


### PR DESCRIPTION
## Rationale
The motivation of this PR is to be able to have tab completion for dict-like access of objects that accept tuples or multiple arguments as keys.

This feature would be useful to make better completion suggestions in the yt project (see e.g. https://github.com/yt-project/yt/pull/2637), which relies heavily on dict-like access where the keys are two keywords (for example `ds['gas','density']`).

## Example
```python
class Foo(dict):
    def __init__(self):
        self['foo', 'bar'] = 1
        self['foo', 'baz'] = 2
        self['foo', 'foobar'] = 3
        self['foo', 'barfoo'] = 4
        self['oof', 'oof'] = 5

    def _ipython_key_completions_(self, *args): 
        return self.keys()

f = Foo()
f['foo', 'ba<TAB>  # shows bar, baz, barfoo
f['<TAB>           # shows foo, oof
```
![image](https://user-images.githubusercontent.com/5411875/84917629-7a904380-b0b7-11ea-9f07-c1ccdedf781a.png)

If the extra prefix (the `foo` in the above example) is not a str, then no completion should happen.

## TODO:
- [x] write tests
