### PR TITLE
Don't register the same callback multiple times

### DIFF
--- a/IPython/core/events.py
+++ b/IPython/core/events.py
@@ -60,7 +60,8 @@ class EventManager(object):
         if not callable(function):
             raise TypeError('Need a callable, got %r' % function)
         callback_proto = available_events.get(event)
-        self.callbacks[event].append(callback_proto.adapt(function))
+        if function not in self.callbacks[event]:
+            self.callbacks[event].append(callback_proto.adapt(function))
     
     def unregister(self, event, function):
         """Remove a callback from the given event."""


### PR DESCRIPTION
Fixes https://github.com/ipython/ipython/issues/12626. An alternative would be to modify `unregister` to removes all copies of a function, but I am not sure if it makes sense to have multiple copies of the same callback. If this breaks something, `configure_inline_support` could also be modified in `ipython\core\pylabtools.py`. 