### PR TITLE
IPDB: "context" command

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -806,6 +806,20 @@ class Pdb(OldPdb):
     do_d = do_down
     do_u = do_up
 
+    def do_context(self, context):
+        """context number_of_lines
+        Set the number of lines of source code to show when displaying
+        stacktrace information.
+        """
+        try:
+            new_context = int(context)
+            if new_context <= 0:
+                raise ValueError()
+        except ValueError:
+            self.error("The 'context' command requires a positive integer argument.")
+        self.context = new_context
+
+
 class InterruptiblePdb(Pdb):
     """Version of debugger where KeyboardInterrupt exits the debugger altogether."""
 

--- a/docs/source/whatsnew/pr/ipdb-context-command.rst
+++ b/docs/source/whatsnew/pr/ipdb-context-command.rst
@@ -1,0 +1,5 @@
+New "context" command in ipdb
+-----------------------------
+
+It is now possible to change the number of lines shown in the backtrace
+information in ipdb using "context" command.


### PR DESCRIPTION
Makes it possible to set the number of lines of code that will be shown in the backtrace _from inside_ the debugger.