### PR TITLE
Reclaim sys.excepthook for interactive shell in %gui qt

### DIFF
--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -19,17 +19,17 @@ def inputhook(context):
     global _appref
     app = QtCore.QCoreApplication.instance()
     if not app:
-        if sys.platform == "linux":
-            if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        if sys.platform == 'linux':
+            if not os.environ.get('DISPLAY') \
+                    and not os.environ.get('WAYLAND_DISPLAY'):
                 import warnings
-
                 global _already_warned
                 if not _already_warned:
                     _already_warned = True
                     warnings.warn(
-                        "The DISPLAY or WAYLAND_DISPLAY environment variable is "
-                        "not set or empty and Qt5 requires this environment "
-                        "variable. Deactivate Qt5 code."
+                        'The DISPLAY or WAYLAND_DISPLAY environment variable is '
+                        'not set or empty and Qt5 requires this environment '
+                        'variable. Deactivate Qt5 code.'
                     )
                 return
         QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
@@ -43,7 +43,7 @@ def inputhook(context):
 
     event_loop = QtCore.QEventLoop(app)
 
-    if sys.platform == "win32":
+    if sys.platform == 'win32':
         # The QSocketNotifier method doesn't appear to work on Windows.
         # Use polling instead.
         timer = QtCore.QTimer()
@@ -55,7 +55,8 @@ def inputhook(context):
     else:
         # On POSIX platforms, we can use a file descriptor to quit the event
         # loop when there is input ready to read.
-        notifier = QtCore.QSocketNotifier(context.fileno(), QtCore.QSocketNotifier.Read)
+        notifier = QtCore.QSocketNotifier(context.fileno(),
+                                          QtCore.QSocketNotifier.Read)
         try:
             # connect the callback we care about before we turn it on
             # lambda is necessary as PyQT inspect the function signature to know

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from IPython.external.qt_for_kernel import QtCore, QtGui
+from IPython import get_ipython
 
 # If we create a QApplication, keep a reference to it so that it doesn't get
 # garbage collected.
@@ -8,28 +9,41 @@ _appref = None
 _already_warned = False
 
 
+def _reclaim_excepthook():
+    shell = get_ipython()
+    if shell is not None:
+        sys.excepthook = shell.excepthook
+
+
 def inputhook(context):
     global _appref
     app = QtCore.QCoreApplication.instance()
     if not app:
-        if sys.platform == 'linux':
-            if not os.environ.get('DISPLAY') \
-                    and not os.environ.get('WAYLAND_DISPLAY'):
+        if sys.platform == "linux":
+            if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
                 import warnings
+
                 global _already_warned
                 if not _already_warned:
                     _already_warned = True
                     warnings.warn(
-                        'The DISPLAY or WAYLAND_DISPLAY environment variable is '
-                        'not set or empty and Qt5 requires this environment '
-                        'variable. Deactivate Qt5 code.'
+                        "The DISPLAY or WAYLAND_DISPLAY environment variable is "
+                        "not set or empty and Qt5 requires this environment "
+                        "variable. Deactivate Qt5 code."
                     )
                 return
         QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
         _appref = app = QtGui.QApplication([" "])
+
+        # "reclaim" IPython sys.excepthook after event loop starts
+        # without this, it defaults back to BaseIPythonApplication.excepthook
+        # and exceptions in the Qt event loop are rendered without traceback
+        # formatting and look like "bug in IPython".
+        QtCore.QTimer.singleShot(0, _reclaim_excepthook)
+
     event_loop = QtCore.QEventLoop(app)
 
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         # The QSocketNotifier method doesn't appear to work on Windows.
         # Use polling instead.
         timer = QtCore.QTimer()
@@ -41,8 +55,7 @@ def inputhook(context):
     else:
         # On POSIX platforms, we can use a file descriptor to quit the event
         # loop when there is input ready to read.
-        notifier = QtCore.QSocketNotifier(context.fileno(),
-                                          QtCore.QSocketNotifier.Read)
+        notifier = QtCore.QSocketNotifier(context.fileno(), QtCore.QSocketNotifier.Read)
         try:
             # connect the callback we care about before we turn it on
             # lambda is necessary as PyQT inspect the function signature to know


### PR DESCRIPTION
Currently, if someone uses the `%gui qt` magic, and an exception occurs in the event loop, it gets rendered with an unformatted traceback.  This appears to be because sys.excepthook is being restored back to `BaseIPythonApplication.excepthook` before the Qt event loop is run (see https://github.com/ipython/ipython/issues/10057#issuecomment-754209074).   To see this, run the following gui in an `ipython --gui qt` session:
```python
from qtpy.QtWidgets import QPushButton

def _raise():
    raise ValueError("clicked")

b = QPushButton("hi")
b.clicked.connect(_raise)
b.show()  # and click the button for traceback
```

Following [this tip](https://github.com/ipython/ipython/issues/10057#issuecomment-261494713), this PR schedules a callback to restore `sys.excepthook` back to the `InteractiveShell.excepthook` immediately after the event loop starts.

