### PR TITLE
Automatic matching of brackets and quotes

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -188,6 +188,15 @@ class TerminalInteractiveShell(InteractiveShell):
         allow_none=True
     ).tag(config=True)
 
+    auto_match = Bool(
+        False,
+        help="""
+        Automatically add/delete closing bracket or quote when opening bracket or quote is entered/deleted.
+        Brackets: (), [], {}
+        Quotes: '', \"\"
+        """,
+    ).tag(config=True)
+
     mouse_support = Bool(False,
         help="Enable mouse support in the prompt\n(Note: prevents selecting text with the mouse)"
     ).tag(config=True)

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -89,7 +89,6 @@ def create_ipython_shortcuts(shell):
     _preceding_text_cache = {}
     _following_text_cache = {}
 
-
     def preceding_text(pattern):
         try:
             return _preceding_text_cache[pattern]
@@ -104,7 +103,6 @@ def create_ipython_shortcuts(shell):
         condition = Condition(_preceding_text)
         _preceding_text_cache[pattern] = condition
         return condition
-
 
     def following_text(pattern):
         try:
@@ -121,19 +119,18 @@ def create_ipython_shortcuts(shell):
         _following_text_cache[pattern] = condition
         return condition
 
-
     # auto match
-    @kb.add('(', filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add("(", filter=focused_insert & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text("()")
         event.current_buffer.cursor_left()
 
-    @kb.add('[', filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add("[", filter=focused_insert & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text("[]")
         event.current_buffer.cursor_left()
 
-    @kb.add('{', filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add("{", filter=focused_insert & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text("{}")
         event.current_buffer.cursor_left()
@@ -149,23 +146,32 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.cursor_left()
 
     # raw string
-    @kb.add('(', filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
+    @kb.add("(", filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
     def _(event):
-        matches = re.match(r".*(r|R)[\"'](-*)", event.current_buffer.document.current_line_before_cursor)
+        matches = re.match(
+            r".*(r|R)[\"'](-*)",
+            event.current_buffer.document.current_line_before_cursor,
+        )
         dashes = matches.group(2) or ""
         event.current_buffer.insert_text("()" + dashes)
         event.current_buffer.cursor_left(len(dashes) + 1)
 
-    @kb.add('[', filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
+    @kb.add("[", filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
     def _(event):
-        matches = re.match(r".*(r|R)[\"'](-*)", event.current_buffer.document.current_line_before_cursor)
+        matches = re.match(
+            r".*(r|R)[\"'](-*)",
+            event.current_buffer.document.current_line_before_cursor,
+        )
         dashes = matches.group(2) or ""
         event.current_buffer.insert_text("[]" + dashes)
         event.current_buffer.cursor_left(len(dashes) + 1)
 
-    @kb.add('{', filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
+    @kb.add("{", filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
     def _(event):
-        matches = re.match(r".*(r|R)[\"'](-*)", event.current_buffer.document.current_line_before_cursor)
+        matches = re.match(
+            r".*(r|R)[\"'](-*)",
+            event.current_buffer.document.current_line_before_cursor,
+        )
         dashes = matches.group(2) or ""
         event.current_buffer.insert_text("{}" + dashes)
         event.current_buffer.cursor_left(len(dashes) + 1)
@@ -181,30 +187,48 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.cursor_left()
 
     # just move cursor
-    @kb.add(')', filter=focused_insert & following_text(r"^\)"))
-    @kb.add(']', filter=focused_insert & following_text(r"^\]"))
-    @kb.add('}', filter=focused_insert & following_text(r"^\}"))
-    @kb.add('"', filter=focused_insert & following_text("^\""))
+    @kb.add(")", filter=focused_insert & following_text(r"^\)"))
+    @kb.add("]", filter=focused_insert & following_text(r"^\]"))
+    @kb.add("}", filter=focused_insert & following_text(r"^\}"))
+    @kb.add('"', filter=focused_insert & following_text('^"'))
     @kb.add("'", filter=focused_insert & following_text("^'"))
     def _(event):
         event.current_buffer.cursor_right()
 
-    @kb.add('backspace', filter=focused_insert & preceding_text(r".*\($") & following_text(r"^\)"))
-    @kb.add('backspace', filter=focused_insert & preceding_text(r".*\[$") & following_text(r"^\]"))
-    @kb.add('backspace', filter=focused_insert & preceding_text(r".*\{$") & following_text(r"^\}"))
-    @kb.add('backspace', filter=focused_insert & preceding_text('.*"$') & following_text('^"'))
-    @kb.add('backspace', filter=focused_insert & preceding_text(r".*'$") & following_text(r"^'"))
+    @kb.add(
+        "backspace",
+        filter=focused_insert & preceding_text(r".*\($") & following_text(r"^\)"),
+    )
+    @kb.add(
+        "backspace",
+        filter=focused_insert & preceding_text(r".*\[$") & following_text(r"^\]"),
+    )
+    @kb.add(
+        "backspace",
+        filter=focused_insert & preceding_text(r".*\{$") & following_text(r"^\}"),
+    )
+    @kb.add(
+        "backspace",
+        filter=focused_insert & preceding_text('.*"$') & following_text('^"'),
+    )
+    @kb.add(
+        "backspace",
+        filter=focused_insert & preceding_text(r".*'$") & following_text(r"^'"),
+    )
     def _(event):
         event.current_buffer.delete()
         event.current_buffer.delete_before_cursor()
 
-
-    if shell.display_completions == 'readlinelike':
-        kb.add('c-i', filter=(has_focus(DEFAULT_BUFFER)
-                              & ~has_selection
-                              & insert_mode
-                              & ~cursor_in_leading_ws
-                        ))(display_completions_like_readline)
+    if shell.display_completions == "readlinelike":
+        kb.add(
+            "c-i",
+            filter=(
+                has_focus(DEFAULT_BUFFER)
+                & ~has_selection
+                & insert_mode
+                & ~cursor_in_leading_ws
+            ),
+        )(display_completions_like_readline)
 
     if sys.platform == "win32":
         kb.add("c-v", filter=(has_focus(DEFAULT_BUFFER) & ~vi_mode))(win_paste)

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -85,6 +85,10 @@ def create_ipython_shortcuts(shell):
 
     kb.add('f2', filter=has_focus(DEFAULT_BUFFER))(open_input_in_editor)
 
+    @Condition
+    def auto_match():
+        return shell.auto_match
+
     focused_insert = (vi_insert_mode | emacs_insert_mode) & has_focus(DEFAULT_BUFFER)
     _preceding_text_cache = {}
     _following_text_cache = {}
@@ -120,27 +124,27 @@ def create_ipython_shortcuts(shell):
         return condition
 
     # auto match
-    @kb.add("(", filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add("(", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text("()")
         event.current_buffer.cursor_left()
 
-    @kb.add("[", filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add("[", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text("[]")
         event.current_buffer.cursor_left()
 
-    @kb.add("{", filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add("{", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text("{}")
         event.current_buffer.cursor_left()
 
-    @kb.add('"', filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add('"', filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text('""')
         event.current_buffer.cursor_left()
 
-    @kb.add("'", filter=focused_insert & following_text(r"[,)}\]]|$"))
+    @kb.add("'", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))
     def _(event):
         event.current_buffer.insert_text("''")
         event.current_buffer.cursor_left()
@@ -187,33 +191,48 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.cursor_left()
 
     # just move cursor
-    @kb.add(")", filter=focused_insert & following_text(r"^\)"))
-    @kb.add("]", filter=focused_insert & following_text(r"^\]"))
-    @kb.add("}", filter=focused_insert & following_text(r"^\}"))
-    @kb.add('"', filter=focused_insert & following_text('^"'))
-    @kb.add("'", filter=focused_insert & following_text("^'"))
+    @kb.add(")", filter=focused_insert & auto_match & following_text(r"^\)"))
+    @kb.add("]", filter=focused_insert & auto_match & following_text(r"^\]"))
+    @kb.add("}", filter=focused_insert & auto_match & following_text(r"^\}"))
+    @kb.add('"', filter=focused_insert & auto_match & following_text('^"'))
+    @kb.add("'", filter=focused_insert & auto_match & following_text("^'"))
     def _(event):
         event.current_buffer.cursor_right()
 
     @kb.add(
         "backspace",
-        filter=focused_insert & preceding_text(r".*\($") & following_text(r"^\)"),
+        filter=focused_insert
+        & preceding_text(r".*\($")
+        & auto_match
+        & following_text(r"^\)"),
     )
     @kb.add(
         "backspace",
-        filter=focused_insert & preceding_text(r".*\[$") & following_text(r"^\]"),
+        filter=focused_insert
+        & preceding_text(r".*\[$")
+        & auto_match
+        & following_text(r"^\]"),
     )
     @kb.add(
         "backspace",
-        filter=focused_insert & preceding_text(r".*\{$") & following_text(r"^\}"),
+        filter=focused_insert
+        & preceding_text(r".*\{$")
+        & auto_match
+        & following_text(r"^\}"),
     )
     @kb.add(
         "backspace",
-        filter=focused_insert & preceding_text('.*"$') & following_text('^"'),
+        filter=focused_insert
+        & preceding_text('.*"$')
+        & auto_match
+        & following_text('^"'),
     )
     @kb.add(
         "backspace",
-        filter=focused_insert & preceding_text(r".*'$") & following_text(r"^'"),
+        filter=focused_insert
+        & preceding_text(r".*'$")
+        & auto_match
+        & following_text(r"^'"),
     )
     def _(event):
         event.current_buffer.delete()


### PR DESCRIPTION
This PR 
1. implements insertion and deletion of matched brackets and quotes
2. makes changes to [IPython/terminal/shortcuts.py](https://github.com/ipython/ipython/pull/12586/files#diff-e9a59ec7c6360d84aafa289edca1c50b)
3. shamelessly borrows code from [randy3k/radian](https://github.com/randy3k/radian/blob/a57f0b50ae8a7f4f152d6b4d3b9d63c365eec788/radian/key_bindings.py#L171)

Example:
1. Start ipython
2. Press `(`, `[`, `{`, `'`, or `"` to insert a pair of round/square/curly brackets or single/double quotes with the cursor inside
3. Press `backspace` or ctrl h to delete the inserted bracket or quote pair

To install to version of `ipython` in this pull request, run
`python -m pip install git+https://github.com/mskar/ipython.git@auto_match`