### PR TITLE
Tests compatibility with Python 3.10

### DIFF
--- a/IPython/core/tests/test_magic_arguments.py
+++ b/IPython/core/tests/test_magic_arguments.py
@@ -77,11 +77,14 @@ def foo(self, args):
 def test_magic_arguments():
     optional = "optional arguments:" if sys.version_info < (3, 10, 0) else "options:"
 
-    assert_equal(magic_foo1.__doc__, f'::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_foo1, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_foo1), 'foo1')
-    assert_equal(magic_foo1(None, ''), argparse.Namespace(foo=None))
-    assert hasattr(magic_foo1, 'has_arguments')
+    assert_equal(
+        magic_foo1.__doc__,
+        f"::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n",
+    )
+    assert_equal(getattr(magic_foo1, "argcmd_name", None), None)
+    assert_equal(real_name(magic_foo1), "foo1")
+    assert_equal(magic_foo1(None, ""), argparse.Namespace(foo=None))
+    assert hasattr(magic_foo1, "has_arguments")
 
     assert_equal(magic_foo2.__doc__, '::\n\n  %foo2\n\n A docstring.\n')
     assert_equal(getattr(magic_foo2, 'argcmd_name', None), None)
@@ -89,33 +92,47 @@ def test_magic_arguments():
     assert_equal(magic_foo2(None, ''), argparse.Namespace())
     assert hasattr(magic_foo2, 'has_arguments')
 
-    assert_equal(magic_foo3.__doc__, f'::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n')
-    assert_equal(getattr(magic_foo3, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_foo3), 'foo3')
-    assert_equal(magic_foo3(None, ''),
-                       argparse.Namespace(bar=None, baz=None, foo=None))
-    assert hasattr(magic_foo3, 'has_arguments')
+    assert_equal(
+        magic_foo3.__doc__,
+        f"::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n",
+    )
+    assert_equal(getattr(magic_foo3, "argcmd_name", None), None)
+    assert_equal(real_name(magic_foo3), "foo3")
+    assert_equal(magic_foo3(None, ""), argparse.Namespace(bar=None, baz=None, foo=None))
+    assert hasattr(magic_foo3, "has_arguments")
 
-    assert_equal(magic_foo4.__doc__, f'::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_foo4, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_foo4), 'foo4')
-    assert_equal(magic_foo4(None, ''), argparse.Namespace())
-    assert hasattr(magic_foo4, 'has_arguments')
+    assert_equal(
+        magic_foo4.__doc__,
+        f"::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n",
+    )
+    assert_equal(getattr(magic_foo4, "argcmd_name", None), None)
+    assert_equal(real_name(magic_foo4), "foo4")
+    assert_equal(magic_foo4(None, ""), argparse.Namespace())
+    assert hasattr(magic_foo4, "has_arguments")
 
-    assert_equal(magic_foo5.__doc__, f'::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_foo5, 'argcmd_name', None), 'frobnicate')
-    assert_equal(real_name(magic_foo5), 'frobnicate')
-    assert_equal(magic_foo5(None, ''), argparse.Namespace(foo=None))
-    assert hasattr(magic_foo5, 'has_arguments')
+    assert_equal(
+        magic_foo5.__doc__,
+        f"::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n",
+    )
+    assert_equal(getattr(magic_foo5, "argcmd_name", None), "frobnicate")
+    assert_equal(real_name(magic_foo5), "frobnicate")
+    assert_equal(magic_foo5(None, ""), argparse.Namespace(foo=None))
+    assert hasattr(magic_foo5, "has_arguments")
 
-    assert_equal(magic_magic_foo.__doc__, f'::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_magic_foo, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_magic_foo), 'magic_foo')
-    assert_equal(magic_magic_foo(None, ''), argparse.Namespace(foo=None))
-    assert hasattr(magic_magic_foo, 'has_arguments')
+    assert_equal(
+        magic_magic_foo.__doc__,
+        f"::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n",
+    )
+    assert_equal(getattr(magic_magic_foo, "argcmd_name", None), None)
+    assert_equal(real_name(magic_magic_foo), "magic_foo")
+    assert_equal(magic_magic_foo(None, ""), argparse.Namespace(foo=None))
+    assert hasattr(magic_magic_foo, "has_arguments")
 
-    assert_equal(foo.__doc__, f'::\n\n  %foo [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(foo, 'argcmd_name', None), None)
-    assert_equal(real_name(foo), 'foo')
-    assert_equal(foo(None, ''), argparse.Namespace(foo=None))
-    assert hasattr(foo, 'has_arguments')
+    assert_equal(
+        foo.__doc__,
+        f"::\n\n  %foo [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n",
+    )
+    assert_equal(getattr(foo, "argcmd_name", None), None)
+    assert_equal(real_name(foo), "foo")
+    assert_equal(foo(None, ""), argparse.Namespace(foo=None))
+    assert hasattr(foo, "has_arguments")

--- a/IPython/core/tests/test_magic_arguments.py
+++ b/IPython/core/tests/test_magic_arguments.py
@@ -7,6 +7,7 @@
 #-----------------------------------------------------------------------------
 
 import argparse
+import sys
 from nose.tools import assert_equal
 
 from IPython.core.magic_arguments import (argument, argument_group, kwds,
@@ -74,7 +75,9 @@ def foo(self, args):
 
 
 def test_magic_arguments():
-    assert_equal(magic_foo1.__doc__, '::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
+    optional = "optional arguments:" if sys.version_info < (3, 10, 0) else "options:"
+
+    assert_equal(magic_foo1.__doc__, f'::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
     assert_equal(getattr(magic_foo1, 'argcmd_name', None), None)
     assert_equal(real_name(magic_foo1), 'foo1')
     assert_equal(magic_foo1(None, ''), argparse.Namespace(foo=None))
@@ -86,32 +89,32 @@ def test_magic_arguments():
     assert_equal(magic_foo2(None, ''), argparse.Namespace())
     assert hasattr(magic_foo2, 'has_arguments')
 
-    assert_equal(magic_foo3.__doc__, '::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n')
+    assert_equal(magic_foo3.__doc__, f'::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n')
     assert_equal(getattr(magic_foo3, 'argcmd_name', None), None)
     assert_equal(real_name(magic_foo3), 'foo3')
     assert_equal(magic_foo3(None, ''),
                        argparse.Namespace(bar=None, baz=None, foo=None))
     assert hasattr(magic_foo3, 'has_arguments')
 
-    assert_equal(magic_foo4.__doc__, '::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
+    assert_equal(magic_foo4.__doc__, f'::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
     assert_equal(getattr(magic_foo4, 'argcmd_name', None), None)
     assert_equal(real_name(magic_foo4), 'foo4')
     assert_equal(magic_foo4(None, ''), argparse.Namespace())
     assert hasattr(magic_foo4, 'has_arguments')
 
-    assert_equal(magic_foo5.__doc__, '::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
+    assert_equal(magic_foo5.__doc__, f'::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
     assert_equal(getattr(magic_foo5, 'argcmd_name', None), 'frobnicate')
     assert_equal(real_name(magic_foo5), 'frobnicate')
     assert_equal(magic_foo5(None, ''), argparse.Namespace(foo=None))
     assert hasattr(magic_foo5, 'has_arguments')
 
-    assert_equal(magic_magic_foo.__doc__, '::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
+    assert_equal(magic_magic_foo.__doc__, f'::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
     assert_equal(getattr(magic_magic_foo, 'argcmd_name', None), None)
     assert_equal(real_name(magic_magic_foo), 'magic_foo')
     assert_equal(magic_magic_foo(None, ''), argparse.Namespace(foo=None))
     assert hasattr(magic_magic_foo, 'has_arguments')
 
-    assert_equal(foo.__doc__, '::\n\n  %foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
+    assert_equal(foo.__doc__, f'::\n\n  %foo [-f FOO]\n\n A docstring.\n\n{optional}\n  -f FOO, --foo FOO  an argument\n')
     assert_equal(getattr(foo, 'argcmd_name', None), None)
     assert_equal(real_name(foo), 'foo')
     assert_equal(foo(None, ''), argparse.Namespace(foo=None))

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -399,12 +399,14 @@ def test_builtin_init():
 
 
 def test_render_signature_short():
-    def short_fun(a=1): pass
+    def short_fun(a=1):
+        pass
+
     sig = oinspect._render_signature(
         signature(short_fun),
         short_fun.__name__,
     )
-    nt.assert_equal(sig, 'short_fun(a=1)')
+    nt.assert_equal(sig, "short_fun(a=1)")
 
 
 def test_render_signature_long():
@@ -414,42 +416,46 @@ def test_render_signature_long():
         a_really_long_parameter: int,
         and_another_long_one: bool = False,
         let_us_make_sure_this_is_looong: Optional[str] = None,
-    ) -> bool: pass
+    ) -> bool:
+        pass
 
     sig = oinspect._render_signature(
         signature(long_function),
         long_function.__name__,
     )
-    nt.assert_in(sig, [
-        # Python >=3.10 with delayed annotations evaulation
-        '''\
+    nt.assert_in(
+        sig,
+        [
+            # Python >=3.10 with delayed annotations evaulation
+            """\
 long_function(
     a_really_long_parameter: 'int',
     and_another_long_one: 'bool' = False,
     let_us_make_sure_this_is_looong: 'Optional[str]' = None,
 ) -> 'bool'\
-''',
-        # Python >=3.9
-        '''\
+""",
+            # Python >=3.9
+            """\
 long_function(
     a_really_long_parameter: int,
     and_another_long_one: bool = False,
     let_us_make_sure_this_is_looong: Optional[str] = None,
 ) -> bool\
-''',
-        # Python >=3.7
-        '''\
+""",
+            # Python >=3.7
+            """\
 long_function(
     a_really_long_parameter: int,
     and_another_long_one: bool = False,
     let_us_make_sure_this_is_looong: Union[str, NoneType] = None,
 ) -> bool\
-''',  # Python <=3.6
-        '''\
+""",  # Python <=3.6
+            """\
 long_function(
     a_really_long_parameter:int,
     and_another_long_one:bool=False,
     let_us_make_sure_this_is_looong:Union[str, NoneType]=None,
 ) -> bool\
-''',
-    ])
+""",
+        ],
+    )

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -421,6 +421,14 @@ def test_render_signature_long():
         long_function.__name__,
     )
     nt.assert_in(sig, [
+        # Python >=3.10 with delayed annotations evaulation
+        '''\
+long_function(
+    a_really_long_parameter: 'int',
+    and_another_long_one: 'bool' = False,
+    let_us_make_sure_this_is_looong: 'Optional[str]' = None,
+) -> 'bool'\
+''',
         # Python >=3.9
         '''\
 long_function(

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -6,16 +6,18 @@
 
 
 from collections import Counter, defaultdict, deque, OrderedDict
+from importlib import import_module
 import os
 import types
 import string
+import sys
 import unittest
 
 import nose.tools as nt
 import pytest
 
 from IPython.lib import pretty
-from IPython.testing.decorators import skip_without, skip_iptest_but_not_pytest
+from IPython.testing.decorators import skip_iptest_but_not_pytest
 
 from io import StringIO
 
@@ -138,13 +140,17 @@ def test_sets(obj, expected_output):
     nt.assert_equal(got_output, expected_output)
 
 
-@skip_without('xxlimited')
 def test_pprint_heap_allocated_type():
     """
     Test that pprint works for heap allocated types.
     """
-    import xxlimited
-    output = pretty.pretty(xxlimited.Null)
+    module_name = "xxlimited" if sys.version_info < (3, 10, 0) else "xxlimited_35"
+    try:
+        module = import_module(module_name)
+    except ImportError:
+        pytest.skip(f"Module {module_name} is not available.")
+
+    output = pretty.pretty(getattr(module, "Null"))
     nt.assert_equal(output, 'xxlimited.Null')
 
 def test_pprint_nomod():


### PR DESCRIPTION
Python 3.10.0a4 has some differences and we are already building Python RPM packages with it so I'm bringing here the changes I need to do to make the tests pass with the latest Python 3.10.0a4. Tests still work for me in Python 3.9.

More explained in individual commits.