### PR TITLE
remove yield test that are not support by pytest anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     fi
   - pip install -e file://$PWD#egg=ipython[test] --upgrade
   - pip install trio curio --upgrade --upgrade-strategy eager
-  - pip install 'pytest<6' 'matplotlib !=3.2.0'
+  - pip install 'pytest' 'matplotlib !=3.2.0'
   - pip install codecov check-manifest pytest-cov --upgrade
 
 

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -138,7 +138,7 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
     except FindCmdError:
         return None
     try:
-        workdir = PurePath(tempfile.mkdtemp())
+        workdir = Path(tempfile.mkdtemp())
         tmpfile = workdir.joinpath("tmp.tex")
         dvifile = workdir.joinpath("tmp.dvi")
         outfile = workdir.joinpath("tmp.png")

--- a/IPython/lib/tests/test_latextools.py
+++ b/IPython/lib/tests/test_latextools.py
@@ -33,9 +33,9 @@ def no_op(*args, **kwargs):
     yield
 
 
+@skip_iptest_but_not_pytest
 @onlyif_cmds_exist("latex", "dvipng")
 @pytest.mark.parametrize("s, wrap", [(u"$$x^2$$", False), (u"x^2", True)])
-@skip_iptest_but_not_pytest
 def test_latex_to_png_dvipng_runs(s, wrap):
     """
     Test that latex_to_png_dvipng just runs without error.

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -12,9 +12,10 @@ import string
 import unittest
 
 import nose.tools as nt
+import pytest
 
 from IPython.lib import pretty
-from IPython.testing.decorators import skip_without
+from IPython.testing.decorators import skip_without, skip_iptest_but_not_pytest
 
 from io import StringIO
 
@@ -105,17 +106,36 @@ def test_callability_checking():
     nt.assert_equal(gotoutput, expectedoutput)
 
 
-def test_sets():
+@pytest.mark.parametrize(
+    "obj,expected_output",
+    zip(
+        [
+            set(),
+            frozenset(),
+            set([1]),
+            frozenset([1]),
+            set([1, 2]),
+            frozenset([1, 2]),
+            set([-1, -2, -3]),
+        ],
+        [
+            "set()",
+            "frozenset()",
+            "{1}",
+            "frozenset({1})",
+            "{1, 2}",
+            "frozenset({1, 2})",
+            "{-3, -2, -1}",
+        ],
+    ),
+)
+@skip_iptest_but_not_pytest
+def test_sets(obj, expected_output):
     """
     Test that set and frozenset use Python 3 formatting.
     """
-    objects = [set(), frozenset(), set([1]), frozenset([1]), set([1, 2]),
-        frozenset([1, 2]), set([-1, -2, -3])]
-    expected = ['set()', 'frozenset()', '{1}', 'frozenset({1})', '{1, 2}',
-        'frozenset({1, 2})', '{-3, -2, -1}']
-    for obj, expected_output in zip(objects, expected):
-        got_output = pretty.pretty(obj)
-        yield nt.assert_equal, got_output, expected_output
+    got_output = pretty.pretty(obj)
+    nt.assert_equal(got_output, expected_output)
 
 
 @skip_without('xxlimited')

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -154,6 +154,17 @@ def make_label_dec(label, ds=None):
     return decor
 
 
+def skip_iptest_but_not_pytest(f):
+    """
+    Warnign this will make the test invisible to iptest.
+    """
+    import os
+
+    if os.environ.get("IPTEST_WORKING_DIR", None) is not None:
+        f.__test__ = False
+    return f
+
+
 # Inspired by numpy's skipif, but uses the full apply_wrapper utility to
 # preserve function metadata better and allows the skip condition to be a
 # callable.

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -376,9 +376,14 @@ def onlyif_cmds_exist(*commands):
     Decorator to skip test when at least one of `commands` is not found.
     """
     for cmd in commands:
+        reason = "This test runs only if command '{cmd}' is installed"
         if not shutil.which(cmd):
-            return skip("This test runs only if command '{0}' "
-                        "is installed".format(cmd))
+            if os.environ.get("IPTEST_WORKING_DIR", None) is not None:
+                return skip(reason)
+            else:
+                import pytest
+
+                return pytest.mark.skip(reason=reason)
     return null_deco
 
 def onlyif_any_cmd_exists(*commands):

--- a/IPython/utils/tests/test_capture.py
+++ b/IPython/utils/tests/test_capture.py
@@ -16,6 +16,9 @@
 import sys
 
 import nose.tools as nt
+import pytest
+
+from IPython.testing.decorators import skip_iptest_but_not_pytest
 
 from IPython.utils import capture
 
@@ -66,38 +69,45 @@ hello_stderr = "hello, stderr"
 #-----------------------------------------------------------------------------
 # Test Functions
 #-----------------------------------------------------------------------------
-
-def test_rich_output_empty():
+@pytest.mark.parametrize("method_mime", _mime_map.items())
+@skip_iptest_but_not_pytest
+def test_rich_output_empty(method_mime):
     """RichOutput with no args"""
     rich = capture.RichOutput()
-    for method, mime in _mime_map.items():
-        yield nt.assert_equal, getattr(rich, method)(), None
+    method, mime = method_mime
+    nt.assert_equal(getattr(rich, method)(), None)
     
 def test_rich_output():
     """test RichOutput basics"""
     data = basic_data
     metadata = basic_metadata
     rich = capture.RichOutput(data=data, metadata=metadata)
-    yield nt.assert_equal, rich._repr_html_(), data['text/html']
-    yield nt.assert_equal, rich._repr_png_(), (data['image/png'], metadata['image/png'])
-    yield nt.assert_equal, rich._repr_latex_(), None
-    yield nt.assert_equal, rich._repr_javascript_(), None
-    yield nt.assert_equal, rich._repr_svg_(), None
+    nt.assert_equal(rich._repr_html_(), data["text/html"])
+    nt.assert_equal(rich._repr_png_(), (data["image/png"], metadata["image/png"]))
+    nt.assert_equal(rich._repr_latex_(), None)
+    nt.assert_equal(rich._repr_javascript_(), None)
+    nt.assert_equal(rich._repr_svg_(), None)
 
-def test_rich_output_no_metadata():
+
+@skip_iptest_but_not_pytest
+@pytest.mark.parametrize("method_mime", _mime_map.items())
+def test_rich_output_no_metadata(method_mime):
     """test RichOutput with no metadata"""
     data = full_data
     rich = capture.RichOutput(data=data)
-    for method, mime in _mime_map.items():
-        yield nt.assert_equal, getattr(rich, method)(), data[mime]
+    method, mime = method_mime
+    nt.assert_equal(getattr(rich, method)(), data[mime])
 
-def test_rich_output_metadata():
+
+@skip_iptest_but_not_pytest
+@pytest.mark.parametrize("method_mime", _mime_map.items())
+def test_rich_output_metadata(method_mime):
     """test RichOutput with metadata"""
     data = full_data
     metadata = full_metadata
     rich = capture.RichOutput(data=data, metadata=metadata)
-    for method, mime in _mime_map.items():
-        yield nt.assert_equal, getattr(rich, method)(), (data[mime], metadata[mime])
+    method, mime = method_mime
+    nt.assert_equal(getattr(rich, method)(), (data[mime], metadata[mime]))
 
 def test_rich_output_display():
     """test RichOutput.display
@@ -109,10 +119,10 @@ def test_rich_output_display():
     rich = capture.RichOutput(data=data)
     with capture.capture_output() as cap:
         rich.display()
-    yield nt.assert_equal, len(cap.outputs), 1
+    nt.assert_equal(len(cap.outputs), 1)
     rich2 = cap.outputs[0]
-    yield nt.assert_equal, rich2.data, rich.data
-    yield nt.assert_equal, rich2.metadata, rich.metadata
+    nt.assert_equal(rich2.data, rich.data)
+    nt.assert_equal(rich2.metadata, rich.metadata)
 
 def test_capture_output():
     """capture_output works"""
@@ -121,8 +131,9 @@ def test_capture_output():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    yield nt.assert_equal, hello_stdout, cap.stdout
-    yield nt.assert_equal, hello_stderr, cap.stderr
+    nt.assert_equal(hello_stdout, cap.stdout)
+    nt.assert_equal(hello_stderr, cap.stderr)
+
 
 def test_capture_output_no_stdout():
     """test capture_output(stdout=False)"""
@@ -131,9 +142,10 @@ def test_capture_output_no_stdout():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    yield nt.assert_equal, "", cap.stdout
-    yield nt.assert_equal, hello_stderr, cap.stderr
-    yield nt.assert_equal, len(cap.outputs), 1
+    nt.assert_equal("", cap.stdout)
+    nt.assert_equal(hello_stderr, cap.stderr)
+    nt.assert_equal(len(cap.outputs), 1)
+
 
 def test_capture_output_no_stderr():
     """test capture_output(stderr=False)"""
@@ -143,9 +155,10 @@ def test_capture_output_no_stderr():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    yield nt.assert_equal, hello_stdout, cap.stdout
-    yield nt.assert_equal, "", cap.stderr
-    yield nt.assert_equal, len(cap.outputs), 1
+    nt.assert_equal(hello_stdout, cap.stdout)
+    nt.assert_equal("", cap.stderr)
+    nt.assert_equal(len(cap.outputs), 1)
+
 
 def test_capture_output_no_display():
     """test capture_output(display=False)"""
@@ -154,6 +167,6 @@ def test_capture_output_no_display():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    yield nt.assert_equal, hello_stdout, cap.stdout
-    yield nt.assert_equal, hello_stderr, cap.stderr
-    yield nt.assert_equal, cap.outputs, []
+    nt.assert_equal(hello_stdout, cap.stdout)
+    nt.assert_equal(hello_stderr, cap.stderr)
+    nt.assert_equal(cap.outputs, [])

--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -3,6 +3,8 @@
 # Distributed under the terms of the Modified BSD License.
 
 import nose.tools as nt
+import pytest
+from IPython.testing.decorators import skip_iptest_but_not_pytest
 
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 
@@ -120,14 +122,20 @@ def test_line_at_cursor():
     nt.assert_equal(line, "pri")
     nt.assert_equal(offset, 4)
 
-def test_multiline_statement():
+
+@pytest.mark.parametrize(
+    "c, token",
+    zip(
+        list(range(16, 22)) + list(range(22, 28)),
+        ["int"] * (22 - 16) + ["map"] * (28 - 22),
+    ),
+)
+@skip_iptest_but_not_pytest
+def test_multiline_statement(c, token):
     cell = """a = (1,
     3)
 
 int()
 map()
 """
-    for c in range(16, 22):
-        yield lambda cell, c: expect_token("int", cell, c), cell, c
-    for c in range(22, 28):
-        yield lambda cell, c: expect_token("map", cell, c), cell, c
+    expect_token(token, cell, c)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ init:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "%CMD_IN_ENV%  python -m pip install --upgrade setuptools pip"
-  - "%CMD_IN_ENV%  pip install nose coverage"
+  - "%CMD_IN_ENV%  pip install nose coverage pytest"
   - "%CMD_IN_ENV%  pip install .[test]"
   - "%CMD_IN_ENV%  mkdir results"
   - "%CMD_IN_ENV%  cd results"


### PR DESCRIPTION
Remove yield test that are not support by pytest anymore

And remove comparison of str/unicode as it is not relevant anymore as
both are the same.

We can now unpin pytest as well, which we shoudl make sure is in release
notes and in the conda-forge recipe