### PR TITLE
Fix CFFileDescriptorCreate argtypes.

### DIFF
--- a/IPython/terminal/pt_inputhooks/osx.py
+++ b/IPython/terminal/pt_inputhooks/osx.py
@@ -41,7 +41,7 @@ CoreFoundation = ctypes.cdll.LoadLibrary(ctypes.util.find_library('CoreFoundatio
 
 CFFileDescriptorCreate = CoreFoundation.CFFileDescriptorCreate
 CFFileDescriptorCreate.restype = void_p
-CFFileDescriptorCreate.argtypes = [void_p, ctypes.c_int, ctypes.c_bool, void_p]
+CFFileDescriptorCreate.argtypes = [void_p, ctypes.c_int, ctypes.c_bool, void_p, void_p]
 
 CFFileDescriptorGetNativeDescriptor = CoreFoundation.CFFileDescriptorGetNativeDescriptor
 CFFileDescriptorGetNativeDescriptor.restype = ctypes.c_int


### PR DESCRIPTION
This is a follow-up to the fix on #12804 which turned out to be incomplete because it worked with python 3.8 and not with python 3.9.  I apologize for the oversight.  With this patch ipython works correctly with modules that open windows such as matplotlib with both python 3.8 and python 3.9.

This should fix #12803 .