### PR TITLE
Use pathlib in display.py

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -351,7 +351,7 @@ class DisplayObject(object):
     def reload(self):
         """Reload the raw data from file or URL."""
         if self.filename is not None:
-            with open(self.filename, self._read_flags) as f:
+            with self.filename.open(self._read_flags) as f:
                 self.data = f.read()
         elif self.url is not None:
             # Deferred import

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -293,7 +293,7 @@ class DisplayObject(object):
             The raw data or a URL or file to load the data from
         url : unicode
             A URL to download the data from.
-        filename : unicode
+        filename : unicode, str or Path
             Path to a local file to load the data from.
         metadata : dict
             Dict of metadata associated to be the object when displayed
@@ -310,6 +310,9 @@ class DisplayObject(object):
                 url = None
                 filename = data
                 data = None
+
+        if filename is not None:
+            filename = Path(filename)
 
         self.url = url
         self.filename = filename
@@ -563,7 +566,7 @@ class JSON(DisplayObject):
             or list containers.
         url : unicode
             A URL to download the data from.
-        filename : unicode
+        filename : unicode, str or Path
             Path to a local file to load the data from.
         expanded : boolean
             Metadata to control whether a JSON display component is expanded.
@@ -649,7 +652,7 @@ class GeoJSON(JSON):
             Leaflet TileLayer options: http://leafletjs.com/reference.html#tilelayer-options
         url : unicode
             A URL to download the data from.
-        filename : unicode
+        filename : unicode, str or Path
             Path to a local file to load the data from.
         metadata: dict
             Specify extra metadata to attach to the json display object.
@@ -716,7 +719,7 @@ class Javascript(TextDisplayObject):
             The Javascript source code or a URL to download it from.
         url : unicode
             A URL to download the data from.
-        filename : unicode
+        filename : unicode, str or Path
             Path to a local file to load the data from.
         lib : list or str
             A sequence of Javascript library URLs to load asynchronously before
@@ -818,7 +821,7 @@ class Image(DisplayObject):
         url : unicode
             A URL to download the data from. If you specify `url=`,
             the image data will not be embedded unless you also specify `embed=True`.
-        filename : unicode
+        filename : unicode, str or Path
             Path to a local file to load the data from.
             Images from a file are always embedded.
         format : unicode
@@ -1040,7 +1043,7 @@ class Video(DisplayObject):
         url : unicode
             A URL for the video. If you specify `url=`,
             the image data will not be embedded.
-        filename : unicode
+        filename : unicode, str or Path
             Path to a local file containing the video.
             Will be interpreted as a local URL unless `embed=True`.
         embed : bool
@@ -1127,8 +1130,7 @@ class Video(DisplayObject):
             if not mimetype:
                 mimetype, _ = mimetypes.guess_type(self.filename)
 
-            with open(self.filename, 'rb') as f:
-                video = f.read()
+            video = self.filename.read_bytes()
         else:
             video = self.data
         if isinstance(video, str):

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import pathlib
 import warnings
 
 from unittest import mock
@@ -128,6 +129,10 @@ def test_image_filename_defaults():
     # check boths paths to allow packages to test at build and install time
     imgfile = os.path.join(tpath, 'core/tests/2x2.png')
     img = display.Image(filename=imgfile)
+    nt.assert_equal('png', img.format)
+    nt.assert_is_not_none(img._repr_png_())
+    # check it works equally well with a pathlib path
+    img = display.Image(filename=pathlib.Path(imgfile))
     nt.assert_equal('png', img.format)
     nt.assert_is_not_none(img._repr_png_())
     img = display.Image(filename=os.path.join(tpath, 'testing/tests/logo.jpg'), embed=False)

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -129,7 +129,7 @@ def test_image_filename_defaults():
     # check boths paths to allow packages to test at build and install time
     imgfile = os.path.join(tpath, 'core/tests/2x2.png')
     img = display.Image(filename=imgfile)
-    nt.assert_equal('png', img.format)
+    nt.assert_equal("png", img.format)
     nt.assert_is_not_none(img._repr_png_())
     # check it works equally well with a pathlib path
     img = display.Image(filename=pathlib.Path(imgfile))


### PR DESCRIPTION
Updated `display.py` classes to use pathlib when possible.

While looking at a different bug I noticed that the classes in `display.py` would mostly accept also a `Path` and also that there was an issue ( #12515) about changing to pathlib whenever possible. Don't know whether there is a specific reason why it wouldn't be used in this file though. Hope it is useful!