### PR TITLE
Issue #12107 fix: additional spaces while parsing timeit-magic options

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -663,7 +663,7 @@ class Magics(Configurable):
             if preserve_non_opts:
                 args = remainder_arg_str.lstrip()
             else:
-                args = ' '.join(args)
+                args = " ".join(args)
 
         return opts,args
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -618,6 +618,9 @@ class Magics(Configurable):
         posix = kw.get('posix', os.name == 'posix')
         strict = kw.get('strict', True)
 
+        preserve_non_opts = kw.get('preserve_non_opts', False)
+        remainder_arg_str = arg_str
+        
         # Check if we have more than one argument to warrant extra processing:
         odict = {}  # Dictionary with options
         args = arg_str.split()
@@ -630,8 +633,13 @@ class Magics(Configurable):
                 opts,args = getopt(argv, opt_str, long_opts)
             except GetoptError as e:
                 raise UsageError('%s ( allowed: "%s" %s)' % (e.msg,opt_str,
-                                        " ".join(long_opts))) from e
+                                                             " ".join(long_opts))) from e
             for o,a in opts:
+                if mode is 'string' and preserve_non_opts:
+                    # remove option-parts from the original args-string and preserve remaining-part.
+                    # This relies on the arg_split(...) and getopt(...)'s impl spec, that the parsed options are 
+                    # returned in the original order. 
+                    remainder_arg_str = remainder_arg_str.replace(o, '', 1).replace(a, '', 1)
                 if o.startswith('--'):
                     o = o[2:]
                 else:
@@ -649,7 +657,10 @@ class Magics(Configurable):
         # Prepare opts,args for return
         opts = Struct(odict)
         if mode == 'string':
-            args = ' '.join(args)
+            if preserve_non_opts:
+                args = remainder_arg_str.lstrip()
+            else:
+                args = ' '.join(args)
 
         return opts,args
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -618,9 +618,9 @@ class Magics(Configurable):
         posix = kw.get('posix', os.name == 'posix')
         strict = kw.get('strict', True)
 
-        preserve_non_opts = kw.get('preserve_non_opts', False)
+        preserve_non_opts = kw.get("preserve_non_opts", False)
         remainder_arg_str = arg_str
-        
+
         # Check if we have more than one argument to warrant extra processing:
         odict = {}  # Dictionary with options
         args = arg_str.split()
@@ -632,15 +632,18 @@ class Magics(Configurable):
             try:
                 opts,args = getopt(argv, opt_str, long_opts)
             except GetoptError as e:
-                raise UsageError('%s ( allowed: "%s" %s)' % (e.msg,opt_str,
-                                                             " ".join(long_opts))) from e
-            for o,a in opts:
-                if mode is 'string' and preserve_non_opts:
+                raise UsageError(
+                    '%s ( allowed: "%s" %s)' % (e.msg, opt_str, " ".join(long_opts))
+                ) from e
+            for o, a in opts:
+                if mode is "string" and preserve_non_opts:
                     # remove option-parts from the original args-string and preserve remaining-part.
-                    # This relies on the arg_split(...) and getopt(...)'s impl spec, that the parsed options are 
-                    # returned in the original order. 
-                    remainder_arg_str = remainder_arg_str.replace(o, '', 1).replace(a, '', 1)
-                if o.startswith('--'):
+                    # This relies on the arg_split(...) and getopt(...)'s impl spec, that the parsed options are
+                    # returned in the original order.
+                    remainder_arg_str = remainder_arg_str.replace(o, "", 1).replace(
+                        a, "", 1
+                    )
+                if o.startswith("--"):
                     o = o[2:]
                 else:
                     o = o[1:]

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1073,8 +1073,8 @@ class ExecutionMagics(Magics):
         does not matter as long as results from timeit.py are not mixed with
         those from %timeit."""
 
-        opts, stmt = self.parse_options(line,'n:r:tcp:qo',
-                                        posix=False, strict=False)
+        opts, stmt = self.parse_options(line, 'n:r:tcp:qo',
+                                        posix=False, strict=False, preserve_non_opts=True)
         if stmt == "" and cell is None:
             return
         

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1073,8 +1073,9 @@ class ExecutionMagics(Magics):
         does not matter as long as results from timeit.py are not mixed with
         those from %timeit."""
 
-        opts, stmt = self.parse_options(line, 'n:r:tcp:qo',
-                                        posix=False, strict=False, preserve_non_opts=True)
+        opts, stmt = self.parse_options(
+            line, "n:r:tcp:qo", posix=False, strict=False, preserve_non_opts=True
+        )
         if stmt == "" and cell is None:
             return
         

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -473,17 +473,19 @@ def test_parse_options():
 def test_parse_options_preserve_non_option_string():
     """Test to assert preservation of non-option part of magic-block, while parsing magic options."""
     m = DummyMagics(_ip)
-    opts, stmt = m.parse_options(' -n1  -r 13 _ = 314 + foo', 'n:r:', preserve_non_opts= True)
-    nt.assert_equal(opts, {'n': '1', 'r': '13'})
-    nt.assert_equal(stmt, '_ = 314 + foo')
+    opts, stmt = m.parse_options(
+        " -n1  -r 13 _ = 314 + foo", "n:r:", preserve_non_opts=True
+    )
+    nt.assert_equal(opts, {"n": "1", "r": "13"})
+    nt.assert_equal(stmt, "_ = 314 + foo")
 
 
 def test_run_magic_preserve_code_block():
     """Test to assert preservation of non-option part of magic-block, while running magic."""
-    _ip.user_ns['spaces'] = []
+    _ip.user_ns["spaces"] = []
     _ip.magic("timeit -n1 -r1 spaces.append([s.count(' ') for s in ['document']])")
-    assert _ip.user_ns['spaces'] == [[0]]
-    
+    assert _ip.user_ns["spaces"] == [[0]]
+
 
 def test_dirops():
     """Test various directory handling operations."""

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -470,6 +470,21 @@ def test_parse_options():
     nt.assert_equal(m.parse_options(u'foo', '')[1], u'foo')
 
 
+def test_parse_options_preserve_non_option_string():
+    """Test to assert preservation of non-option part of magic-block, while parsing magic options."""
+    m = DummyMagics(_ip)
+    opts, stmt = m.parse_options(' -n1  -r 13 _ = 314 + foo', 'n:r:', preserve_non_opts= True)
+    nt.assert_equal(opts, {'n': '1', 'r': '13'})
+    nt.assert_equal(stmt, '_ = 314 + foo')
+
+
+def test_run_magic_preserve_code_block():
+    """Test to assert preservation of non-option part of magic-block, while running magic."""
+    _ip.user_ns['spaces'] = []
+    _ip.magic("timeit -n1 -r1 spaces.append([s.count(' ') for s in ['document']])")
+    assert _ip.user_ns['spaces'] == [[0]]
+    
+
 def test_dirops():
     """Test various directory handling operations."""
     # curpath = lambda :os.path.splitdrive(os.getcwd())[1].replace('\\','/')


### PR DESCRIPTION
The timeit magic needs to analyze its args to search for any of its supported options (-n/-r etc).
While doing so, the current implementation tokenizes whole args-string to look for the options. Though we should be only searching for the options in the prefix part of the args-string.
The full tokenization and splicing of the remainder string is changing the executable statement syntactically and/or semantically.
This fix preserves the original args-string and only removes the prefixed options, thus eliminating the problems associated with splicing.
