### PR TITLE
Fix settrace for recursive debugger

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -588,6 +588,7 @@ class Pdb(OldPdb):
         argument (which is an arbitrary expression or statement to be
         executed in the current environment).
         """
+        trace_function = sys.gettrace()
         sys.settrace(None)
         globals = self.curframe.f_globals
         locals = self.curframe_locals
@@ -598,7 +599,7 @@ class Pdb(OldPdb):
         self.message("ENTERING RECURSIVE DEBUGGER")
         sys.call_tracing(p.run, (arg, globals, locals))
         self.message("LEAVING RECURSIVE DEBUGGER")
-        sys.settrace(self.trace_dispatch)
+        sys.settrace(trace_function)
         self.lastcmd = p.lastcmd
 
     def do_pdef(self, arg):


### PR DESCRIPTION
Fixes #12658
```
Python 3.7.6 (default, Jan  8 2020, 20:23:39) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.18.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: 1/0
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-1-9e1622b385b6> in <module>
----> 1 1/0

ZeroDivisionError: division by zero

In [2]: %debug
> <ipython-input-1-9e1622b385b6>(1)<module>()
----> 1 1/0

ipdb> debug print()
ENTERING RECURSIVE DEBUGGER
> <string>(1)<module>()

(ipdb>) q
LEAVING RECURSIVE DEBUGGER
ipdb> w
> <ipython-input-1-9e1622b385b6>(1)<module>()
----> 1 1/0

ipdb>
```