### PR TITLE
Provide option for tab to apply completion

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -142,6 +142,32 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Add shortcuts from 'emacs' insert mode to 'vi' insert mode.",
     ).tag(config=True)
 
+    auto_complete_function_parentheses = Bool(True,
+    help="Add parentheses when autocompleting functions.",
+    ).tag(config=True)
+
+    auto_complete_selected_option_on_tab = Bool(True,
+        help="""When the completion menu is showing
+        and a completion option is selected,
+        apply the currently selected completion option with tab.""",
+    ).tag(config=True)
+
+    auto_complete_top_option_on_enter = Bool(True,
+        help="""When the completion menu is showing,
+        but no completion options are selected,
+        apply the first completion menu option with enter.""",
+    ).tag(config=True)
+
+    auto_complete_top_option_on_tab = Bool(True,
+        help="""When the completion menu is showing
+        and no completion options are selected,
+        apply the first completion menu option with tab.""",
+    ).tag(config=True)
+
+    auto_complete_only_option_on_tab = Bool(True,
+        help="When there is only one completion option, apply it with tab.",
+    ).tag(config=True)
+
     autoformatter = Unicode(None,
         help="Autoformatter to reformat Terminal code. Can be `'black'` or `None`",
         allow_none=True


### PR DESCRIPTION
In #12575, I requested a feature that adds parentheses after functions completed with `Tab` or `Enter`. 
This pull request implements the feature I requested (function completion with added parentheses), but also strives to make autocompletion work like in the VSCode Python extension and PyCharm. In VSCode and PyCharm, `Tab` applies completion instead of cycling through completion options, like in bash or zsh.

This feature is enabled by default, but it can be disabled by adding 
```python
c.InteractiveShell.tab_apply_completion = False
```
to `ipython_config.py`. 

For more information, please take a look at [this comment](https://github.com/ipython/ipython/issues/12575#issuecomment-702484214) in #12575.

To install IPython with the `tab_apply_completion` feature, run 
`python -m pip install git+https://github.com/mskar/ipython.git@tab_apply_completion`
## TLDR: 
previous behavior: 
- `Tab` cycles completion
- function completion does not add parentheses 

proposed behavior: 
- `Tab` applies completion
- function completion adds parentheses

## Changes:
Changed: when triggering completion with `Tab`, insert text that all options have in common
Changed: use `Tab` to accept only option or accept selected
Changed: do not move through options with not `Tab` and `Shift-Tab`
Unchanged: use `Enter` to accept if completion menu is showing
Unchanged: move through options with `c-n` and `c-p`
Unchanged: cancel completion with `c-g`