### PR TITLE
validate ESC_PAREN ('/') is followed by a callable name and not empty

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -395,7 +395,10 @@ def _tr_quote2(content):
 
 def _tr_paren(content):
     "Translate lines escaped with a slash: /"
-    name, _, args = content.partition(' ')
+    name, _, args = content.partition(" ")
+    if name == "":
+        raise SyntaxError(f'"{ESC_SHELL}" must be followed by a callable name')
+
     return '%s(%s)' % (name, ", ".join(args.split()))
 
 tr = { ESC_SHELL  : 'get_ipython().system({!r})'.format,


### PR DESCRIPTION
When running a single python expression with just a slash - `/`, a tuple is returned.

```python
In [1]: /
Out[1]: ()
```

This weird case happens because when a line starts with `/` the `inputtransformer` transforms it into a call of the first word after the `/` as the callable name and rest tokens after as arguments. 

This PR fixes that issue by validating that at least a callable name is given and it's not empty, if not a `SyntaxError` will be raised.

```python
In [1]: /
  File "<ipython-input-1-8f27084b6294>", line 1
    /
    ^
SyntaxError: invalid syntax


In [2]:
```

Validated that tests are passing.
