### PR TITLE
removed old python2 cast_unicode

### DIFF
--- a/IPython/paths.py
+++ b/IPython/paths.py
@@ -8,9 +8,14 @@ from warnings import warn
 import IPython
 from IPython.utils.importstring import import_item
 from IPython.utils.path import (
-    get_home_dir, get_xdg_dir, get_xdg_cache_dir, compress_user, _writable_dir,
-    ensure_dir_exists, fs_encoding)
-from IPython.utils import py3compat
+    get_home_dir,
+    get_xdg_dir,
+    get_xdg_cache_dir,
+    compress_user,
+    _writable_dir,
+    ensure_dir_exists,
+)
+
 
 def get_ipython_dir() -> str:
     """Get the IPython directory for this platform and user.
@@ -103,7 +108,8 @@ def get_ipython_module_path(module_str):
     mod = import_item(module_str)
     the_path = mod.__file__.replace('.pyc', '.py')
     the_path = the_path.replace('.pyo', '.py')
-    return py3compat.cast_unicode(the_path, fs_encoding)
+    return the_path
+
 
 def locate_profile(profile='default'):
     """Find the path to the folder associated with a given profile.


### PR DESCRIPTION
fixes #12515 
`cast_unicode` is unnecessary because `module.__file__` is always a `str`