### PR TITLE
Cursor shape changes with vi editing mode

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -12,8 +12,19 @@ from IPython.utils.py3compat import input
 from IPython.utils.terminal import toggle_set_term_title, set_term_title, restore_term_title
 from IPython.utils.process import abbrev_cwd
 from traitlets import (
-    Bool, Unicode, Dict, Integer, observe, Instance, Type, default, Enum, Union,
-    Any, validate
+    Bool,
+    Unicode,
+    Dict,
+    Integer,
+    observe,
+    Instance,
+    Type,
+    default,
+    Enum,
+    Union,
+    Any,
+    validate,
+    Float,
 )
 
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
@@ -140,6 +151,25 @@ class TerminalInteractiveShell(InteractiveShell):
     emacs_bindings_in_vi_insert_mode = Bool(
         True,
         help="Add shortcuts from 'emacs' insert mode to 'vi' insert mode.",
+    ).tag(config=True)
+
+    modal_cursor = Bool(
+        True,
+        help="""
+       Cursor shape changes depending on vi mode: beam in vi insert mode,
+       block in nav mode, underscore in replace mode.""",
+    ).tag(config=True)
+
+    ttimeoutlen = Float(
+        0.01,
+        help="""The time in milliseconds that is waited for a key code
+       to complete.""",
+    ).tag(config=True)
+
+    timeoutlen = Float(
+        0.5,
+        help="""The time in milliseconds that is waited for a mapped key
+       sequence to complete.""",
     ).tag(config=True)
 
     autoformatter = Unicode(None,

--- a/docs/autogen_shortcuts.py
+++ b/docs/autogen_shortcuts.py
@@ -41,12 +41,14 @@ def multi_filter_str(flt):
 log_filters = {'_AndList': 'And', '_OrList': 'Or'}
 log_invert =  {'_Invert'}
 
-class _DummyTerminal(object):
+class _DummyTerminal:
     """Used as a buffer to get prompt_toolkit bindings
     """
     handle_return = None
     input_transformer_manager = None
     display_completions = None
+    editing_mode = "emacs"
+
 
 ipy_bindings = create_ipython_shortcuts(_DummyTerminal()).bindings
 


### PR DESCRIPTION
This pull request implements a vim mode-dependent cursor.

The cursor shape is 
- beam in Insert mode:
![image](https://user-images.githubusercontent.com/13444106/94983026-31042100-050d-11eb-90d6-3be825ff41cb.png)
![image](https://user-images.githubusercontent.com/13444106/94983051-5ee96580-050d-11eb-89e1-efebd480bfad.png)
- block in Nav (Normal) mode
![image](https://user-images.githubusercontent.com/13444106/94983035-3b261f80-050d-11eb-807a-10bd6927e8d8.png)
![image](https://user-images.githubusercontent.com/13444106/94983054-67da3700-050d-11eb-8651-ad2186d9a225.png)
- underscore in Replace mode
![image](https://user-images.githubusercontent.com/13444106/94983041-48dba500-050d-11eb-903e-4a5b13d0f813.png)
![image](https://user-images.githubusercontent.com/13444106/94983072-71fc3580-050d-11eb-9b97-600b38534262.png)

The code is based on [a prompt_toolkit issue](https://github.com/prompt-toolkit/python-prompt-toolkit/issues/192#issuecomment-557800620).

I put the cursor code in `IPython/terminal/shortcuts.py`, because the imported classes are from `prompt_toolkit`'s `key_binding` module. This may be a stretch, but pressing keyboard shortcuts switches modes and changes the cursor shape.

This PR only effects vi mode.

This feature is enabled by default can be disabled by adding 
```python
c.InteractiveShell.modal_cursor = False
```
to `ipython_config.py`. 

To install a version of ipython with the modal cursor, run the line below.

`python -m pip install git+https://github.com/mskar/ipython.git@vim_cursor`