### PR TITLE
use pathlib in test_extension, test_logger, test_application, test_oinspect, and test_profile

### DIFF
--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -37,12 +37,12 @@ def test_unicode_ipdir():
     ipdir = tempfile.mkdtemp(suffix=u"€")
     
     # Create the config file, so it tries to load it.
-    with open(Path(ipdir, 'ipython_config.py'), "w") as f:
+    with open(ipdir / 'ipython_config.py', "w") as f:
         pass
     
     old_ipdir1 = os.environ.pop("IPYTHONDIR", None)
     old_ipdir2 = os.environ.pop("IPYTHON_DIR", None)
-    os.environ["IPYTHONDIR"] = ipdir
+    os.environ["IPYTHONDIR"] = str(ipdir)
     try:
         app = BaseIPythonApplication()
         # The lines below are copied from Application.initialize()

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -3,6 +3,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 import nose.tools as nt
 
@@ -18,9 +19,9 @@ def test_unicode_cwd():
     """Check that IPython starts with non-ascii characters in the path."""
     wd = tempfile.mkdtemp(suffix=u"€")
     
-    old_wd = os.getcwd()
+    old_wd = Path.cwd()
     os.chdir(wd)
-    #raise Exception(repr(os.getcwd()))
+
     try:
         app = BaseIPythonApplication()
         # The lines below are copied from Application.initialize()
@@ -36,7 +37,7 @@ def test_unicode_ipdir():
     ipdir = tempfile.mkdtemp(suffix=u"€")
     
     # Create the config file, so it tries to load it.
-    with open(os.path.join(ipdir, 'ipython_config.py'), "w") as f:
+    with open(Path(ipdir, 'ipython_config.py'), "w") as f:
         pass
     
     old_ipdir1 = os.environ.pop("IPYTHONDIR", None)
@@ -61,7 +62,7 @@ def test_cli_priority():
             test = Unicode().tag(config=True)
 
         # Create the config file, so it tries to load it.
-        with open(os.path.join(td, 'ipython_config.py'), "w") as f:
+        with open(Path(td, 'ipython_config.py'), "w") as f:
             f.write("c.TestApp.test = 'config file'")
 
         app = TestApp()

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -37,7 +37,7 @@ def test_unicode_ipdir():
     ipdir = Path(tempfile.mkdtemp(suffix=u"€"))
     
     # Create the config file, so it tries to load it.
-    with open(ipdir / 'ipython_config.py', "w") as f:
+    with open(ipdir / "ipython_config.py", "w") as f:
         pass
     
     old_ipdir1 = os.environ.pop("IPYTHONDIR", None)
@@ -62,7 +62,7 @@ def test_cli_priority():
             test = Unicode().tag(config=True)
 
         # Create the config file, so it tries to load it.
-        with open(Path(td, 'ipython_config.py'), "w") as f:
+        with open(Path(td, "ipython_config.py"), "w") as f:
             f.write("c.TestApp.test = 'config file'")
 
         app = TestApp()

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -34,7 +34,7 @@ def test_unicode_cwd():
 @dec.onlyif_unicode_paths
 def test_unicode_ipdir():
     """Check that IPython starts with non-ascii characters in the IP dir."""
-    ipdir = tempfile.mkdtemp(suffix=u"€")
+    ipdir = Path(tempfile.mkdtemp(suffix=u"€"))
     
     # Create the config file, so it tries to load it.
     with open(ipdir / 'ipython_config.py', "w") as f:

--- a/IPython/core/tests/test_extension.py
+++ b/IPython/core/tests/test_extension.py
@@ -28,12 +28,12 @@ def load_ipython_extension(ip):
 def test_extension_loading():
     em = get_ipython().extension_manager
     with TemporaryDirectory() as td:
-        ext1 = Path(td, 'ext1.py')
-        with open(ext1, 'w') as f:
+        ext1 = Path(td, "ext1.py")
+        with open(ext1, "w") as f:
             f.write(ext1_content)
-        
-        ext2 = Path(td, 'ext2.py')
-        with open(ext2, 'w') as f:
+
+        ext2 = Path(td, "ext2.py")
+        with open(ext2, "w") as f:
             f.write(ext2_content)
         
         with prepended_to_syspath(td):
@@ -78,8 +78,8 @@ def test_extension_loading():
 def test_extension_builtins():
     em = get_ipython().extension_manager
     with TemporaryDirectory() as td:
-        ext3 = Path(td, 'ext3.py')
-        with open(ext3, 'w') as f:
+        ext3 = Path(td, "ext3.py")
+        with open(ext3, "w") as f:
             f.write(ext3_content)
         
         assert 'ext3' not in em.loaded

--- a/IPython/core/tests/test_extension.py
+++ b/IPython/core/tests/test_extension.py
@@ -1,4 +1,4 @@
-import os.path
+from pathlib import Path
 
 import nose.tools as nt
 
@@ -28,11 +28,11 @@ def load_ipython_extension(ip):
 def test_extension_loading():
     em = get_ipython().extension_manager
     with TemporaryDirectory() as td:
-        ext1 = os.path.join(td, 'ext1.py')
+        ext1 = Path(td, 'ext1.py')
         with open(ext1, 'w') as f:
             f.write(ext1_content)
         
-        ext2 = os.path.join(td, 'ext2.py')
+        ext2 = Path(td, 'ext2.py')
         with open(ext2, 'w') as f:
             f.write(ext2_content)
         
@@ -78,7 +78,7 @@ def test_extension_loading():
 def test_extension_builtins():
     em = get_ipython().extension_manager
     with TemporaryDirectory() as td:
-        ext3 = os.path.join(td, 'ext3.py')
+        ext3 = Path(td, 'ext3.py')
         with open(ext3, 'w') as f:
             f.write(ext3_content)
         

--- a/IPython/core/tests/test_logger.py
+++ b/IPython/core/tests/test_logger.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Test IPython.core.logger"""
 
-import os.path
+from pathlib import Path
 
 import nose.tools as nt
 from IPython.utils.tempdir import TemporaryDirectory
@@ -21,7 +21,7 @@ def test_logstart_inaccessible_file():
 
 def test_logstart_unicode():
     with TemporaryDirectory() as tdir:
-        logfname = os.path.join(tdir, "test_unicode.log")
+        logfname = Path(tdir, "test_unicode.log")
         _ip.run_cell("'abc€'")
         try:
             _ip.magic("logstart -to %s" % logfname)

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -952,24 +952,29 @@ def test_script_bg_out():
     ip = get_ipython()
     ip.run_cell_magic("script", "--bg --out output sh", "echo 'hi'")
 
-    nt.assert_equal(ip.user_ns['output'].read(), b'hi\n')
-    ip.user_ns['output'].close()
+    nt.assert_equal(ip.user_ns["output"].read(), b"hi\n")
+    ip.user_ns["output"].close()
+
 
 @dec.skip_win32
 def test_script_bg_err():
     ip = get_ipython()
     ip.run_cell_magic("script", "--bg --err error sh", "echo 'hello' >&2")
-    nt.assert_equal(ip.user_ns['error'].read(), b'hello\n')
-    ip.user_ns['error'].close()
+    nt.assert_equal(ip.user_ns["error"].read(), b"hello\n")
+    ip.user_ns["error"].close()
+
 
 @dec.skip_win32
 def test_script_bg_out_err():
     ip = get_ipython()
-    ip.run_cell_magic("script", "--bg --out output --err error sh", "echo 'hi'\necho 'hello' >&2")
-    nt.assert_equal(ip.user_ns['output'].read(), b'hi\n')
-    nt.assert_equal(ip.user_ns['error'].read(), b'hello\n')
-    ip.user_ns['output'].close()
-    ip.user_ns['error'].close()
+    ip.run_cell_magic(
+        "script", "--bg --out output --err error sh", "echo 'hi'\necho 'hello' >&2"
+    )
+    nt.assert_equal(ip.user_ns["output"].read(), b"hi\n")
+    nt.assert_equal(ip.user_ns["error"].read(), b"hello\n")
+    ip.user_ns["output"].close()
+    ip.user_ns["error"].close()
+
 
 def test_script_defaults():
     ip = get_ipython()

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -173,12 +173,12 @@ def test_info():
     expted_class = str(type(type))  # <class 'type'> (Python 3) or <type 'type'>
     nt.assert_equal(i['base_class'], expted_class)
     nt.assert_regex(i['string_form'], "<class 'IPython.core.tests.test_oinspect.Call'( at 0x[0-9a-f]{1,9})?>")
-    fname = __file__
-    if fname.endswith(".pyc"):
-        fname = fname[:-1]
+    fname = Path(__file__)
+    if fname.suffix == ".pyc":
+        fname = fname.with_suffix('.py')
     # case-insensitive comparison needed on some filesystems
     # e.g. Windows:
-    nt.assert_equal(i['file'].lower(), compress_user(fname).lower())
+    nt.assert_equal(i['file'].lower(), compress_user(str(fname)).lower())
     nt.assert_equal(i['definition'], None)
     nt.assert_equal(i['docstring'], Call.__doc__)
     nt.assert_equal(i['source'], None)

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -53,7 +53,7 @@ class Test(TestCase):
 # A couple of utilities to ensure these tests work the same from a source or a
 # binary install
 def pyfile(fname):
-    return os.path.normcase(re.sub('.py[co]$', '.py', str(fname)))
+    return os.path.normcase(re.sub(".py[co]$", ".py", str(fname)))
 
 
 def match_pyfiles(f1, f2):
@@ -175,16 +175,16 @@ def test_info():
     nt.assert_regex(i['string_form'], "<class 'IPython.core.tests.test_oinspect.Call'( at 0x[0-9a-f]{1,9})?>")
     fname = Path(__file__)
     if fname.suffix == ".pyc":
-        fname = fname.with_suffix('.py')
+        fname = fname.with_suffix(".py")
     # case-insensitive comparison needed on some filesystems
     # e.g. Windows:
-    nt.assert_equal(i['file'].lower(), compress_user(str(fname)).lower())
-    nt.assert_equal(i['definition'], None)
-    nt.assert_equal(i['docstring'], Call.__doc__)
-    nt.assert_equal(i['source'], None)
-    nt.assert_true(i['isclass'])
-    nt.assert_equal(i['init_definition'], "Call(x, y=1)")
-    nt.assert_equal(i['init_docstring'], Call.__init__.__doc__)
+    nt.assert_equal(i["file"].lower(), compress_user(str(fname)).lower())
+    nt.assert_equal(i["definition"], None)
+    nt.assert_equal(i["docstring"], Call.__doc__)
+    nt.assert_equal(i["source"], None)
+    nt.assert_true(i["isclass"])
+    nt.assert_equal(i["init_definition"], "Call(x, y=1)")
+    nt.assert_equal(i["init_docstring"], Call.__init__.__doc__)
 
     i = inspector.info(Call, detail_level=1)
     nt.assert_not_equal(i['source'], None)

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -8,6 +8,7 @@
 from inspect import signature, Signature, Parameter
 import os
 import re
+from pathlib import Path
 
 import nose.tools as nt
 
@@ -38,7 +39,7 @@ def setup_module():
 # defined, if any code is inserted above, the following line will need to be
 # updated.  Do NOT insert any whitespace between the next line and the function
 # definition below.
-THIS_LINE_NUMBER = 41  # Put here the actual number of this line
+THIS_LINE_NUMBER = 42  # Put here the actual number of this line
 
 from unittest import TestCase
 
@@ -60,7 +61,7 @@ def match_pyfiles(f1, f2):
 
 
 def test_find_file():
-    match_pyfiles(oinspect.find_file(test_find_file), os.path.abspath(__file__))
+    match_pyfiles(oinspect.find_file(test_find_file), Path(__file__).resolve())
 
 
 def test_find_file_decorated1():
@@ -75,7 +76,7 @@ def test_find_file_decorated1():
     def f(x):
         "My docstring"
     
-    match_pyfiles(oinspect.find_file(f), os.path.abspath(__file__))
+    match_pyfiles(oinspect.find_file(f), Path(__file__).resolve())
     nt.assert_equal(f.__doc__, "My docstring")
 
 
@@ -91,7 +92,7 @@ def test_find_file_decorated2():
     def f(x):
         "My docstring 2"
     
-    match_pyfiles(oinspect.find_file(f), os.path.abspath(__file__))
+    match_pyfiles(oinspect.find_file(f), Path(__file__).resolve())
     nt.assert_equal(f.__doc__, "My docstring 2")
     
 
@@ -264,7 +265,7 @@ def test_empty_property_has_no_source():
 
 
 def test_property_sources():
-    import posixpath 
+    import posixpath
     # A simple adder whose source and signature stays
     # the same across Python distributions
     def simple_add(a, b):

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -53,7 +53,7 @@ class Test(TestCase):
 # A couple of utilities to ensure these tests work the same from a source or a
 # binary install
 def pyfile(fname):
-    return os.path.normcase(re.sub('.py[co]$', '.py', fname))
+    return os.path.normcase(re.sub('.py[co]$', '.py', str(fname)))
 
 
 def match_pyfiles(f1, f2):

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 
 from unittest import TestCase
 
@@ -41,8 +42,8 @@ from IPython.utils.tempdir import TemporaryDirectory
 # Globals
 #-----------------------------------------------------------------------------
 TMP_TEST_DIR = tempfile.mkdtemp()
-HOME_TEST_DIR = os.path.join(TMP_TEST_DIR, "home_test_dir")
-IP_TEST_DIR = os.path.join(HOME_TEST_DIR,'.ipython')
+HOME_TEST_DIR = Path(TMP_TEST_DIR, "home_test_dir")
+IP_TEST_DIR = Path(HOME_TEST_DIR,'.ipython')
 
 #
 # Setup/teardown functions/decorators
@@ -55,7 +56,7 @@ def setup_module():
     """
     # Do not mask exceptions here.  In particular, catching WindowsError is a
     # problem because that exception is only defined on Windows...
-    os.makedirs(IP_TEST_DIR)
+    IP_TEST_DIR.mkdir(parents=True)
 
 
 def teardown_module():
@@ -86,8 +87,8 @@ class ProfileStartupTest(TestCase):
         # create profile dir
         self.pd = ProfileDir.create_profile_dir_by_name(IP_TEST_DIR, 'test')
         self.options = ['--ipython-dir', IP_TEST_DIR, '--profile', 'test']
-        self.fname = os.path.join(TMP_TEST_DIR, 'test.py')
-        
+        self.fname = Path(TMP_TEST_DIR, 'test.py')
+
     def tearDown(self):
         # We must remove this profile right away so its presence doesn't
         # confuse other tests.
@@ -95,7 +96,7 @@ class ProfileStartupTest(TestCase):
 
     def init(self, startup_file, startup, test):
         # write startup python file
-        with open(os.path.join(self.pd.startup_dir, startup_file), 'w') as f:
+        with open(Path(self.pd.startup_dir, startup_file), 'w') as f:
             f.write(startup)
         # write simple test file, to check that the startup file was run
         with open(self.fname, 'w') as f:
@@ -120,11 +121,11 @@ def test_list_profiles_in():
     # the module-level teardown.
     td = tempfile.mkdtemp(dir=TMP_TEST_DIR)
     for name in ('profile_foo', 'profile_hello', 'not_a_profile'):
-        os.mkdir(os.path.join(td, name))
+        Path(td, name).mkdir()
     if dec.unicode_paths:
-        os.mkdir(os.path.join(td, u'profile_ünicode'))
-    
-    with open(os.path.join(td, 'profile_file'), 'w') as f:
+        Path(td, u'profile_ünicode').mkdir()
+
+    with open(Path(td, 'profile_file'), 'w') as f:
         f.write("I am not a profile directory")
     profiles = list_profiles_in(td)
     
@@ -154,8 +155,7 @@ def test_profile_create_ipython_dir():
     with TemporaryDirectory() as td:
         getoutput([sys.executable, '-m', 'IPython', 'profile', 'create',
              'foo', '--ipython-dir=%s' % td])
-        profile_dir = os.path.join(td, 'profile_foo')
-        assert os.path.exists(profile_dir)
-        ipython_config = os.path.join(profile_dir, 'ipython_config.py')
-        assert os.path.exists(ipython_config)
-        
+        profile_dir = Path(td, 'profile_foo')
+        assert profile_dir.exists()
+        ipython_config = Path(profile_dir, 'ipython_config.py')
+        assert ipython_config.exists()

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -86,9 +86,9 @@ def win32_without_pywin32():
 class ProfileStartupTest(TestCase):
     def setUp(self):
         # create profile dir
-        self.pd = ProfileDir.create_profile_dir_by_name(IP_TEST_DIR, 'test')
-        self.options = ['--ipython-dir', IP_TEST_DIR, '--profile', 'test']
-        self.fname = TMP_TEST_DIR / 'test.py'
+        self.pd = ProfileDir.create_profile_dir_by_name(IP_TEST_DIR, "test")
+        self.options = ["--ipython-dir", IP_TEST_DIR, "--profile", "test"]
+        self.fname = TMP_TEST_DIR / "test.py"
 
     def tearDown(self):
         # We must remove this profile right away so its presence doesn't
@@ -97,7 +97,7 @@ class ProfileStartupTest(TestCase):
 
     def init(self, startup_file, startup, test):
         # write startup python file
-        with open(Path(self.pd.startup_dir, startup_file), 'w') as f:
+        with open(Path(self.pd.startup_dir, startup_file), "w") as f:
             f.write(startup)
         # write simple test file, to check that the startup file was run
         with open(self.fname, 'w') as f:
@@ -121,12 +121,12 @@ def test_list_profiles_in():
     # No need to remove these directories and files, as they will get nuked in
     # the module-level teardown.
     td = Path(tempfile.mkdtemp(dir=TMP_TEST_DIR))
-    for name in ('profile_foo', 'profile_hello', 'not_a_profile'):
+    for name in ("profile_foo", "profile_hello", "not_a_profile"):
         Path(td, name).mkdir(parents=True)
     if dec.unicode_paths:
-        Path(td, u'profile_ünicode').mkdir()
+        Path(td, u"profile_ünicode").mkdir()
 
-    with open(td / 'profile_file', 'w') as f:
+    with open(td / "profile_file", "w") as f:
         f.write("I am not a profile directory")
     profiles = list_profiles_in(td)
     
@@ -154,16 +154,18 @@ def test_list_bundled_profiles():
 def test_profile_create_ipython_dir():
     """ipython profile create respects --ipython-dir"""
     with TemporaryDirectory() as td:
-        getoutput([
-          sys.executable, 
-          '-m', 
-          'IPython', 
-          'profile', 
-          'create',
-          'foo', 
-          '--ipython-dir=%s' % td
-        ])
-        profile_dir = Path(td, 'profile_foo')
+        getoutput(
+            [
+                sys.executable,
+                "-m",
+                "IPython",
+                "profile",
+                "create",
+                "foo",
+                "--ipython-dir=%s" % td,
+            ]
+        )
+        profile_dir = Path(td, "profile_foo")
         assert profile_dir.exists()
-        ipython_config = profile_dir / 'ipython_config.py'
+        ipython_config = profile_dir / "ipython_config.py"
         assert ipython_config.exists()

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -119,13 +119,13 @@ class ProfileStartupTest(TestCase):
 def test_list_profiles_in():
     # No need to remove these directories and files, as they will get nuked in
     # the module-level teardown.
-    td = tempfile.mkdtemp(dir=TMP_TEST_DIR)
+    td = Path(tempfile.mkdtemp(dir=TMP_TEST_DIR))
     for name in ('profile_foo', 'profile_hello', 'not_a_profile'):
         Path(td, name).mkdir()
     if dec.unicode_paths:
         Path(td, u'profile_ünicode').mkdir()
 
-    with open(Path(td, 'profile_file'), 'w') as f:
+    with open(td / 'profile_file', 'w') as f:
         f.write("I am not a profile directory")
     profiles = list_profiles_in(td)
     


### PR DESCRIPTION
replaces path strings with pathlib.Path objects as per [this issue](https://github.com/ipython/ipython/issues/12515)