### PR TITLE
Fix to #12180 (display.Video failing with data=None)

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1086,7 +1086,7 @@ class Video(DisplayObject):
         if url is None and isinstance(data, str) and data.startswith(('http:', 'https:')):
             url = data
             data = None
-        elif os.path.exists(data):
+        elif data is not None and os.path.exists(data):
             filename = data
             data = None
 


### PR DESCRIPTION
I've noticed a bug when reading Video by filename (checking the issues I've seen it was already reported here: #12180) 

**The bug:**
While this would work perfectly
```python
from IPython.core import display
im = display.Image(filename="path_to_some_image.jpg")
```

I noticed this would fail:
```python
from IPython.core import display
vi = display.Video(filename="path_to_some_video.avi")
```

with `TypeError` due to the `os.path.exists(data)` check, which I think it can be inconsistent. 

**The fix:**
I've just added a check to skip it if there is no `data`.

(I've noticed only afterwards that there was already someone assigned to it though!)