### PR TITLE
Allow spaces when using debug magic

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -451,7 +451,13 @@ class ExecutionMagics(Magics):
 
         if not (args.breakpoint or args.statement or cell):
             self._debug_post_mortem()
+        elif not (args.breakpoint or cell):
+            # If there is no breakpoints, the line is just code to execute
+            self._debug_exec(line, None)
         else:
+            # Here we try to reconstruct the code from the output of
+            # parse_argstring. This might not work if the code has spaces
+            # For example this fails for `print("a b")`
             code = "\n".join(args.statement)
             if cell:
                 code += "\n" + cell

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -599,6 +599,19 @@ def doctest_precision():
     Out[5]: '3.141593e+00'
     """
 
+def test_debug_magic():
+    """Test debugging a small code with %debug
+    
+    In [1]: %debug print("a b")
+    NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
+    > <string>(1)<module>()
+
+    ipdb> c
+    a b
+
+    In [2]:
+    """
+
 def test_psearch():
     with tt.AssertPrints("dict.fromkeys"):
         _ip.run_cell("dict.fr*?")

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -32,6 +32,7 @@ from IPython.utils.io import capture_output
 from IPython.utils.tempdir import (TemporaryDirectory,
                                     TemporaryWorkingDirectory)
 from IPython.utils.process import find_cmd
+from .test_debugger import PdbTestInput
 
 
 @magic.magics_class
@@ -602,13 +603,13 @@ def doctest_precision():
 def test_debug_magic():
     """Test debugging a small code with %debug
     
-    In [1]: %debug print("a b")
+    In [1]: with PdbTestInput(['c']):
+       ...:     %debug print("a b")
+       ...:
     NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
     > <string>(1)<module>()
-
     ipdb> c
     a b
-
     In [2]:
     """
 

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -604,7 +604,7 @@ def test_debug_magic():
     """Test debugging a small code with %debug
     
     In [1]: with PdbTestInput(['c']):
-       ...:     %debug print("a b")
+       ...:     %debug print("a b") #doctest: +ELLIPSIS
        ...:
     ...
     ipdb> c

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -607,7 +607,6 @@ def test_debug_magic():
        ...:     %debug print("a b")
        ...:
     NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
-    > <string>(1)<module>()
     ipdb> c
     a b
     In [2]:

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -606,7 +606,7 @@ def test_debug_magic():
     In [1]: with PdbTestInput(['c']):
        ...:     %debug print("a b")
        ...:
-    NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
+    ...
     ipdb> c
     a b
     In [2]:


### PR DESCRIPTION
This fixes #11931 if no arguments are given