### PR TITLE
Update history.py to use pathlib

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -230,7 +230,7 @@ class HistoryAccessor(HistoryAccessorBase):
         # use detect_types so that timestamps return datetime objects
         kwargs = dict(detect_types=sqlite3.PARSE_DECLTYPES|sqlite3.PARSE_COLNAMES)
         kwargs.update(self.connection_options)
-        self.db = sqlite3.connect(self.hist_file, **kwargs)
+        self.db = sqlite3.connect(str(self.hist_file), **kwargs)
         self.db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer
                         primary key autoincrement, start timestamp,
                         end timestamp, num_cmds integer, remark text)""")
@@ -801,7 +801,7 @@ class HistorySavingThread(threading.Thread):
     def run(self):
         # We need a separate db connection per thread:
         try:
-            self.db = sqlite3.connect(self.history_manager.hist_file,
+            self.db = sqlite3.connect(str(self.history_manager.hist_file),
                             **self.history_manager.connection_options
             )
             while True:

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -16,8 +16,17 @@ from decorator import decorator
 from IPython.utils.decorators import undoc
 from IPython.paths import locate_profile
 from traitlets import (
-    Any, Bool, Dict, Instance, Integer, List, Unicode, Union, TraitError,
-    default, observe
+    Any,
+    Bool,
+    Dict,
+    Instance,
+    Integer,
+    List,
+    Unicode,
+    Union,
+    TraitError,
+    default,
+    observe,
 )
 
 #-----------------------------------------------------------------------------
@@ -100,6 +109,7 @@ def catch_corrupt_db(f, self, *a, **kw):
             # Failed with :memory:, something serious is wrong
             raise
 
+
 class HistoryAccessorBase(LoggingConfigurable):
     """An abstract class for History Accessors """
 
@@ -129,7 +139,8 @@ class HistoryAccessor(HistoryAccessorBase):
     _corrupt_db_limit = 2
 
     # String holding the path to the history file
-    hist_file = Union([Instance(Path), Unicode()],
+    hist_file = Union(
+        [Instance(Path), Unicode()],
         help="""Path to file to use for SQLite history database.
 
         By default, IPython will put the history database in the IPython
@@ -145,7 +156,7 @@ class HistoryAccessor(HistoryAccessorBase):
         you can also use the specific value `:memory:` (including the colon
         at both end but not the back ticks), to avoid creating an history file.
 
-        """
+        """,
     ).tag(config=True)
 
     enabled = Bool(True,
@@ -178,7 +189,7 @@ class HistoryAccessor(HistoryAccessorBase):
                     (self.__class__.__name__, new)
             raise TraitError(msg)
 
-    def __init__(self, profile='default', hist_file="", **traits):
+    def __init__(self, profile="default", hist_file="", **traits):
         """Create a new history accessor.
 
         Parameters
@@ -200,7 +211,7 @@ class HistoryAccessor(HistoryAccessorBase):
             self.hist_file = hist_file
 
         try:
-            self.hist_file 
+            self.hist_file
         except TraitError:
             # No one has set the hist_file, yet.
             self.hist_file = self._get_hist_file_name(profile)
@@ -218,7 +229,7 @@ class HistoryAccessor(HistoryAccessorBase):
         profile : str
           The name of a profile which has a history file.
         """
-        return Path(locate_profile(profile)) / 'history.sqlite'
+        return Path(locate_profile(profile)) / "history.sqlite"
 
     @catch_corrupt_db
     def init_db(self):
@@ -535,7 +546,7 @@ class HistoryManager(HistoryAccessor):
         The profile parameter is ignored, but must exist for compatibility with
         the parent class."""
         profile_dir = self.shell.profile_dir.location
-        return Path(profile_dir)/'history.sqlite'
+        return Path(profile_dir) / "history.sqlite"
 
     @only_when_enabled
     def new_session(self, conn=None):
@@ -801,8 +812,9 @@ class HistorySavingThread(threading.Thread):
     def run(self):
         # We need a separate db connection per thread:
         try:
-            self.db = sqlite3.connect(str(self.history_manager.hist_file),
-                            **self.history_manager.connection_options
+            self.db = sqlite3.connect(
+                str(self.history_manager.hist_file),
+                **self.history_manager.connection_options
             )
             while True:
                 self.history_manager.save_flag.wait()

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -7,7 +7,7 @@
 
 # stdlib
 import io
-import os
+from pathlib import Path
 import sys
 import tempfile
 from datetime import datetime
@@ -29,8 +29,9 @@ def test_proper_default_encoding():
 def test_history():
     ip = get_ipython()
     with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
         hist_manager_ori = ip.history_manager
-        hist_file = os.path.join(tmpdir, 'history.sqlite')
+        hist_file = tmp_path / 'history.sqlite'
         try:
             ip.history_manager = HistoryManager(shell=ip, hist_file=hist_file)
             hist = [u'a=1', u'def f():\n    test = 1\n    return test', u"b='€Æ¾÷ß'"]
@@ -55,10 +56,10 @@ def test_history():
             ip.magic('%hist 2-500')
 
             # Check that we can write non-ascii characters to a file
-            ip.magic("%%hist -f %s" % os.path.join(tmpdir, "test1"))
-            ip.magic("%%hist -pf %s" % os.path.join(tmpdir, "test2"))
-            ip.magic("%%hist -nf %s" % os.path.join(tmpdir, "test3"))
-            ip.magic("%%save %s 1-10" % os.path.join(tmpdir, "test4"))
+            ip.magic("%%hist -f %s" % (tmp_path / "test1"))
+            ip.magic("%%hist -pf %s" % (tmp_path / "test2"))
+            ip.magic("%%hist -nf %s" % (tmp_path / "test3"))
+            ip.magic("%%save %s 1-10" % (tmp_path / "test4"))
 
             # New session
             ip.history_manager.reset()
@@ -126,8 +127,8 @@ def test_history():
             nt.assert_equal(list(gothist), [(1,3,(hist[2],"spam"))] )
 
             # Cross testing: check that magic %save can get previous session.
-            testfilename = os.path.realpath(os.path.join(tmpdir, "test.py"))
-            ip.magic("save " + testfilename + " ~1/1-3")
+            testfilename = (tmp_path /"test.py").resolve()
+            ip.magic("save " + str(testfilename) + " ~1/1-3")
             with io.open(testfilename, encoding='utf-8') as testfile:
                 nt.assert_equal(testfile.read(),
                                         u"# coding: utf-8\n" + u"\n".join(hist)+u"\n")
@@ -176,13 +177,13 @@ def test_timestamp_type():
 def test_hist_file_config():
     cfg = Config()
     tfile = tempfile.NamedTemporaryFile(delete=False)
-    cfg.HistoryManager.hist_file = tfile.name
+    cfg.HistoryManager.hist_file = Path(tfile.name)
     try:
         hm = HistoryManager(shell=get_ipython(), config=cfg)
         nt.assert_equal(hm.hist_file, cfg.HistoryManager.hist_file)
     finally:
         try:
-            os.remove(tfile.name)
+            Path(tfile.name).unlink()
         except OSError:
             # same catch as in testing.tools.TempFileMixin
             # On Windows, even though we close the file, we still can't
@@ -197,7 +198,7 @@ def test_histmanager_disabled():
     ip = get_ipython()
     with TemporaryDirectory() as tmpdir:
         hist_manager_ori = ip.history_manager
-        hist_file = os.path.join(tmpdir, 'history.sqlite')
+        hist_file = Path(tmpdir) / 'history.sqlite'
         cfg.HistoryManager.hist_file = hist_file
         try:
             ip.history_manager = HistoryManager(shell=ip, config=cfg)
@@ -211,4 +212,4 @@ def test_histmanager_disabled():
             ip.history_manager = hist_manager_ori
 
     # hist_file should not be created
-    nt.assert_false(os.path.exists(hist_file))
+    nt.assert_false(hist_file.exists())

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -31,7 +31,7 @@ def test_history():
     with TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
         hist_manager_ori = ip.history_manager
-        hist_file = tmp_path / 'history.sqlite'
+        hist_file = tmp_path / "history.sqlite"
         try:
             ip.history_manager = HistoryManager(shell=ip, hist_file=hist_file)
             hist = [u'a=1', u'def f():\n    test = 1\n    return test', u"b='€Æ¾÷ß'"]
@@ -127,7 +127,7 @@ def test_history():
             nt.assert_equal(list(gothist), [(1,3,(hist[2],"spam"))] )
 
             # Cross testing: check that magic %save can get previous session.
-            testfilename = (tmp_path /"test.py").resolve()
+            testfilename = (tmp_path / "test.py").resolve()
             ip.magic("save " + str(testfilename) + " ~1/1-3")
             with io.open(testfilename, encoding='utf-8') as testfile:
                 nt.assert_equal(testfile.read(),
@@ -198,7 +198,7 @@ def test_histmanager_disabled():
     ip = get_ipython()
     with TemporaryDirectory() as tmpdir:
         hist_manager_ori = ip.history_manager
-        hist_file = Path(tmpdir) / 'history.sqlite'
+        hist_file = Path(tmpdir) / "history.sqlite"
         cfg.HistoryManager.hist_file = hist_file
         try:
             ip.history_manager = HistoryManager(shell=ip, config=cfg)

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -10,6 +10,7 @@ Authors
 # Distributed under the terms of the Modified BSD License.
 
 import os
+from pathlib import Path
 import re
 import sys
 import tempfile
@@ -142,7 +143,7 @@ def default_config():
     config.TerminalTerminalInteractiveShell.term_title = False,
     config.TerminalInteractiveShell.autocall = 0
     f = tempfile.NamedTemporaryFile(suffix=u'test_hist.sqlite', delete=False)
-    config.HistoryManager.hist_file = f.name
+    config.HistoryManager.hist_file = Path(f.name)
     f.close()
     config.HistoryManager.db_cache_size = 10000
     return config


### PR DESCRIPTION
Tests were returning exeption in atexit_operations
AttributeError: 'str' object has no attribute 'unlink'

This commit embraces usage of pathlib in history.py and related
tests, fixing aforementioned problem.