### PR TITLE
Added clear kwarg to display()

### DIFF
--- a/IPython/core/display_functions.py
+++ b/IPython/core/display_functions.py
@@ -120,6 +120,9 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         Set an id for the display.
         This id can be used for updating this display area later via update_display.
         If given as `True`, generate a new `display_id`
+    clear : bool, optional
+        Should the output area be cleared before displaying anything? If True,
+        this will wait for additional output before clearing. [default: False]
     kwargs: additional keyword-args, optional
         Additional keyword-arguments are passed through to the display publisher.
 
@@ -239,7 +242,8 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         print(*objs)
         return
 
-    raw = kwargs.pop('raw', False)
+    raw = kwargs.pop("raw", False)
+    clear = kwargs.pop("clear", False)
     if transient is None:
         transient = {}
     if metadata is None:
@@ -262,6 +266,9 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
 
     if not raw:
         format = InteractiveShell.instance().display_formatter.format
+
+    if clear:
+        clear_output(wait=True)
 
     for obj in objs:
         if raw:


### PR DESCRIPTION
display() is a very useful function in the ipython kernel (especially now that it is in scope by default). However, many times that I use it, I also need `clear_output()`, and `clear_output(wait=True)`. However, it is quite a pain to have to:

```python
from IPython.display import clear_output
```

In addition, many user don't know about `clear_output`, nor the wait option.

This PR adds `display(clear=True)` with `wait=True` by default. If you want to clear it now rather than later, you can:

```python
display(clear=True)
print() # forces the clear now!
```
