### PR TITLE
dpaste.com API correction

### DIFF
--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -246,7 +246,7 @@ class CodeMagics(Magics):
 
     @line_magic
     def pastebin(self, parameter_s=''):
-        """Upload code to dpaste's paste bin, returning the URL.
+        """Upload code to dpaste.com, returning the URL.
 
         Usage:\\
           %pastebin [-d "Custom description"] 1-7

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -267,14 +267,18 @@ class CodeMagics(Magics):
             print(e.args[0])
             return
 
-        post_data = urlencode({
-          "title": opts.get('d', "Pasted from IPython"),
-          "syntax": "python",
-          "content": code
-        }).encode('utf-8')
+        post_data = urlencode(
+            {
+                "title": opts.get("d", "Pasted from IPython"),
+                "syntax": "python",
+                "content": code,
+            }
+        ).encode("utf-8")
 
-        request = Request("http://dpaste.com/api/v2/",
-            headers={"User-Agent": "IPython v{}".format(version)})
+        request = Request(
+            "http://dpaste.com/api/v2/",
+            headers={"User-Agent": "IPython v{}".format(version)},
+        )
         response = urlopen(request, post_data)
         return response.headers.get('Location')
 

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -20,7 +20,7 @@ import re
 import sys
 import ast
 from itertools import chain
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 from urllib.parse import urlencode
 from pathlib import Path
 
@@ -29,6 +29,7 @@ from IPython.core.error import TryNext, StdinNotImplementedError, UsageError
 from IPython.core.macro import Macro
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.core.oinspect import find_file, find_source_lines
+from IPython.core.release import version
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.contexts import preserve_keys
 from IPython.utils.path import get_py_filename
@@ -255,7 +256,7 @@ class CodeMagics(Magics):
 
         Options:
 
-          -d: Pass a custom description for the gist. The default will say
+          -d: Pass a custom description. The default will say
               "Pasted from IPython".
         """
         opts, args = self.parse_options(parameter_s, 'd:')
@@ -268,11 +269,13 @@ class CodeMagics(Magics):
 
         post_data = urlencode({
           "title": opts.get('d', "Pasted from IPython"),
-          "syntax": "python3",
+          "syntax": "python",
           "content": code
         }).encode('utf-8')
 
-        response = urlopen("http://dpaste.com/api/v2/", post_data)
+        request = Request("http://dpaste.com/api/v2/",
+            headers={"User-Agent": "IPython v{}".format(version)})
+        response = urlopen(request, post_data)
         return response.headers.get('Location')
 
     @line_magic


### PR DESCRIPTION
Hello good people of IPython! 

I run [dpaste.com](https://dpaste.com/about), which IPython uses via the `%pastebin` magic. In July I updated my Pygments version, which caused the `python3` syntax key that IPython uses to disappear. I special-cased this on my end so that users wouldn't hit an error, but this PR fixes it at the source.

(TLDR on the syntax name change on the Pygments end:  `python` became `python2`, and `python3` became `python`.)

I also added a UA header to the request, to comply with the "automated use" section of the  [dpaste.com TOS](https://dpaste.com/terms) (though the `%pastebin` magic is more "semi-automated" than automated really).

This is my first IPython PR. I've read the contributor guidelines and believe I'm following expected workflow, but please let me know if more is needed (e.g. if I should create an Issue to track this). I don't have a local development instance of IPython, so apologies if the Travis build triggered by this PR finds some dumb error. I'll fix any such.