### PR TITLE
more useful feedback on style checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,14 +57,24 @@ script:
        # on nightly fake parso known the grammar
        cp /home/travis/virtualenv/python3.9-dev/lib/python3.9/site-packages/parso/python/grammar38.txt /home/travis/virtualenv/python3.9-dev/lib/python3.9/site-packages/parso/python/grammar39.txt
     fi
+  - |
+    # check style on changes
+    # run `darker -r master` and commit changes to fix
+    if [[ "${TRAVIS_PULL_REQUEST:-false}" != "false" ]] \
+    && [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]] \
+    && [[ "$TRAVIS_OS_NAME" == "linux" ]];
+    then
+      darker -r ${TRAVIS_COMMIT_RANGE%%.*} --check --diff . || (
+        echo "Changes need auto-formatting. Run:"
+        echo "    darker -r ${TRAVIS_COMMIT_RANGE%%.*}"
+        echo "then commit and push changes to fix."
+        exit 1
+      )
+    fi
   - cd /tmp && iptest --coverage xml && cd -
   - pytest IPython
   - mypy IPython/terminal/ptutils.py
   - mypy IPython/core/c*.py
-  - |
-    if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      darker -r 60625f241f298b5039cb2debc365db38aa7bb522 --check --diff .
-    fi
   # On the latest Python (on Linux) only, make sure that the docs build.
   - |
     if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then


### PR DESCRIPTION
follow-up to #12502 

- give copy-pasteable command to fix formatting with `darker`
- use $TRAVIS_COMMIT_RANGE to limit to PR, instead of hardcoded ref
- only run on pull requests
- run style check before tests, for quicker feedback

For example feedback, see [this run](https://travis-ci.org/github/ipython/ipython/jobs/724854948#L471-L473):

```
Changes need auto-formatting. Run:
    darker -r c4780a39d4d176bd73880658b1c9e8fca62acaf0
then commit and push changes to fix.
```