### PR TITLE
[IPython/core/interactiveshell.py] Fix handling of SystemExit as thrown by argparse

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2031,6 +2031,10 @@ class InteractiveShell(SingletonConfigurable):
                 self.showsyntaxerror(filename, running_compiled_code)
             elif etype is UsageError:
                 self.show_usage_error(value)
+            elif etype is SystemExit:
+                elist = traceback.extract_tb(last_traceback) if running_compiled_code else []
+                stb = self.SyntaxTB.structured_traceback(etype, value, elist)
+                self._showtraceback(etype, value, stb)
             else:
                 if exception_only:
                     stb = ['An exception has occurred, use %tb to see '


### PR DESCRIPTION
Related: https://github.com/ipython/ipython/issues/12652 (with solution for IPython 7.18.1)

Replicate bug:
```
ipython3 -c 'from argparse import ArgumentParser; p=ArgumentParser();p.add_argument("-a");p.parse_args(["-a"])'
```

Output with this PR:
```
usage: ipython3 [-h] [-a A]
ipython3: error: argument -a: expected one argument
Traceback (most recent call last):

  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py", line 1800, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)

  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py", line 2006, in _parse_known_args
    start_index = consume_optional(start_index)

  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py", line 1936, in consume_optional
    arg_count = match_argument(action, selected_patterns)

  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py", line 2101, in _match_argument
    raise ArgumentError(action, msg)

ArgumentError: argument -a: expected one argument


During handling of the above exception, another exception occurred:

SystemExit: 2

/usr/local/lib/python3.8/site-packages/IPython/core/interactiveshell.py:3424: UserWarning: To exit: use 'exit', 'quit', or Ctrl-D.
  warn("To exit: use 'exit', 'quit', or Ctrl-D.", stacklevel=1)
```

Output without this PR:
```
usage: ipython3 [-h] [-a A]
ipython3: error: argument -a: expected one argument
---------------------------------------------------------------------------
ArgumentError                             Traceback (most recent call last)
/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser.parse_known_args(self, args, namespace)
   1799 try:
-> 1800     namespace, args = self._parse_known_args(args, namespace)
   1801     if hasattr(namespace, _UNRECOGNIZED_ARGS_ATTR):

/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser._parse_known_args(self, arg_strings, namespace)
   2005     # consume the next optional and any arguments for it
-> 2006     start_index = consume_optional(start_index)
   2008 # consume any positionals following the last Optional

/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser._parse_known_args.<locals>.consume_optional(start_index)
   1935 selected_patterns = arg_strings_pattern[start:]
-> 1936 arg_count = match_argument(action, selected_patterns)
   1937 stop = start + arg_count

/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser._match_argument(self, action, arg_strings_pattern)
   2098         msg = ngettext('expected %s argument',
   2099                        'expected %s arguments',
   2100                        action.nargs) % action.nargs
-> 2101     raise ArgumentError(action, msg)
   2103 # return the number of arguments matched

ArgumentError: argument -a: expected one argument

During handling of the above exception, another exception occurred:

SystemExit                                Traceback (most recent call last)
    [... skipping hidden 1 frame]

<ipython-input-1-20b1cea4e9fc> in <module>
----> 1 from argparse import ArgumentParser; p=ArgumentParser();p.add_argument("-a");p.parse_args(["-a"])

/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser.parse_args(self, args, namespace)
   1767 def parse_args(self, args=None, namespace=None):
-> 1768     args, argv = self.parse_known_args(args, namespace)
   1769     if argv:

/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser.parse_known_args(self, args, namespace)
   1806 err = _sys.exc_info()[1]
-> 1807 self.error(str(err))

/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser.error(self, message)
   2520 args = {'prog': self.prog, 'message': message}
-> 2521 self.exit(2, _('%(prog)s: error: %(message)s\n') % args)

/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/argparse.py in ArgumentParser.exit(self, status, message)
   2507     self._print_message(message, _sys.stderr)
-> 2508 _sys.exit(status)

SystemExit: 2

During handling of the above exception, another exception occurred:

AssertionError                            Traceback (most recent call last)
    [... skipping hidden 1 frame]

/usr/local/lib/python3.8/site-packages/IPython/core/interactiveshell.py in InteractiveShell.showtraceback(self, exc_tuple, filename, tb_offset, exception_only, running_compiled_code)
   2035 if exception_only:
   2036     stb = ['An exception has occurred, use %tb to see '
   2037            'the full traceback.\n']
-> 2038     stb.extend(self.InteractiveTB.get_exception_only(etype,
   2039                                                      value))
   2040 else:
   2041     try:
   2042         # Exception classes can customise their traceback - we
   2043         # use this in IPython.parallel for exceptions occurring
   2044         # in the engines. This should return a list of strings.

/usr/local/lib/python3.8/site-packages/IPython/core/ultratb.py in ListTB.get_exception_only(self, etype, value)
    510 def get_exception_only(self, etype, value):
    511     """Only print the exception type and message, without a traceback.
    512 
    513     Parameters
   (...)
    516     evalue : exception value
    517     """
--> 518     return ListTB.structured_traceback(self, etype, value)

/usr/local/lib/python3.8/site-packages/IPython/core/ultratb.py in ListTB.structured_traceback(self, etype, evalue, etb, tb_offset, context)
    390     chained_exc_ids.add(id(exception[1]))
    391     chained_exceptions_tb_offset = 0
    392     out_list = (
--> 393         self.structured_traceback(
    394             etype, evalue, (etb, chained_exc_ids),
    395             chained_exceptions_tb_offset, context)
    396         + chained_exception_message
    397         + out_list)
    399 return out_list

/usr/local/lib/python3.8/site-packages/IPython/core/ultratb.py in AutoFormattedTB.structured_traceback(self, etype, value, tb, tb_offset, number_of_lines_of_context)
    996 else:
    997     self.tb = tb
--> 998 return FormattedTB.structured_traceback(
    999     self, etype, value, tb, tb_offset, number_of_lines_of_context)

/usr/local/lib/python3.8/site-packages/IPython/core/ultratb.py in FormattedTB.structured_traceback(self, etype, value, tb, tb_offset, number_of_lines_of_context)
    895 mode = self.mode
    896 if mode in self.verbose_modes:
    897     # Verbose modes need a full traceback
--> 898     return VerboseTB.structured_traceback(
    899         self, etype, value, tb, tb_offset, number_of_lines_of_context
    900     )
    901 elif mode == 'Minimal':
    902     return ListTB.get_exception_only(self, etype, value)

/usr/local/lib/python3.8/site-packages/IPython/core/ultratb.py in VerboseTB.structured_traceback(self, etype, evalue, etb, tb_offset, number_of_lines_of_context)
    751 def structured_traceback(self, etype, evalue, etb, tb_offset=None,
    752                          number_of_lines_of_context=5):
    753     """Return a nice text document describing the traceback."""
--> 755     formatted_exception = self.format_exception_as_a_whole(etype, evalue, etb, number_of_lines_of_context,
    756                                                            tb_offset)
    758     colors = self.Colors  # just a shorthand + quicker name lookup
    759     colorsnormal = colors.Normal  # used a lot

/usr/local/lib/python3.8/site-packages/IPython/core/ultratb.py in VerboseTB.format_exception_as_a_whole(self, etype, evalue, etb, number_of_lines_of_context, tb_offset)
    696 tb_offset = self.tb_offset if tb_offset is None else tb_offset
    697 head = self.prepare_header(etype, self.long_header)
--> 698 records = self.get_records(etb, number_of_lines_of_context, tb_offset)
    700 frames = []
    701 skipped = 0

/usr/local/lib/python3.8/site-packages/IPython/core/ultratb.py in VerboseTB.get_records(self, etb, number_of_lines_of_context, tb_offset)
    743     formatter = None
    744 options = stack_data.Options(
    745     before=before,
    746     after=after,
    747     pygments_formatter=formatter,
    748 )
--> 749 return list(stack_data.FrameInfo.stack_data(etb, options=options))[tb_offset:]

/usr/local/lib/python3.8/site-packages/stack_data/core.py in FrameInfo.stack_data(cls, frame_or_tb, options, collapse_repeated_frames)
    506 @classmethod
    507 def stack_data(
    508         cls,
   (...)
    512         collapse_repeated_frames: bool = True
    513 ) -> Iterator[Union['FrameInfo', RepeatedFrames]]:
    514     """
    515     An iterator of FrameInfo and RepeatedFrames objects representing
    516     a full traceback or stack. Similar consecutive frames are collapsed into RepeatedFrames
   (...)
    520     and optionally an Options object to configure.
    521     """
--> 522     stack = list(iter_stack(frame_or_tb))
    524     # Reverse the stack from a frame so that it's in the same order
    525     # as the order from a traceback, which is the order of a printed
    526     # traceback when read top to bottom (most recent call last)
    527     if is_frame(frame_or_tb):

/usr/local/lib/python3.8/site-packages/stack_data/utils.py in iter_stack(frame_or_tb)
     92 while frame_or_tb:
     93     yield frame_or_tb
---> 94     if is_frame(frame_or_tb):
     95         frame_or_tb = frame_or_tb.f_back
     96     else:

/usr/local/lib/python3.8/site-packages/stack_data/utils.py in is_frame(frame_or_tb)
     86 def is_frame(frame_or_tb: Union[FrameType, TracebackType]) -> bool:
---> 87     assert_(isinstance(frame_or_tb, (types.FrameType, types.TracebackType)))
     88     return isinstance(frame_or_tb, (types.FrameType,))

/usr/local/lib/python3.8/site-packages/stack_data/utils.py in assert_(condition, error)
    166 if isinstance(error, str):
    167     error = AssertionError(error)
--> 168 raise error

AssertionError:
```