### PR TITLE
mktempfile returns Path object

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3597,10 +3597,10 @@ class InteractiveShell(SingletonConfigurable):
           - data(None): if data is given, it gets written out to the temp file
             immediately, and the file is closed again."""
 
-        dir_path = Path(tempfile.mkdtemp(prefix=prefix))
-        self.tempdirs.append(dir_path)
+        temp_directory = Path(tempfile.mkdtemp(prefix=prefix))
+        self.tempdirs.append(temp_directory)
 
-        handle, filename = tempfile.mkstemp(".py", prefix, dir=str(dir_path))
+        handle, filename = tempfile.mkstemp(".py", prefix, dir=temp_directory)
         os.close(handle)  # On Windows, there can only be one open handle on a file
 
         file_path = Path(filename)
@@ -3608,7 +3608,8 @@ class InteractiveShell(SingletonConfigurable):
 
         if data:
             file_path.write_text(data)
-        return filename
+
+        return file_path
 
     @undoc
     def write(self,data):

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -492,7 +492,7 @@ class CodeMagics(Magics):
                     use_temp = False
 
         if use_temp:
-            filename = shell.mktempfile(data)
+            filename = str(shell.mktempfile(data))
             print('IPython will make a temporary file named:',filename)
 
         # use last_call to remember the state of the previous call, but don't
@@ -505,16 +505,17 @@ class CodeMagics(Magics):
             pass
 
 
+        # TODO use Path object instead of string
         return filename, lineno, use_temp
 
     def _edit_macro(self,mname,macro):
         """open an editor with the macro data in a file"""
-        filename = self.shell.mktempfile(macro.value)
-        self.shell.hooks.editor(filename)
+        file_path = self.shell.mktempfile(macro.value)
+        # TODO use Path object instead of string
+        self.shell.hooks.editor(str(file_path))
 
         # and make a new macro object, to replace the old one
-        mvalue = Path(filename).read_text()
-        self.shell.user_ns[mname] = Macro(mvalue)
+        self.shell.user_ns[mname] = Macro(file_path.read_text())
 
     @skip_doctest
     @line_magic

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -9,28 +9,28 @@ recurring bugs we seem to encounter with high-level interaction.
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
 import ast
+import asyncio
 import os
-import signal
 import shutil
+import signal
 import sys
 import tempfile
 import unittest
-from unittest import mock
-
 from os.path import join
+from unittest import mock
 
 import nose.tools as nt
 
-from IPython.core.error import InputRejected
-from IPython.core.inputtransformer import InputTransformer
 from IPython.core import interactiveshell
+from IPython.core.error import InputRejected
+from IPython.core.history import HistoryManager
+from IPython.testing import tools as tt
 from IPython.testing.decorators import (
     skipif, skip_win32, onlyif_unicode_paths, onlyif_cmds_exist,
 )
-from IPython.testing import tools as tt
 from IPython.utils.process import find_cmd
+
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -450,14 +450,14 @@ class InteractiveShellTestCase(unittest.TestCase):
             ip.set_custom_exc((), None)
     
     def test_mktempfile(self):
-        filename = ip.mktempfile()
+        file = ip.mktempfile()
         # Check that we can open the file again on Windows
-        with open(filename, 'w') as f:
-            f.write('abc')
+        with file.open("w") as f:
+            f.write("abc")
 
-        filename = ip.mktempfile(data='blah')
-        with open(filename, 'r') as f:
-            self.assertEqual(f.read(), 'blah')
+        file = ip.mktempfile(data="blah")
+        with file.open("r") as f:
+            self.assertEqual(f.read(), "blah")
 
     def test_new_main_mod(self):
         # Smoketest to check that this accepts a unicode module name
@@ -504,6 +504,30 @@ class InteractiveShellTestCase(unittest.TestCase):
             res = ip.run_cell('%' + cmd)
             self.assertEqual(res.success, True)
 
+    # def test_removes_temp_files_and_directories(self):
+    #     original_history_manager = ip.history_manager
+    #     with tempfile.TemporaryDirectory() as db_dir:
+    #         hist_file = os.path.join(db_dir, "history.sqlite")
+    #         ip.history_manager = HistoryManager(shell=ip, hist_file=hist_file)
+    # 
+    #         # First we ensure that we have created at least a tempfile
+    #         ip.mktempfile()
+    # 
+    #         # Ensure saving thread is shut down before we try to clean up the files
+    #         ip.history_manager.reset(new_session=False)
+    # 
+    #         # Then we run the atexit operations
+    #         ip.atexit_operations()
+    # 
+    #         # Now we check that they are deleted on exit
+    #         for tmpdir in ip.tempdirs:
+    #             self.assertFalse(tmpdir.exists())
+    # 
+    #         for tmpfile in ip.tempfiles:
+    #             self.assertFalse(tmpfile.exists())
+    # 
+    #     # Finnaly restore history manager
+    #     ip.history_manager = original_history_manager
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -504,30 +504,30 @@ class InteractiveShellTestCase(unittest.TestCase):
             res = ip.run_cell('%' + cmd)
             self.assertEqual(res.success, True)
 
-    # def test_removes_temp_files_and_directories(self):
-    #     original_history_manager = ip.history_manager
-    #     with tempfile.TemporaryDirectory() as db_dir:
-    #         hist_file = os.path.join(db_dir, "history.sqlite")
-    #         ip.history_manager = HistoryManager(shell=ip, hist_file=hist_file)
-    # 
-    #         # First we ensure that we have created at least a tempfile
-    #         ip.mktempfile()
-    # 
-    #         # Ensure saving thread is shut down before we try to clean up the files
-    #         ip.history_manager.reset(new_session=False)
-    # 
-    #         # Then we run the atexit operations
-    #         ip.atexit_operations()
-    # 
-    #         # Now we check that they are deleted on exit
-    #         for tmpdir in ip.tempdirs:
-    #             self.assertFalse(tmpdir.exists())
-    # 
-    #         for tmpfile in ip.tempfiles:
-    #             self.assertFalse(tmpfile.exists())
-    # 
-    #     # Finnaly restore history manager
-    #     ip.history_manager = original_history_manager
+    def test_removes_temp_files_and_directories(self):
+        original_history_manager = ip.history_manager
+        with tempfile.TemporaryDirectory() as db_dir:
+            hist_file = os.path.join(db_dir, "history.sqlite")
+            ip.history_manager = HistoryManager(shell=ip, hist_file=hist_file)
+
+            # First we ensure that we have created at least a tempfile
+            ip.mktempfile()
+
+            # Ensure saving thread is shut down before we try to clean up the files
+            ip.history_manager.reset(new_session=False)
+
+            # Then we run the atexit operations
+            ip.atexit_operations()
+
+            # Now we check that they are deleted on exit
+            for tmpdir in ip.tempdirs:
+                self.assertFalse(tmpdir.exists())
+
+            for tmpfile in ip.tempfiles:
+                self.assertFalse(tmpfile.exists())
+
+        # Finnaly restore history manager
+        ip.history_manager = original_history_manager
 
 class TestSafeExecfileNonAsciiPath(unittest.TestCase):
 

--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -403,9 +403,11 @@ class Demo(object):
         if index>0:
             index -= 1
 
-        filename = self.shell.mktempfile(self.src_blocks[index])
-        self.shell.hooks.editor(filename, 1)
-        with open(Path(filename), "r") as f:
+        file_path = self.shell.mktempfile(self.src_blocks[index])
+
+        # TODO use the Path object instead of the string
+        self.shell.hooks.editor(str(file_path), 1)
+        with file_path.open("r") as f:
             new_block = f.read()
         # update the source and colored block
         self.src_blocks[index] = new_block

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -95,7 +95,7 @@ def start_ipython():
     # A few more tweaks needed for playing nicely with doctests...
 
     # remove history file
-    shell.tempfiles.append(Path(config.HistoryManager.hist_file))
+#    shell.tempfiles.append(Path(config.HistoryManager.hist_file))
 
     # These traps are normally only active for interactive use, set them
     # permanently since we'll be mocking interactive sessions.

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -13,14 +13,12 @@ import builtins as builtin_mod
 import sys
 import types
 import warnings
-
 from pathlib import Path
 
-from . import tools
-
 from IPython.core import page
-from IPython.utils import io
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from IPython.utils import io
+from . import tools
 
 
 class StreamProxy(io.IOStream):


### PR DESCRIPTION
Related with #12515 

I changed the mktempfile function in IPython/core/interactiveshell.py to return a Path object instead of a string.
Now I'm changing the callers of that function to handle that.

