### PR TITLE
Always display last frame when show tracebacks with hidden frames.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -290,7 +290,7 @@ class Pdb(OldPdb):
 
     def hidden_frames(self, stack):
         """
-        Given an index in the stack return wether it should be skipped.
+        Given an index in the stack return whether it should be skipped.
 
         This is used in up/down and where to skip frames.
         """
@@ -713,7 +713,9 @@ class Pdb(OldPdb):
                     break
             else:
                 # if no break occured.
-                self.error("all frames above hidden")
+                self.error(
+                    "all frames above hidden, use `skip_hidden False` to get get into those."
+                )
                 return
 
             Colors = self.color_scheme_table.active_colors
@@ -756,7 +758,9 @@ class Pdb(OldPdb):
                 if counter >= count:
                     break
             else:
-                self.error("all frames bellow hidden")
+                self.error(
+                    "all frames bellow hidden, use `skip_hidden False` to get get into those."
+                )
                 return
 
             Colors = self.color_scheme_table.active_colors

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -699,9 +699,10 @@ class VerboseTB(TBTools):
 
         frames = []
         skipped = 0
-        for r in records:
+        lastrecord = len(records) - 1
+        for i, r in enumerate(records):
             if not isinstance(r, stack_data.RepeatedFrames) and self.skip_hidden:
-                if r.frame.f_locals.get("__tracebackhide__", 0):
+                if r.frame.f_locals.get("__tracebackhide__", 0) and i != lastrecord:
                     skipped += 1
                     continue
             if skipped:


### PR DESCRIPTION
Partial toward #12565,

This is slightly more complicated when we start the debugger as we would
need to track which frame we started on.