### PR TITLE
Transmute existing IPython CLI into a kernel. 

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -339,6 +339,22 @@ class ExecutionResult(object):
 class InteractiveShell(SingletonConfigurable):
     """An enhanced, interactive shell for Python."""
 
+    def set_parent(self, parent):
+        """Set the parent header for associating output with its triggering input"""
+        self.parent_header = parent
+        parent#self.displayhook.set_parent(parent)
+        #self.display_pub.set_parent(parent)
+        if hasattr(self, '_data_pub'):
+            self.data_pub.set_parent(parent)
+        try:
+            sys.stdout.set_parent(parent)
+        except AttributeError:
+            pass
+        try:
+            sys.stderr.set_parent(parent)
+        except AttributeError:
+            pass
+
     _instance = None
     
     ast_transformers = List([], help=

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -115,6 +115,7 @@ class Multipleton(Configurable):
 
     @classmethod
     def instance(cls, *args, **kwargs):
+        raise ValueError
         if not cls._instances:
             cls(*args, **kwargs)
         return cls._instances[-1]

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -102,23 +102,33 @@ except ImportError:
     sphinxify = None
 
 
-class Multipleton(Configurable):
+from contextlib import contextmanager
 
-    _instances = []
+class Multipleton(SingletonConfigurable):
+    """
+    Subclass of singleton configurable that allow limited nested of SingletonConfigurable
 
-    def __init__(self, *args, **kwargs):
-        self._instances.append(self)
-
-    @classmethod
-    def initialized(cls):
-        return hasattr(cls, "_instance") and cls._instance
+    """
 
     @classmethod
-    def instance(cls, *args, **kwargs):
-        raise ValueError
-        if not cls._instances:
-            cls(*args, **kwargs)
-        return cls._instances[-1]
+    @contextmanager
+    def nest(cls):
+        save = cls._instance
+        try:
+            cls._instance = None
+            yield
+        except BaseException:
+            cls._instance = save
+
+    # def __init__(self, *args, **kwargs):
+    #    self._instances.append(self)
+
+    # @classmethod
+    # def instance(cls, *args, **kwargs):
+    #    raise ValueError
+    #    if not cls._instances:
+    #        cls(*args, **kwargs)
+    #    return cls._instances[-1]
 
 
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -30,7 +30,7 @@ from io import open as io_open
 
 from pickleshare import PickleShareDB
 
-from traitlets.config.configurable import SingletonConfigurable
+from traitlets.config.configurable import SingletonConfigurable, Configurable
 from traitlets.utils.importstring import import_item
 from IPython.core import oinspect
 from IPython.core import magic
@@ -100,6 +100,25 @@ try:
             }
 except ImportError:
     sphinxify = None
+
+
+class Multipleton(Configurable):
+
+    _instances = []
+
+    def __init__(self, *args, **kwargs):
+        self._instances.append(self)
+
+    @classmethod
+    def initialized(cls):
+        return hasattr(cls, "_instance") and cls._instance
+
+    @classmethod
+    def instance(cls, *args, **kwargs):
+        if not cls._instances:
+            cls(*args, **kwargs)
+        return cls._instances[-1]
+
 
 
 class ProvisionalWarning(DeprecationWarning):
@@ -336,7 +355,7 @@ class ExecutionResult(object):
                 (name, id(self), self.execution_count, self.error_before_exec, self.error_in_exec, repr(self.info), repr(self.result))
 
 
-class InteractiveShell(SingletonConfigurable):
+class InteractiveShell(Multipleton):
     """An enhanced, interactive shell for Python."""
 
     def set_parent(self, parent):

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -328,7 +328,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         # shell.display_banner should always be False for the terminal
         # based app, because we call shell.show_banner() by hand below
         # so the banner shows *before* all extension loading stuff.
-        self.shell = self.interactive_shell_class(
+        self.shell = self.interactive_shell_class.instance(
             parent=self,
             profile_dir=self.profile_dir,
             ipython_dir=self.ipython_dir,

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -328,9 +328,12 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         # shell.display_banner should always be False for the terminal
         # based app, because we call shell.show_banner() by hand below
         # so the banner shows *before* all extension loading stuff.
-        self.shell = self.interactive_shell_class.instance(parent=self,
-                        profile_dir=self.profile_dir,
-                        ipython_dir=self.ipython_dir, user_ns=self.user_ns)
+        self.shell = self.interactive_shell_class(
+            parent=self,
+            profile_dir=self.profile_dir,
+            ipython_dir=self.ipython_dir,
+            user_ns=self.user_ns,
+        )
         self.shell.configurables.append(self)
 
     def init_banner(self):

--- a/kernelify
+++ b/kernelify
@@ -1,0 +1,5 @@
+from ipykernel.kernelapp import IPKernelApp
+from ipykernel.kernelapp import IPythonKernel
+app = IPKernelApp(shell=shell)
+app.initialize()
+app.start()


### PR DESCRIPTION
Flip side of https://github.com/ipython/ipykernel/pull/550

Right now this looks like

```
In [2]: from ipykernel.kernelapp import IPKernelApp
   ...: from ipykernel.kernelapp import IPythonKernel
   ...: shell = get_ipython()
   ...: app = IPKernelApp(shell=shell)
   ...: app.initialize(shell=shell)
   ...: app.start()
NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049

To connect another client to this kernel, use:
    --existing kernel-55116.json
```

On a second console you can do "jupyter console --existing", and connect to original IPython.
