### PR TITLE
Fix TerminalInteractiveShell.true_color docs

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -201,10 +201,12 @@ class TerminalInteractiveShell(InteractiveShell):
     ).tag(config=True)
 
     true_color = Bool(False,
-        help=("Use 24bit colors instead of 256 colors in prompt highlighting. "
-              "If your terminal supports true color, the following command "
-              "should print 'TRUECOLOR' in orange: "
-              "printf \"\\x1b[38;2;255;100;0mTRUECOLOR\\x1b[0m\\n\"")
+        help="""Use 24bit colors instead of 256 colors in prompt highlighting.
+        If your terminal supports true color, the following command should
+        print ``TRUECOLOR`` in orange::
+
+            printf \"\\x1b[38;2;255;100;0mTRUECOLOR\\x1b[0m\\n\"
+        """,
     ).tag(config=True)
 
     editor = Unicode(get_default_editor(),


### PR DESCRIPTION
## The Issue

The escape sequences used in the [`TerminalInteractiveShell.true_color` documentation](https://ipython.readthedocs.io/en/7.18.1/config/options/terminal.html#configtrait-TerminalInteractiveShell.true_color) currently don't render correctly. This can be confusing for the user as they try to figure out whether their terminal has true color support.

## Before Changes

With the current documentation the escape sequences are invisible, making the suggested command incorrect. The line with the `printf` is also split from the argument.

![terminalinteractiveshell-truecolor-before](https://user-images.githubusercontent.com/3084059/96353967-075b0600-1086-11eb-9a1a-f46ec15b28c0.png)

## After Changes

The proposed fix places the docs into a multi-line string and then uses reStructuredText formatting to put the `printf` statement into a code block. Inside that code block the escape sequences render correctly. For visual clarity the word `TRUECOLOR` was also given monospace formatting.

![terminalinteractiveshell-truecolor-after](https://user-images.githubusercontent.com/3084059/96353969-0f1aaa80-1086-11eb-95f1-4cb3be4ce665.png)

## Testing Done
```
$ iptest --all --fast
Test group: extensions -------------------------------------------- OK
Test group: lib --------------------------------------------------- OK
Test group: testing ----------------------------------------------- OK
Test group: utils ------------------------------------------------- OK
Test group: terminal ---------------------------------------------- OK
Test group: autoreload -------------------------------------------- OK
Test group: core -------------------------------------------------- OK
______________________________________________________________________
Test suite completed for system with the following information:
IPython version: 8.0.0.dev
IPython commit : 30e0b9640 (repository)
IPython package: /tmp/ipython/IPython
Python version : 3.9.0 (default, Oct  5 2020, 13:02:35) [GCC 9.3.1 20200408 (Red Hat 9.3.1-2)]
sys.executable : ~/.virtualenvs/ipython/bin/python
Platform       : Linux-5.7.7-100.fc31.x86_64-x86_64-with-glibc2.30

Tools and libraries available at test time:
   matplotlib pygments

Status: OK (7 test groups). Took 15.286s.
```

If this PR is acceptable, please consider adding the `hacktoberfest-accepted` label to it. Thanks! :grin: 