### PR TITLE
Make better prediction of the virtualenv site-packages version

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -940,12 +940,11 @@ class InteractiveShell(SingletonConfigurable):
             p_ver = sys.version_info[:2]
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
-            re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
-            if re_m:
-                predicted_p_ver = [int(num) for num in re_m.groups()]
-                predicted_path = Path(str(virtual_env_path).format(*predicted_p_ver))
+            predicted_p_ver = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
+            if predicted_p_ver:
+                predicted_path = Path(str(virtual_env_path).format(*predicted_p_ver.groups()))
                 if predicted_path.exists():
-                    p_ver = predicted_p_ver
+                    p_ver = predicted_p_ver.groups()
 
             virtual_env = str(virtual_env_path).format(*p_ver)
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -936,18 +936,17 @@ class InteractiveShell(SingletonConfigurable):
         else:
             venv_path_prefix = Path(os.environ["VIRTUAL_ENV"], "lib")
             venv_path_suffix = Path("site-packages")
+            p_ver = sys.version_info[:2]
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
             re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
             if re_m:
-                p_ver = [int(num) for num in re_m.groups()]
+                predicted_p_ver = [int(num) for num in re_m.groups()]
                 predicted_path = (
-                    venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
+                    venv_path_prefix / "python{}.{}".format(*predicted_p_ver) / venv_path_suffix
                 )
-                if not predicted_path.exists():
-                    p_ver = sys.version_info[:2]
-            else:
-                p_ver = sys.version_info[:2]
+                if predicted_path.exists():
+                    p_ver = predicted_p_ver
 
             virtual_env = str(
                 venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -949,7 +949,7 @@ class InteractiveShell(SingletonConfigurable):
             else:
                 p_ver = sys.version_info[:2]
 
-            virtual_env = (
+            virtual_env = str(
                 venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
             )
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -941,13 +941,17 @@ class InteractiveShell(SingletonConfigurable):
             re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
             if re_m:
                 p_ver = [int(num) for num in re_m.groups()]
-                predicted_path = venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
+                predicted_path = (
+                    venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
+                )
                 if not predicted_path.exists():
                     p_ver = sys.version_info[:2]
             else:
                 p_ver = sys.version_info[:2]
 
-            virtual_env = venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
+            virtual_env = (
+                venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
+            )
 
         warn(
             "Attempting to work in a virtualenv. If you encounter problems, "

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -943,7 +943,7 @@ class InteractiveShell(SingletonConfigurable):
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
             re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
             if re_m:
-                p_ver = [int(num) for num in m.groups()]
+                p_ver = [int(num) for num in re_m.groups()]
                 if not os.path.exists(venv_path.format(*p_ver)):
                     p_ver = sys.version_info[:2]
             else:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -934,7 +934,9 @@ class InteractiveShell(SingletonConfigurable):
         if sys.platform == "win32":
             virtual_env = Path(os.environ["VIRTUAL_ENV"], "Lib", "site-packages")
         else:
-            virtual_env_path = Path(os.environ["VIRTUAL_ENV"], "lib", "python{}.{}", "site-packages")
+            virtual_env_path = Path(
+                os.environ["VIRTUAL_ENV"], "lib", "python{}.{}", "site-packages"
+            )
             p_ver = sys.version_info[:2]
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -940,11 +940,11 @@ class InteractiveShell(SingletonConfigurable):
             p_ver = sys.version_info[:2]
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
-            predicted_p_ver = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
-            if predicted_p_ver:
-                predicted_path = Path(str(virtual_env_path).format(*predicted_p_ver.groups()))
+            re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
+            if re_m:
+                predicted_path = Path(str(virtual_env_path).format(*re_m.groups()))
                 if predicted_path.exists():
-                    p_ver = predicted_p_ver.groups()
+                    p_ver = re_m.groups()
 
             virtual_env = str(virtual_env_path).format(*p_ver)
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -938,10 +938,22 @@ class InteractiveShell(SingletonConfigurable):
                 "Lib", "site-packages"
             )
         else:
-            virtual_env = Path(os.environ["VIRTUAL_ENV"]).joinpath(
-                "lib", "python{}.{}".format(*sys.version_info[:2]), "site-packages"
+            venv_path = os.path.join(
+                os.environ["VIRTUAL_ENV"], "lib", "python{}.{}", "site-packages"
             )
-        
+
+            # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
+            if m := re.search(
+                r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"]
+            ):
+                p_ver = [int(num) for num in m.groups()]
+                if not os.path.exists(venv_path.format(*p_ver)):
+                    p_ver = sys.version_info[:2]
+            else:
+                p_ver = sys.version_info[:2]
+
+            virtual_env = venv_path.format(*p_ver)
+
         import site
         sys.path.insert(0, virtual_env)
         site.addsitedir(virtual_env)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -952,8 +952,10 @@ class InteractiveShell(SingletonConfigurable):
 
             virtual_env = venv_path.format(*p_ver)
 
-        warn("Attempting to work in a virtualenv. If you encounter problems, "
-             "please install IPython inside the virtualenv.")
+        warn(
+            "Attempting to work in a virtualenv. If you encounter problems, "
+            "please install IPython inside the virtualenv."
+        )
         import site
         sys.path.insert(0, virtual_env)
         site.addsitedir(virtual_env)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -934,23 +934,18 @@ class InteractiveShell(SingletonConfigurable):
         if sys.platform == "win32":
             virtual_env = Path(os.environ["VIRTUAL_ENV"], "Lib", "site-packages")
         else:
-            venv_path_prefix = Path(os.environ["VIRTUAL_ENV"], "lib")
-            venv_path_suffix = Path("site-packages")
+            virtual_env_path = Path(os.environ["VIRTUAL_ENV"], "lib", "python{}.{}", "site-packages")
             p_ver = sys.version_info[:2]
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
             re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
             if re_m:
                 predicted_p_ver = [int(num) for num in re_m.groups()]
-                predicted_path = (
-                    venv_path_prefix / "python{}.{}".format(*predicted_p_ver) / venv_path_suffix
-                )
+                predicted_path = Path(str(virtual_env_path).format(*predicted_p_ver))
                 if predicted_path.exists():
                     p_ver = predicted_p_ver
 
-            virtual_env = str(
-                venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
-            )
+            virtual_env = str(virtual_env_path).format(*p_ver)
 
         warn(
             "Attempting to work in a virtualenv. If you encounter problems, "

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -941,9 +941,7 @@ class InteractiveShell(SingletonConfigurable):
             )
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
-            re_m = re.search(
-                r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"]
-            )
+            re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
             if re_m:
                 p_ver = [int(num) for num in m.groups()]
                 if not os.path.exists(venv_path.format(*p_ver)):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -931,8 +931,6 @@ class InteractiveShell(SingletonConfigurable):
             # Our exe is inside or has access to the virtualenv, don't need to do anything.
             return
 
-        warn("Attempting to work in a virtualenv. If you encounter problems, please "
-             "install IPython inside the virtualenv.")
         if sys.platform == "win32":
             virtual_env = os.path.join(
                 os.environ["VIRTUAL_ENV"], "Lib", "site-packages"
@@ -954,6 +952,8 @@ class InteractiveShell(SingletonConfigurable):
 
             virtual_env = venv_path.format(*p_ver)
 
+        warn("Attempting to work in a virtualenv. If you encounter problems, "
+             "please install IPython inside the virtualenv.")
         import site
         sys.path.insert(0, virtual_env)
         site.addsitedir(virtual_env)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -932,24 +932,22 @@ class InteractiveShell(SingletonConfigurable):
             return
 
         if sys.platform == "win32":
-            virtual_env = os.path.join(
-                os.environ["VIRTUAL_ENV"], "Lib", "site-packages"
-            )
+            virtual_env = Path(os.environ["VIRTUAL_ENV"], "Lib", "site-packages")
         else:
-            venv_path = os.path.join(
-                os.environ["VIRTUAL_ENV"], "lib", "python{}.{}", "site-packages"
-            )
+            venv_path_prefix = Path(os.environ["VIRTUAL_ENV"], "lib")
+            venv_path_suffix = Path("site-packages")
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
             re_m = re.search(r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"])
             if re_m:
                 p_ver = [int(num) for num in re_m.groups()]
-                if not os.path.exists(venv_path.format(*p_ver)):
+                predicted_path = venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
+                if not predicted_path.exists():
                     p_ver = sys.version_info[:2]
             else:
                 p_ver = sys.version_info[:2]
 
-            virtual_env = venv_path.format(*p_ver)
+            virtual_env = venv_path_prefix / "python{}.{}".format(*p_ver) / venv_path_suffix
 
         warn(
             "Attempting to work in a virtualenv. If you encounter problems, "

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -934,8 +934,8 @@ class InteractiveShell(SingletonConfigurable):
         warn("Attempting to work in a virtualenv. If you encounter problems, please "
              "install IPython inside the virtualenv.")
         if sys.platform == "win32":
-            virtual_env = Path(os.environ["VIRTUAL_ENV"]).joinpath(
-                "Lib", "site-packages"
+            virtual_env = os.path.join(
+                os.environ["VIRTUAL_ENV"], "Lib", "site-packages"
             )
         else:
             venv_path = os.path.join(

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -941,9 +941,10 @@ class InteractiveShell(SingletonConfigurable):
             )
 
             # Predict version from py[thon]-x.x in the $VIRTUAL_ENV
-            if m := re.search(
+            re_m = re.search(
                 r"\bpy(?:thon)?([23])\.(\d+)\b", os.environ["VIRTUAL_ENV"]
-            ):
+            )
+            if re_m:
                 p_ver = [int(num) for num in m.groups()]
                 if not os.path.exists(venv_path.format(*p_ver)):
                     p_ver = sys.version_info[:2]


### PR DESCRIPTION
This PR improves virtualenv integration.

Current implementation assumes that the Python used in virtualenv is in the same version as the Python that is being used to run IPython. This is definitely not truth in most cases. In fact, one of the purpose of using virtualenv is to run different Python's interpreter versions. So the assumption is in opposite of the one of principal goals of the virtualenv idea.

This PR predicts a proper path to the virtualenv's libraries by looking-up at `$VIRTUAL_ENV` environmental variable against `pythonX.Y` or `pyX.Y` substrings. The `$VIRTUAL_ENV` usually contains Python's version in the name, e.g. `project-name-py3.7`, `project-name-py3.8`. If predicted path doesn't exist, the previous functionality is proceed.

Example:
- Python/system - 3.9
- Python/virtualenv - 3.7

Results:

- Current implementation - predicted path: `$VIRTUAL_ENV/lib/python3.9/site-packages`
- PR - predicted path: `$VIRTUAL_ENV/lib/python3.7/site/packages`