### PR TITLE
skip test if ipykernel not there.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ matrix:
       python: "nightly"
       dist: xenial
     - arch: amd64
-      python: "3.9-dev"
+      python: "3.9"
     - os: osx
       language: generic
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ matrix:
       python: "nightly"
       dist: xenial
     - arch: amd64
-      python: "3.9"
+      python: "3.9-dev"
     - os: osx
       language: generic
       python: 3.7

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -138,7 +138,9 @@ def _get_inline_config():
     from ipykernel.pylab.config import InlineBackend
     return InlineBackend.instance()
 
-@dec.skip_without('matplotlib')
+
+@dec.skip_without("ipykernel")
+@dec.skip_without("matplotlib")
 def test_set_matplotlib_close():
     cfg = _get_inline_config()
     cfg.close_figures = False
@@ -173,7 +175,9 @@ def test_set_matplotlib_formats():
             else:
                 nt.assert_not_in(Figure, f)
 
-@dec.skip_without('matplotlib')
+
+@dec.skip_without("ipykernel")
+@dec.skip_without("matplotlib")
 def test_set_matplotlib_formats_kwargs():
     from matplotlib.figure import Figure
     ip = get_ipython()


### PR DESCRIPTION
This is in particular useful for publishing on conda-forge when bumping
Python version, as ipykernel and ipython have circular dependencies when
running the full test suite.