### PR TITLE
qt: sip changes for PyQt5 >= 5.11

### DIFF
--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -155,7 +155,12 @@ def qtapi_version():
     try:
         import sip
     except ImportError:
-        return
+        # as of PyQt5 5.11, sip is no longer available as a top-level
+        # module and needs to be imported from the PyQt5 namespace
+        try:
+            from PyQt5 import sip
+        except ImportError:
+            return
     try:
         return sip.getapi('QString')
     except ValueError:


### PR DESCRIPTION
The former top-level module `sip` becomes `PyQt5.sip`, as per https://www.riverbankcomputing.com/static/Docs/PyQt5/incompatibilities.html in PyQt5 >= 5.11

This adds a fallback to the logic for checking the Qt string API in `qtapi_version()`

https://github.com/ipython/ipython/pull/11613 fixed another case where `sip` was used unconditionally, but while this case already had a guard against failure, I think it would fail to get the API version in this case. It's possible that this is ultimately protecting a dead path though.

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966035