### PR TITLE
upgrade jedi to 17.2 but don't let go to 18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,15 +183,15 @@ extras_require = dict(
 )
 
 install_requires = [
-    'setuptools>=18.5',
-    'jedi>=0.17.2,<0.18.0',
-    'decorator',
-    'pickleshare',
-    'traitlets>=4.2',
-    'prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1',
-    'pygments',
-    'backcall',
-    'stack_data',
+    "setuptools>=18.5",
+    "jedi>=0.17.2,<0.18.0",
+    "decorator",
+    "pickleshare",
+    "traitlets>=4.2",
+    "prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1",
+    "pygments",
+    "backcall",
+    "stack_data",
 ]
 
 # Platform-specific dependencies:

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ extras_require = dict(
 
 install_requires = [
     'setuptools>=18.5',
-    'jedi>=0.16',
+    'jedi>=0.17.2,<0.18.0',
     'decorator',
     'pickleshare',
     'traitlets>=4.2',


### PR DESCRIPTION
`jedi==18.0+` breaks the api used by ipython in completer.py because jedi has removed the `column` kwarg in jedi.api.Interpreter

fixes #12766 
tested on `Ubuntu 20.04` and `ipython==7.19.0` and `jupyter==1.0.0`