### PR TITLE
Compatibility with traitlets 5.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     fi
   - pip install -e file://$PWD#egg=ipython[test] --upgrade
   - pip install trio curio --upgrade --upgrade-strategy eager
-  - pip install pytest 'matplotlib !=3.2.0' mypy
+  - pip install 'pytest<6' 'matplotlib !=3.2.0' mypy
   - pip install codecov check-manifest --upgrade
   - pip install mypy
   - |

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -432,7 +432,7 @@ class BaseFormatter(Configurable):
         """Add a format function for a given type.
         
         Parameters
-        -----------
+        ----------
         typ : type or '__module__.__name__' string for a type
             The class of the object that will be formatted using `func`.
         func : callable

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -198,7 +198,7 @@ def ipexec(fname, options=None, commands=()):
     ipython_cmd = get_ipython_cmd()
     # Absolute path for filename
     full_fname = os.path.join(test_dir, fname)
-    full_cmd = ipython_cmd + cmdargs + [full_fname]
+    full_cmd = ipython_cmd + cmdargs + ['--', full_fname]
     env = os.environ.copy()
     # FIXME: ignore all warnings in ipexec while we have shims
     # should we keep suppressing warnings here, even after removing shims?


### PR DESCRIPTION
This now uses argparse which parses things a bit differently, and in
particular needs -- to execure a file and not assume that --profile get
a list of items.