### PR TITLE
use pathlib on test_deepreload.py

### DIFF
--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -12,21 +12,22 @@ from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.tempdir import TemporaryDirectory
 from IPython.lib.deepreload import reload as dreload
 
+
 def test_deepreload():
     "Test that dreload does deep reloads and skips excluded modules."
     with TemporaryDirectory() as tmpdir:
         with prepended_to_syspath(tmpdir):
             tmpdirpath = Path(tmpdir)
-            with open( tmpdirpath / 'A.py' , 'w') as f:
+            with open(tmpdirpath / "A.py", "w") as f:
                 f.write("class Object(object):\n    pass\n")
-            with open( tmpdirpath / 'B.py' , 'w') as f:
+            with open(tmpdirpath / "B.py", "w") as f:
                 f.write("import A\n")
             import A
             import B
 
             # Test that A is not reloaded.
             obj = A.Object()
-            dreload(B, exclude=['A'])
+            dreload(B, exclude=["A"])
             nt.assert_true(isinstance(obj, A.Object))
 
             # Test that A is reloaded.

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -4,7 +4,7 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import os
+from pathlib import Path
 
 import nose.tools as nt
 
@@ -16,9 +16,10 @@ def test_deepreload():
     "Test that dreload does deep reloads and skips excluded modules."
     with TemporaryDirectory() as tmpdir:
         with prepended_to_syspath(tmpdir):
-            with open(os.path.join(tmpdir, 'A.py'), 'w') as f:
+            tmpdirpath = Path(tmpdir)
+            with open( tmpdirpath / 'A.py' , 'w') as f:
                 f.write("class Object(object):\n    pass\n")
-            with open(os.path.join(tmpdir, 'B.py'), 'w') as f:
+            with open( tmpdirpath / 'B.py' , 'w') as f:
                 f.write("import A\n")
             import A
             import B


### PR DESCRIPTION
Using pathlib.Path() for better readability.

See #12515