### PR TITLE
use pathlib in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requires utilities which are not available under Windows."""
 
 import os
 import sys
+from pathlib import Path
 
 # **Python version check**
 #
@@ -61,7 +62,8 @@ Python {py} detected.
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
-if os.path.exists('MANIFEST'): os.remove('MANIFEST')
+if Path("MANIFEST").exists():
+    Path("MANIFEST").unlink()
 
 from distutils.core import setup
 
@@ -82,9 +84,6 @@ from setupbase import (
     install_scripts_for_symlink,
     unsymlink,
 )
-
-isfile = os.path.isfile
-pjoin = os.path.join
 
 #-------------------------------------------------------------------------------
 # Handle OS specific things


### PR DESCRIPTION
Hi!

I took a jab at #12515, using pathlib in `setup.py`.

This simply includes changing an `os.remove` to `pathlib.Path.unlink` ~which conveniently allows skipping the `os.path.exists` check altogether~ Edit: `Path.unlink(missing_ok: bool)` is only available from Python 3.8.

There're unused aliases to `os.path.isfile` & `os.path.join`, which I remove.

Hope this doesn't take much of your time to review.

Thanks!

