### PR TITLE
Don't allow Jedi to go to v1.18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ extras_require = dict(
 
 install_requires = [
     'setuptools>=18.5',
-    'jedi>=0.16',
+    'jedi>=0.16,<0.18.0',
     'decorator',
     'pickleshare',
     'traitlets>=4.2',

--- a/setup.py
+++ b/setup.py
@@ -183,15 +183,15 @@ extras_require = dict(
 )
 
 install_requires = [
-    'setuptools>=18.5',
-    'jedi>=0.16,<0.18.0',
-    'decorator',
-    'pickleshare',
-    'traitlets>=4.2',
-    'prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1',
-    'pygments',
-    'backcall',
-    'stack_data',
+    "setuptools>=18.5",
+    "jedi>=0.16,<0.18.0",
+    "decorator",
+    "pickleshare",
+    "traitlets>=4.2",
+    "prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1",
+    "pygments",
+    "backcall",
+    "stack_data",
 ]
 
 # Platform-specific dependencies:


### PR DESCRIPTION
This addresses issue https://github.com/ipython/ipython/issues/12740, where autocomplete breaks with the latest version of Jedi (1.18.0)

Currently, if you do a fresh install of iPython it results in broken autocomplete. This fixes it by preventing Jedi from going to whatever the latest version is.