### PR TITLE
PR: Move extraction of local scope to a method

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2322,10 +2322,20 @@ class InteractiveShell(SingletonConfigurable):
             kwargs = {}
             # Grab local namespace if we need it:
             if getattr(fn, "needs_local_scope", False):
-                kwargs['local_ns'] = sys._getframe(stack_depth).f_locals
+                kwargs['local_ns'] = self.get_local_scope(stack_depth)
             with self.builtin_trap:
                 result = fn(*args, **kwargs)
             return result
+
+    def get_local_scope(self, stack_depth):
+        """Get local scope at given stack depth.
+
+        Parameters
+        ----------
+        stack_depth : int
+          Depth relative to calling frame
+        """
+        return sys._getframe(stack_depth + 1).f_locals
 
     def run_cell_magic(self, magic_name, line, cell):
         """Execute the given cell magic.


### PR DESCRIPTION
When calling ipython magic from pdb, the locals need to be set from the pdb locals, which is different from the frame locals. Moving this call to a method enables a subclass to change the behaviour of `get_local_scope` to make this possible. This would enable using `%timeit` while debugging in Spyder for example.