### PR TITLE
Allow passing a custom CachingCompiler to the interactive shell

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -340,7 +340,7 @@ class InteractiveShell(SingletonConfigurable):
     """An enhanced, interactive shell for Python."""
 
     _instance = None
-    
+
     ast_transformers = List([], help=
         """
         A list of ast.NodeTransformer subclass instances, which will be applied
@@ -407,7 +407,7 @@ class InteractiveShell(SingletonConfigurable):
         Enable magic commands to be called without the leading %.
         """
     ).tag(config=True)
-    
+
     banner1 = Unicode(default_banner,
         help="""The part of the banner to be printed before the profile"""
     ).tag(config=True)
@@ -443,7 +443,8 @@ class InteractiveShell(SingletonConfigurable):
     display_formatter = Instance(DisplayFormatter, allow_none=True)
     displayhook_class = Type(DisplayHook)
     display_pub_class = Type(DisplayPublisher)
-    
+    compiler_class = Type(CachingCompiler)
+
     sphinxify_docstring = Bool(False, help=
         """
         Enables rich html representation of docstrings. (This requires the
@@ -534,7 +535,7 @@ class InteractiveShell(SingletonConfigurable):
     ).tag(config=True)
 
     # deprecated prompt traits:
-    
+
     prompt_in1 = Unicode('In [\\#]: ',
         help="Deprecated since IPython 4.0 and ignored since 5.0, set TerminalInteractiveShell.prompts object directly."
     ).tag(config=True)
@@ -547,14 +548,14 @@ class InteractiveShell(SingletonConfigurable):
     prompts_pad_left = Bool(True,
         help="Deprecated since IPython 4.0 and ignored since 5.0, set TerminalInteractiveShell.prompts object directly."
     ).tag(config=True)
-    
+
     @observe('prompt_in1', 'prompt_in2', 'prompt_out', 'prompt_pad_left')
     def _prompt_trait_changed(self, change):
         name = change['name']
         warn("InteractiveShell.{name} is deprecated since IPython 4.0"
              " and ignored since 5.0, set TerminalInteractiveShell.prompts"
              " object directly.".format(name=name))
-        
+
         # protect against weird cases where self.config may not exist:
 
     show_rewritten_input = Bool(True,
@@ -638,7 +639,7 @@ class InteractiveShell(SingletonConfigurable):
         self.init_profile_dir(profile_dir)
         self.init_instance_attrs()
         self.init_environment()
-        
+
         # Check if we're in a virtualenv, and set up sys.path.
         self.init_virtualenv()
 
@@ -748,7 +749,7 @@ class InteractiveShell(SingletonConfigurable):
         self.more = False
 
         # command compiler
-        self.compile = CachingCompiler()
+        self.compile = self.compiler_class()
 
         # Make an empty namespace, which extension writers can rely on both
         # existing and NEVER being used by ipython itself.  This gives them a
@@ -986,7 +987,7 @@ class InteractiveShell(SingletonConfigurable):
     #-------------------------------------------------------------------------
     # Things related to the banner
     #-------------------------------------------------------------------------
-    
+
     @property
     def banner(self):
         banner = self.banner1
@@ -1000,7 +1001,7 @@ class InteractiveShell(SingletonConfigurable):
         if banner is None:
             banner = self.banner
         sys.stdout.write(banner)
-    
+
     #-------------------------------------------------------------------------
     # Things related to hooks
     #-------------------------------------------------------------------------
@@ -1017,10 +1018,10 @@ class InteractiveShell(SingletonConfigurable):
             # default hooks have priority 100, i.e. low; user hooks should have
             # 0-100 priority
             self.set_hook(hook_name,getattr(hooks,hook_name), 100, _warn_deprecated=False)
-        
+
         if self.display_page:
             self.set_hook('show_in_pager', page.as_hook(page.display_page), 90)
-    
+
     def set_hook(self,name,hook, priority=50, str_key=None, re_key=None,
                  _warn_deprecated=True):
         """set_hook(name,hook) -> sets an internal IPython hook.
@@ -1084,7 +1085,7 @@ class InteractiveShell(SingletonConfigurable):
         warn("ip.register_post_execute is deprecated, use "
              "ip.events.register('post_run_cell', func) instead.", stacklevel=2)
         self.events.register('post_run_cell', func)
-    
+
     def _clear_warning_registry(self):
         # clear the warning registry, so that different code blocks with
         # overlapping line number ranges don't cause spurious suppression of
@@ -1126,12 +1127,12 @@ class InteractiveShell(SingletonConfigurable):
         else:
             main_mod.__dict__.clear()
             main_mod.__name__ = modname
-        
+
         main_mod.__file__ = filename
         # It seems pydoc (and perhaps others) needs any module instance to
         # implement a __nonzero__ method
         main_mod.__nonzero__ = lambda : True
-        
+
         return main_mod
 
     def clear_main_mod_cache(self):
@@ -1283,7 +1284,7 @@ class InteractiveShell(SingletonConfigurable):
                          'user_local':self.user_ns,
                          'builtin':builtin_mod.__dict__
                          }
-    
+
     @property
     def user_global_ns(self):
         return self.user_module.__dict__
@@ -1316,17 +1317,17 @@ class InteractiveShell(SingletonConfigurable):
             user_ns.setdefault("__name__", "__main__")
             user_module = DummyMod()
             user_module.__dict__ = user_ns
-            
+
         if user_module is None:
             user_module = types.ModuleType("__main__",
                 doc="Automatically created module for IPython interactive environment")
-        
+
         # We must ensure that __builtin__ (without the final 's') is always
         # available and pointing to the __builtin__ *module*.  For more details:
         # http://mail.python.org/pipermail/python-dev/2001-April/014068.html
         user_module.__dict__.setdefault('__builtin__', builtin_mod)
         user_module.__dict__.setdefault('__builtins__', builtin_mod)
-        
+
         if user_ns is None:
             user_ns = user_module.__dict__
 
@@ -1382,7 +1383,7 @@ class InteractiveShell(SingletonConfigurable):
         # For more details:
         # http://mail.python.org/pipermail/python-dev/2001-April/014068.html
         ns = {}
-        
+
         # make global variables for user access to the histories
         ns['_ih'] = self.history_manager.input_hist_parsed
         ns['_oh'] = self.history_manager.output_hist
@@ -1395,7 +1396,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # Store myself as the public api!!!
         ns['get_ipython'] = self.get_ipython
-        
+
         ns['exit'] = self.exiter
         ns['quit'] = self.exiter
 
@@ -1409,7 +1410,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # Finally, update the real user's namespace
         self.user_ns.update(ns)
-    
+
     @property
     def all_ns_refs(self):
         """Get a list of references to all the namespace dictionaries in which
@@ -1435,7 +1436,7 @@ class InteractiveShell(SingletonConfigurable):
         # Reset last execution result
         self.last_execution_succeeded = True
         self.last_execution_result = None
-        
+
         # Flush cached output items
         if self.displayhook.do_full_cache:
             self.displayhook.flush()
@@ -1500,7 +1501,7 @@ class InteractiveShell(SingletonConfigurable):
             raise ValueError("Refusing to delete %s" % varname)
 
         ns_refs = self.all_ns_refs
-        
+
         if by_name:                    # Delete by name
             for ns in ns_refs:
                 try:
@@ -1775,8 +1776,14 @@ class InteractiveShell(SingletonConfigurable):
             if meth == 'pdoc':
                 pmethod(info.obj, oname, formatter)
             elif meth == 'pinfo':
-                pmethod(info.obj, oname, formatter, info, 
-                        enable_html_pager=self.enable_html_pager, **kw)
+                pmethod(
+                    info.obj,
+                    oname,
+                    formatter,
+                    info,
+                    enable_html_pager=self.enable_html_pager,
+                    **kw
+                )
             else:
                 pmethod(info.obj, oname)
         else:
@@ -1900,7 +1907,7 @@ class InteractiveShell(SingletonConfigurable):
             print('Exception type :', etype)
             print('Exception value:', value)
             print('Traceback      :', tb)
-        
+
         def validate_stb(stb):
             """validate structured traceback return type
 
@@ -1929,7 +1936,7 @@ class InteractiveShell(SingletonConfigurable):
         else:
             def wrapped(self,etype,value,tb,tb_offset=None):
                 """wrap CustomTB handler, to protect IPython from user code
-                
+
                 This makes it harder (but not impossible) for custom exception
                 handlers to crash IPython.
                 """
@@ -1978,10 +1985,10 @@ class InteractiveShell(SingletonConfigurable):
 
     def _get_exc_info(self, exc_tuple=None):
         """get exc_info from a given tuple, sys.exc_info() or sys.last_type etc.
-        
+
         Ensures sys.last_type,value,traceback hold the exc_info we found,
         from whichever source.
-        
+
         raises ValueError if none of these contain any information
         """
         if exc_tuple is None:
@@ -1993,10 +2000,10 @@ class InteractiveShell(SingletonConfigurable):
             if hasattr(sys, 'last_type'):
                 etype, value, tb = sys.last_type, sys.last_value, \
                                    sys.last_traceback
-        
+
         if etype is None:
             raise ValueError("No exception to find")
-        
+
         # Now store the exception info in sys.last_type etc.
         # WARNING: these variables are somewhat deprecated and not
         # necessarily safe to use in a threaded environment, but tools
@@ -2005,16 +2012,16 @@ class InteractiveShell(SingletonConfigurable):
         sys.last_type = etype
         sys.last_value = value
         sys.last_traceback = tb
-        
+
         return etype, value, tb
-    
+
     def show_usage_error(self, exc):
         """Show a short message for UsageErrors
-        
+
         These are special exceptions that shouldn't show a traceback.
         """
         print("UsageError: %s" % exc, file=sys.stderr)
-    
+
     def get_exception_only(self, exc_tuple=None):
         """
         Return as a string (ending with a newline) the exception that
@@ -2128,7 +2135,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def init_readline(self):
         """DEPRECATED
-        
+
         Moved to terminal subclass, here only to simplify the init logic."""
         # Set a number of methods that depend on readline to be no-op
         warnings.warn('`init_readline` is no-op since IPython 5.0 and is Deprecated',
@@ -2295,12 +2302,13 @@ class InteractiveShell(SingletonConfigurable):
         # should be split into a prompt manager and displayhook. We probably
         # even need a centralize colors management object.
         self.run_line_magic('colors', self.colors)
-    
+
     # Defined here so that it's included in the documentation
     @functools.wraps(magic.MagicsManager.register_function)
     def register_magic_function(self, func, magic_kind='line', magic_name=None):
-        self.magics_manager.register_function(func, 
-                                  magic_kind=magic_kind, magic_name=magic_name)
+        self.magics_manager.register_function(
+            func, magic_kind=magic_kind, magic_name=magic_name
+        )
 
     def run_line_magic(self, magic_name, line, _stack_depth=1):
         """Execute the given line magic.
@@ -2531,7 +2539,7 @@ class InteractiveShell(SingletonConfigurable):
                 ec = 130
             if ec > 128:
                 ec = -(ec - 128)
-        
+
         # We explicitly do NOT return the subprocess status code, because
         # a non-None value would trigger :func:`sys.displayhook` calls.
         # Instead, we store the exit_code in user_ns.  Note the semantics
@@ -2594,7 +2602,7 @@ class InteractiveShell(SingletonConfigurable):
     def init_payload(self):
         self.payload_manager = PayloadManager(parent=self)
         self.configurables.append(self.payload_manager)
-    
+
     #-------------------------------------------------------------------------
     # Things related to the prefilter
     #-------------------------------------------------------------------------
@@ -2634,13 +2642,13 @@ class InteractiveShell(SingletonConfigurable):
 
     def _user_obj_error(self):
         """return simple exception dict
-        
+
         for use in user_expressions
         """
-        
+
         etype, evalue, tb = self._get_exc_info()
         stb = self.InteractiveTB.get_exception_only(etype, evalue)
-        
+
         exc_info = {
             "status": "error",
             "traceback": stb,
@@ -2649,13 +2657,13 @@ class InteractiveShell(SingletonConfigurable):
         }
 
         return exc_info
-    
+
     def _format_user_obj(self, obj):
         """format a user object to display dict
-        
+
         for use in user_expressions
         """
-        
+
         data, md = self.display_formatter.format(obj)
         value = {
             'status' : 'ok',
@@ -2663,7 +2671,7 @@ class InteractiveShell(SingletonConfigurable):
             'metadata' : md,
         }
         return value
-    
+
     def user_expressions(self, expressions):
         """Evaluate a dict of expressions in the user's namespace.
 
@@ -2682,7 +2690,7 @@ class InteractiveShell(SingletonConfigurable):
         out = {}
         user_ns = self.user_ns
         global_ns = self.user_global_ns
-        
+
         for key, expr in expressions.items():
             try:
                 value = self._format_user_obj(eval(expr, global_ns, user_ns))
@@ -3096,12 +3104,14 @@ class InteractiveShell(SingletonConfigurable):
         # Our own compiler remembers the __future__ environment. If we want to
         # run code with a separate __future__ environment, use the default
         # compiler
-        compiler = self.compile if shell_futures else CachingCompiler()
+        compiler = self.compile if shell_futures else self.compiler_class()
 
         _run_async = False
 
         with self.builtin_trap:
-            cell_name = self.compile.cache(cell, self.execution_count)
+            cell_name = self.compile.cache(
+                cell, self.execution_count, raw_code=raw_cell
+            )
 
             with self.display_trap:
                 # Compile to bytecode
@@ -3207,13 +3217,13 @@ class InteractiveShell(SingletonConfigurable):
 
     def transform_ast(self, node):
         """Apply the AST transformations from self.ast_transformers
-        
+
         Parameters
         ----------
         node : ast.Node
           The root node to be transformed. Typically called with the ast.Module
           produced by parsing user input.
-        
+
         Returns
         -------
         An ast.Node corresponding to the node it was called with. Note that it
@@ -3260,7 +3270,7 @@ class InteractiveShell(SingletonConfigurable):
           Experimental value: 'async' Will try to run top level interactive
           async/await code in default runner, this will not respect the
           interactivity setting and will only run the last node if it is an
-          expression. 
+          expression.
 
         compiler : callable
           A function with the same interface as the built-in compile(), to turn
@@ -3481,17 +3491,17 @@ class InteractiveShell(SingletonConfigurable):
 
     def enable_gui(self, gui=None):
         raise NotImplementedError('Implement enable_gui in a subclass')
-    
+
     def enable_matplotlib(self, gui=None):
         """Enable interactive matplotlib and inline figure support.
-        
+
         This takes the following steps:
-        
+
         1. select the appropriate eventloop and matplotlib backend
         2. set up matplotlib for interactive use with that backend
         3. configure formatters for inline figure display
         4. enable the selected gui eventloop
-        
+
         Parameters
         ----------
         gui : optional, string
@@ -3505,7 +3515,7 @@ class InteractiveShell(SingletonConfigurable):
         """
         from IPython.core import pylabtools as pt
         gui, backend = pt.find_gui_and_backend(gui, self.pylab_gui_select)
-    
+
         if gui != 'inline':
             # If we have our first gui selection, store it
             if self.pylab_gui_select is None:
@@ -3515,16 +3525,16 @@ class InteractiveShell(SingletonConfigurable):
                 print('Warning: Cannot change to a different GUI toolkit: %s.'
                         ' Using %s instead.' % (gui, self.pylab_gui_select))
                 gui, backend = pt.find_gui_and_backend(self.pylab_gui_select)
-        
+
         pt.activate_matplotlib(backend)
         pt.configure_inline_support(self, backend)
-        
+
         # Now we must activate the gui pylab wants to use, and fix %run to take
         # plot updates into account
         self.enable_gui(gui)
         self.magics_manager.registry['ExecutionMagics'].default_runner = \
             pt.mpl_runner(self.safe_execfile)
-        
+
         return gui, backend
 
     def enable_pylab(self, gui=None, import_all=True, welcome_message=False):
@@ -3534,7 +3544,7 @@ class InteractiveShell(SingletonConfigurable):
         namespace all of numpy and pylab, and configures IPython to correctly
         interact with the GUI event loop.  The GUI backend to be used can be
         optionally selected with the optional ``gui`` argument.
-        
+
         This method only adds preloading the namespace to InteractiveShell.enable_matplotlib.
 
         Parameters
@@ -3554,9 +3564,9 @@ class InteractiveShell(SingletonConfigurable):
           This argument is ignored, no welcome message will be displayed.
         """
         from IPython.core.pylabtools import import_pylab
-        
+
         gui, backend = self.enable_matplotlib(gui)
-        
+
         # We want to prevent the loading of pylab to pollute the user's
         # namespace as shown by the %who* magics, so we execute the activation
         # code in an empty namespace, and we update *both* user_ns and


### PR DESCRIPTION
cc. @johanmabille @SylvainCorlay @jtpio

This permits customization of the filename computation prior to caching/compiling. This is needed if we want to have JupyterLab debugger support in the future, as the debugger protocol relies on a cell "filename" in order to track breakpoints added to non-executed cells.

In the JupyterLab debugger implementation, this filename is a computed hash of the raw cell code, which must be the same as the filename used when executing the code in the kernel in order for debugpy to stop on breakpoints.

As a proof of concept, I pushed [a PR to xeus-python which relies on IPython](https://github.com/jupyter-xeus/xeus-python/pull/400) for the code execution/completion. The xeus-python PR builds against this one, and allows starting a debugging session!

![ipython_debug](https://user-images.githubusercontent.com/21197331/106870529-80cc4200-66d1-11eb-9be5-28b841214714.png)


**Note:** My PR contains multiple trailing spaces removal, review from this link to remove noise: https://github.com/ipython/ipython/pull/12809/files?diff=split&w=1