### PR TITLE
Pin traitlets to a Python3.5 compatible version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ install_requires = [
     'jedi>=0.10',
     'decorator',
     'pickleshare',
-    'traitlets>=4.2',
+    'traitlets<5',
     'prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1',
     'pygments',
     'backcall',


### PR DESCRIPTION
ipython 7.x guarantees compatibility with Python<3.6 in its README.
`traitlets>=5` uses the `f''` string formatting which only exists in 3.6,
so traitlets 5.x should be avoided on this branch.