### PR TITLE
Use pathlib in docs/autogen_shortcuts.py

### DIFF
--- a/docs/autogen_shortcuts.py
+++ b/docs/autogen_shortcuts.py
@@ -76,14 +76,17 @@ for kb in ipy_bindings:
 
 if __name__ == '__main__':
     here = Path(__file__).parent
-    dest = here / 'source' / 'config' / 'shortcuts'
+    dest = here / "source" / "config" / "shortcuts"
 
     def sort_key(item):
         k, v = item
         shortcut, flt = k
         return (str(shortcut), str(flt))
 
-    for filters, output_filename in [(single_filter, 'single_filtered'), (multi_filter, 'multi_filtered')]:
-        with (dest / '{}.csv'.format(output_filename)).open('w') as csv:
+    for filters, output_filename in [
+        (single_filter, "single_filtered"),
+        (multi_filter, "multi_filtered"),
+    ]:
+        with (dest / "{}.csv".format(output_filename)).open("w") as csv:
             for (shortcut, flt), v in sorted(filters.items(), key=sort_key):
-                csv.write(':kbd:`{}`\t{}\t{}\n'.format(shortcut, flt, v))
+                csv.write(":kbd:`{}`\t{}\t{}\n".format(shortcut, flt, v))

--- a/docs/autogen_shortcuts.py
+++ b/docs/autogen_shortcuts.py
@@ -1,4 +1,4 @@
-from os.path import abspath, dirname, join
+from pathlib import Path
 
 from IPython.terminal.shortcuts import create_ipython_shortcuts
 
@@ -75,16 +75,10 @@ for kb in ipy_bindings:
 
 
 if __name__ == '__main__':
+    here = Path(__file__).parent
+    dest = here / 'source' / 'config' / 'shortcuts'
 
-    sort_key = lambda k:(str(k[0][1]),str(k[0][0]))
-
-    here = abspath(dirname(__file__))
-    dest = join(here, 'source', 'config', 'shortcuts')
-
-    with open(join(dest, 'single_filtered.csv'), 'w') as csv:
-        for k, v in sorted(single_filter.items(), key=sort_key):
-            csv.write(':kbd:`{}`\t{}\t{}\n'.format(k[0], k[1], v))
-
-    with open(join(dest, 'multi_filtered.csv'), 'w') as csv:
-        for k, v in sorted(multi_filter.items(), key=sort_key):
-            csv.write(':kbd:`{}`\t{}\t{}\n'.format(k[0], k[1], v))
+    for filters, output_filename in [(single_filter, 'single_filtered'), (multi_filter, 'multi_filtered')]:
+        with (dest / '{}.csv'.format(output_filename)).open('w') as csv:
+            for (shortcut, flt), v in sorted(filters.items(), key=lambda ((shortcut, flt), v): (str(shortcut), str(flt))):
+                csv.write(':kbd:`{}`\t{}\t{}\n'.format(shortcut, flt, v))

--- a/docs/autogen_shortcuts.py
+++ b/docs/autogen_shortcuts.py
@@ -78,7 +78,12 @@ if __name__ == '__main__':
     here = Path(__file__).parent
     dest = here / 'source' / 'config' / 'shortcuts'
 
+    def sort_key(item):
+        k, v = item
+        shortcut, flt = k
+        return (str(shortcut), str(flt))
+
     for filters, output_filename in [(single_filter, 'single_filtered'), (multi_filter, 'multi_filtered')]:
         with (dest / '{}.csv'.format(output_filename)).open('w') as csv:
-            for (shortcut, flt), v in sorted(filters.items(), key=lambda ((shortcut, flt), v): (str(shortcut), str(flt))):
+            for (shortcut, flt), v in sorted(filters.items(), key=sort_key):
                 csv.write(':kbd:`{}`\t{}\t{}\n'.format(shortcut, flt, v))


### PR DESCRIPTION
Converted `os.path` usage in `docs/autogen_shortcuts.py` to `pathlib`, and also improved the surrounding code a little.

As per #12515