### PR TITLE
Use Pathlib in test_application.py and test_completerlib.py

### DIFF
--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -6,7 +6,6 @@ import tempfile
 from pathlib import Path
 
 import nose.tools as nt
-
 from traitlets import Unicode
 
 from IPython.core.application import BaseIPythonApplication

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -36,9 +36,8 @@ def test_unicode_ipdir():
     ipdir = Path(tempfile.mkdtemp(suffix=u"€"))
     
     # Create the config file, so it tries to load it.
-    with ipdir.joinpath("ipython_config.py").open("w") as f:
-        pass
-    
+    ipdir.joinpath("ipython_config.py").touch()
+
     old_ipdir1 = os.environ.pop("IPYTHONDIR", None)
     old_ipdir2 = os.environ.pop("IPYTHON_DIR", None)
     os.environ["IPYTHONDIR"] = str(ipdir)

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -3,6 +3,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 import nose.tools as nt
 
@@ -33,15 +34,15 @@ def test_unicode_cwd():
 @dec.onlyif_unicode_paths
 def test_unicode_ipdir():
     """Check that IPython starts with non-ascii characters in the IP dir."""
-    ipdir = tempfile.mkdtemp(suffix=u"€")
+    ipdir = Path(tempfile.mkdtemp(suffix=u"€"))
     
     # Create the config file, so it tries to load it.
-    with open(os.path.join(ipdir, 'ipython_config.py'), "w") as f:
+    with ipdir.joinpath("ipython_config.py").open("w") as f:
         pass
     
     old_ipdir1 = os.environ.pop("IPYTHONDIR", None)
     old_ipdir2 = os.environ.pop("IPYTHON_DIR", None)
-    os.environ["IPYTHONDIR"] = ipdir
+    os.environ["IPYTHONDIR"] = str(ipdir)
     try:
         app = BaseIPythonApplication()
         # The lines below are copied from Application.initialize()
@@ -61,7 +62,7 @@ def test_cli_priority():
             test = Unicode().tag(config=True)
 
         # Create the config file, so it tries to load it.
-        with open(os.path.join(td, 'ipython_config.py'), "w") as f:
+        with Path(td).joinpath("ipython_config.py").open("w") as f:
             f.write("c.TestApp.test = 'config file'")
 
         app = TestApp()

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -40,7 +40,7 @@ class Test_magic_run_completer(unittest.TestCase):
         for d in self.dirs:
             os.mkdir(self.BASETESTDIR.joinpath(d))
 
-        self.oldpath = os.getcwd()
+        self.oldpath = Path.cwd()
         os.chdir(self.BASETESTDIR)
 
     def tearDown(self):
@@ -101,7 +101,7 @@ class Test_magic_run_completer_nonascii(unittest.TestCase):
         for fil in [u"aaø.py", u"a.py", u"b.py"]:
             with self.BASETESTDIR.joinpath(fil).open("w") as sfile:
                 sfile.write("pass\n")
-        self.oldpath = os.getcwd()
+        self.oldpath = Path.cwd()
         os.chdir(self.BASETESTDIR)
 
     def tearDown(self):

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -86,9 +86,9 @@ class Test_magic_run_completer(unittest.TestCase):
         self.assertEqual(
             match,
             {
-                str(self.BASETESTDIR.joinpath(f))
+                str(self.BASETESTDIR.joinpath(f)).replace('\\','/')
                 if Path(f).suffix
-                else str(self.BASETESTDIR.joinpath(f)) + os.sep
+                else str(self.BASETESTDIR.joinpath(f)).replace('\\','/') + os.sep
                 for f in (u"a.py", u"aao.py", u"aao.txt", u"adir/")
             },
         )

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -86,9 +86,9 @@ class Test_magic_run_completer(unittest.TestCase):
         self.assertEqual(
             match,
             {
-                str(self.BASETESTDIR.joinpath(f)).replace('\\','/')
+                str(self.BASETESTDIR.joinpath(f)).replace("\\", "/")
                 if Path(f).suffix
-                else str(self.BASETESTDIR.joinpath(f)).replace('\\','/') + os.sep
+                else str(self.BASETESTDIR.joinpath(f)).replace("\\", "/") + os.sep
                 for f in (u"a.py", u"aao.py", u"aao.txt", u"adir/")
             },
         )

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -17,8 +17,8 @@ from pathlib import Path
 import nose.tools as nt
 
 from IPython.core.completerlib import magic_run_completer, module_completion, try_import
-from IPython.utils.tempdir import TemporaryDirectory
 from IPython.testing.decorators import onlyif_unicode_paths
+from IPython.utils.tempdir import TemporaryDirectory
 
 
 class MockEvent(object):
@@ -83,9 +83,16 @@ class Test_magic_run_completer(unittest.TestCase):
         # We specifically use replace here rather than normpath, because
         # at one point there were duplicates 'adir' and 'adir/', and normpath
         # would hide the failure for that.
-        self.assertEqual(match, {str(self.BASETESTDIR.joinpath(f)) if Path(f).suffix
-                                 else str(self.BASETESTDIR.joinpath(f)) + os.sep
-                            for f in (u"a.py", u"aao.py", u"aao.txt", u"adir/")})
+        self.assertEqual(
+            match,
+            {
+                str(self.BASETESTDIR.joinpath(f))
+                if Path(f).suffix
+                else str(self.BASETESTDIR.joinpath(f)) + os.sep
+                for f in (u"a.py", u"aao.py", u"aao.txt", u"adir/")
+            },
+        )
+
 
 class Test_magic_run_completer_nonascii(unittest.TestCase):
     @onlyif_unicode_paths

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -88,7 +88,7 @@ class Test_magic_run_completer(unittest.TestCase):
             {
                 str(self.BASETESTDIR.joinpath(f)).replace("\\", "/")
                 if Path(f).suffix
-                else str(self.BASETESTDIR.joinpath(f)).replace("\\", "/") + os.sep
+                else (str(self.BASETESTDIR.joinpath(f)) + os.sep).replace("\\", "/")
                 for f in (u"a.py", u"aao.py", u"aao.txt", u"adir/")
             },
         )

--- a/IPython/testing/globalipapp.py
+++ b/IPython/testing/globalipapp.py
@@ -13,14 +13,13 @@ import builtins as builtin_mod
 import sys
 import types
 import warnings
-
 from pathlib import Path
 
-from . import tools
-
 from IPython.core import page
-from IPython.utils import io
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
+from IPython.utils import io
+
+from . import tools
 
 
 class StreamProxy(io.IOStream):


### PR DESCRIPTION
Refactored `test_application.py` to use Pathlib.

Fix #12515.