### PR TITLE
Pathlib in core.magics

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -40,6 +40,7 @@ from IPython.utils.timing import clock, clock2
 from warnings import warn
 from logging import error
 from io import StringIO
+from pathlib import Path
 
 if sys.version_info > (3,8):
     from ast import Module
@@ -362,8 +363,7 @@ class ExecutionMagics(Magics):
             print('\n*** Profile stats marshalled to file',\
                   repr(dump_file)+'.',sys_exit)
         if text_file:
-            with open(text_file, 'w') as pfile:
-                pfile.write(output)
+            Path(text_file).write_text(output)
             print('\n*** Profile printout saved to text file',\
                   repr(text_file)+'.',sys_exit)
 
@@ -724,7 +724,7 @@ class ExecutionMagics(Magics):
         sys.argv = [filename] + args  # put in the proper filename
 
         if 'n' in opts:
-            name = os.path.splitext(os.path.basename(filename))[0]
+            name = Path(filename).stem
         else:
             name = '__main__'
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -32,12 +32,14 @@ def _get_conda_executable():
 
     # Otherwise, attempt to extract the executable from conda history.
     # This applies in any conda environment.
-    R = re.compile(r"^#\s*cmd:\s*(?P<command>.*conda)\s[create|install]")
-    with open(Path(sys.prefix, "conda-meta", "history")) as f:
-        for line in f:
-            match = R.match(line)
-            if match:
-                return match.groupdict()['command']
+    history = Path(sys.prefix, "conda-meta", "history").read_text()
+    match = re.search(
+        r"^#\s*cmd:\s*(?P<command>.*conda)\s[create|install]",
+        history,
+        flags=re.MULTILINE,
+    )
+    if match:
+        return match.groupdict()["command"]
     
     # Fallback: assume conda is available on the system path.
     return "conda"

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -8,33 +8,32 @@
 #  The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import os
 import re
 import shlex
 import sys
 
+from pathlib import Path
 from IPython.core.magic import Magics, magics_class, line_magic
 
 
 def _is_conda_environment():
     """Return True if the current Python executable is in a conda env"""
     # TODO: does this need to change on windows?
-    conda_history = os.path.join(sys.prefix, 'conda-meta', 'history')
-    return os.path.exists(conda_history)
+    return Path(sys.prefix, 'conda-meta', 'history').exists()
 
 
 def _get_conda_executable():
     """Find the path to the conda executable"""
     # Check if there is a conda executable in the same directory as the Python executable.
     # This is the case within conda's root environment.
-    conda = os.path.join(os.path.dirname(sys.executable), 'conda')
-    if os.path.isfile(conda):
-        return conda
+    conda = Path(sys.executable).parent / 'conda'
+    if conda.isfile():
+        return str(conda)
 
     # Otherwise, attempt to extract the executable from conda history.
     # This applies in any conda environment.
     R = re.compile(r"^#\s*cmd:\s*(?P<command>.*conda)\s[create|install]")
-    with open(os.path.join(sys.prefix, 'conda-meta', 'history')) as f:
+    with open(Path(sys.prefix, 'conda-meta', 'history')) as f:
         for line in f:
             match = R.match(line)
             if match:

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -19,21 +19,21 @@ from IPython.core.magic import Magics, magics_class, line_magic
 def _is_conda_environment():
     """Return True if the current Python executable is in a conda env"""
     # TODO: does this need to change on windows?
-    return Path(sys.prefix, 'conda-meta', 'history').exists()
+    return Path(sys.prefix, "conda-meta", "history").exists()
 
 
 def _get_conda_executable():
     """Find the path to the conda executable"""
     # Check if there is a conda executable in the same directory as the Python executable.
     # This is the case within conda's root environment.
-    conda = Path(sys.executable).parent / 'conda'
+    conda = Path(sys.executable).parent / "conda"
     if conda.isfile():
         return str(conda)
 
     # Otherwise, attempt to extract the executable from conda history.
     # This applies in any conda environment.
     R = re.compile(r"^#\s*cmd:\s*(?P<command>.*conda)\s[create|install]")
-    with open(Path(sys.prefix, 'conda-meta', 'history')) as f:
+    with open(Path(sys.prefix, "conda-meta", "history")) as f:
         for line in f:
             match = R.match(line)
             if match:


### PR DESCRIPTION
See #12515.

This introduces usage of pathlib, including in places where it could be used instead of `os.path`, in:
- `IPython.core.magics.execution`
- `IPython.core.magics.packaging`

Don't be scared by the amount of edited lines. By the boy-scout rule I've fixed some issues with code style that my linter was yapping about: redundant or missing whitespace / lines, wrong indentation, unnecessary usage of `\`. These changes shouldn't alter any behavior. In `IPython.core.magics.execution` it turned out to be _a lot_ of hunks. 