### PR TITLE
Enable emacs keybindings in vi insert mode (ebivim)

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -137,6 +137,10 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Shortcut style to use at the prompt. 'vi' or 'emacs'.",
     ).tag(config=True)
 
+    emacs_bindings_in_vi_insert_mode = Bool(True,
+        help="Add shortcuts from 'emacs' insert mode to 'vi' insert mode.",
+    ).tag(config=True)
+
     autoformatter = Unicode(None,
         help="Autoformatter to reformat Terminal code. Can be `'black'` or `None`",
         allow_none=True

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -137,7 +137,8 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Shortcut style to use at the prompt. 'vi' or 'emacs'.",
     ).tag(config=True)
 
-    emacs_bindings_in_vi_insert_mode = Bool(True,
+    emacs_bindings_in_vi_insert_mode = Bool(
+        True,
         help="Add shortcuts from 'emacs' insert mode to 'vi' insert mode.",
     ).tag(config=True)
 

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -18,6 +18,7 @@ from prompt_toolkit.filters import (has_focus, has_selection, Condition,
     vi_insert_mode, emacs_insert_mode, has_completions, vi_mode)
 from prompt_toolkit.key_binding.bindings.completion import display_completions_like_readline
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.bindings import named_commands as nc
 
 from IPython.utils.decorators import undoc
 
@@ -91,6 +92,74 @@ def create_ipython_shortcuts(shell):
 
     if sys.platform == 'win32':
         kb.add('c-v', filter=(has_focus(DEFAULT_BUFFER) & ~vi_mode))(win_paste)
+
+
+    @Condition
+    def ebivim():
+        return shell.emacs_bindings_in_vi_insert_mode
+
+    focused_insert = has_focus(DEFAULT_BUFFER) & vi_insert_mode
+
+    # Needed for to accept autosuggestions in vi insert mode
+    @kb.add("c-e", filter=focused_insert & ebivim)
+    def _(event):
+        b = event.current_buffer
+        suggestion = b.suggestion
+        if suggestion:
+            b.insert_text(suggestion.text)
+        else:
+            nc.end_of_line(event)
+
+    @kb.add("c-f", filter=focused_insert & ebivim)
+    def _(event):
+        b = event.current_buffer
+        suggestion = b.suggestion
+        if suggestion:
+            b.insert_text(suggestion.text)
+        else:
+            nc.forward_char(event)
+
+    @kb.add("escape", "f", filter=focused_insert & ebivim)
+    def _(event):
+        b = event.current_buffer
+        suggestion = b.suggestion
+        if suggestion:
+            t = re.split(r"(\S+\s+)", suggestion.text)
+            b.insert_text(next((x for x in t if x), ""))
+        else:
+            nc.forward_word(event)
+
+    # Simple Control keybindings
+    key_cmd_dict = {
+        "c-a": nc.beginning_of_line,
+        "c-b": nc.backward_char,
+        "c-k": nc.kill_line,
+        "c-w": nc.backward_kill_word,
+        "c-y": nc.yank,
+        "c-_": nc.undo,
+    }
+
+    for key, cmd in key_cmd_dict.items():
+        kb.add(key, filter=focused_insert & ebivim)(cmd)
+
+    # Alt and Combo Control keybindings
+    keys_cmd_dict = {
+        # Control Combos
+        ("c-x", "c-e"): nc.edit_and_execute,
+        ("c-x", "e"): nc.edit_and_execute,
+        # Alt
+        ("escape", "b"): nc.backward_word,
+        ("escape", "c"): nc.capitalize_word,
+        ("escape", "d"): nc.kill_word,
+        ("escape", "h"): nc.backward_kill_word,
+        ("escape", "l"): nc.downcase_word,
+        ("escape", "u"): nc.uppercase_word,
+        ("escape", "y"): nc.yank_pop,
+        ("escape", "."): nc.yank_last_arg,
+    }
+
+    for keys, cmd in keys_cmd_dict.items():
+        kb.add(*keys, filter=focused_insert & ebivim)(cmd)
 
     return kb
 

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -90,9 +90,8 @@ def create_ipython_shortcuts(shell):
                               & ~cursor_in_leading_ws
                         ))(display_completions_like_readline)
 
-    if sys.platform == 'win32':
-        kb.add('c-v', filter=(has_focus(DEFAULT_BUFFER) & ~vi_mode))(win_paste)
-
+    if sys.platform == "win32":
+        kb.add("c-v", filter=(has_focus(DEFAULT_BUFFER) & ~vi_mode))(win_paste)
 
     @Condition
     def ebivim():


### PR DESCRIPTION
# Rationale: 
Emacs keybindings are the default in many UNIX shells (e.g. [`bash` uses GNU `readline`](https://en.m.wikipedia.org/wiki/GNU_Readline#Editing_modes)) and Python consoles (including IPython), but these bindings are unavailable when vi mode is enabled (e.g. with `set -o vi` in `bash`, `bindkey -v` in `zsh`, or `c.TerminalInteractiveShell.editing_mode = 'vi'` in IPython).

Not having access to emacs keybindings is a problem for the autosuggestions feature from #12570.

As I described in #12570, the emacs bindings `Ctrl-E`, `Ctrl-F`, and `Alt-F` are used to accept autosuggestions. 

Without these bindings, vi editing mode users will have to use the right arrow key to accept autosuggestions.
If there is one that vi users hate... it's using arrow keys.😁

There is a `Condition` called `ebivim` to turn this feature on and off. Currently, `ebivim` is set to `True` by default to facilitate testing of this feature, but it can be disabled by adding `c.InteractiveShell.emacs_bindings_in_vi_insert_mode = False` to `ipython_config.py`. 

Some users may want to disable this feature, because it conflicts with one (rather useless) vim insert mode binding: `Ctrl-K`(insert digraph). If anyone needs to use digraphs in IPython, they can enter vim by pressing `Ctrl-X`, `Ctrl-E` (assuming `vim` is their `$EDITOR`) and then press `Ctrl-K` followed by the digraph combo (e.g. [`n`, `~` is ñ](https://twitter.com/ben_j_lindsay/status/1310358009936318464?s=20)). 

# Details

This pull request implements the bindings used for accepting autosuggestions, but also many others:
<details><summary>Please click here for the full list of keyboard shortcuts</summary>

- `Alt-B`: move left one word
- `Alt-C`: capitalize word
- `Alt-D`: cut right one word
- `Alt-F`: move right one word
- `Alt-H`: cut left one word
- `Alt-L`: lowercase word
- `Alt-U`: uppercase word
- `Alt-Y`: rotate killring
- `Alt-.`: insert last argument

- `Ctrl-A`: move to line start
- `Ctrl-B`: move left one character
- `Ctrl-D`: cut right one character
- `Ctrl-E`: move to line end
- `Ctrl-F`: move right one character
- `Ctrl-H`: cut left one character
- `Ctrl-K`: cut to line end
- `Ctrl-U`: cut to line start
- `Ctrl-W`: cut left one word
- `Ctrl-Y`: paste
- `Ctrl-_`: undo (in addition to `_`, `-` works too)
- `Ctrl-X`, `Ctrl-E`: edit in `$EDITOR` and execute (also works if `Ctrl` is released after `Ctrl-X`)
</details>

To install a version of ipython with autosuggestions enabled, run:

`pip install git+https://github.com/mskar/ipython@emacs_bindings_in_vi_insert_mode`