### PR TITLE
Reduce travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - graphviz
 
 python:
-    - 3.6
+    - 3.8
 
 env:
   global:
@@ -41,13 +41,8 @@ install:
     fi
   - pip install -e file://$PWD#egg=ipython[test] --upgrade
   - pip install trio curio --upgrade --upgrade-strategy eager
-  - pip install 'pytest<6' 'matplotlib !=3.2.0' mypy
+  - pip install 'pytest<6' 'matplotlib !=3.2.0'
   - pip install codecov check-manifest pytest-cov --upgrade
-  - pip install mypy
-  - |
-    if [[ "$MASTER_DEPENDENCIES" == "True" ]]; then
-       pip install git+https://github.com/ipython/traitlets#egg=traitlets --force
-    fi
 
 
 script:
@@ -61,12 +56,10 @@ script:
     if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       cd /tmp && iptest --coverage xml && cd -
     fi
-  - pytest IPython
-  - mypy IPython/terminal/ptutils.py
-  - mypy IPython/core/c*.py
+  - pytest --maxfail=10 IPython
   # On the latest Python (on Linux) only, make sure that the docs build.
   - |
-    if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       pip install -r docs/requirements.txt
       python tools/fixup_whats_new_pr.py
       make -C docs/ html SPHINXOPTS="-W"
@@ -97,9 +90,6 @@ matrix:
       language: generic
       python: 3.7
       env: TRAVIS_PYTHON_VERSION=3.7
-    - arch: amd64
-      python: "3.8"
-      env: MASTER_DEPENDENCIES=True
   allow_failures:
     - python: nightly
 


### PR DESCRIPTION
Travis seem to now have a lower limit on open-source builds; so reduce
dependency on Travis to get faster turnaround.

Will also limit the number of failures to 10, so that if there are many
test failing we don't spend too many cycles.