### PR TITLE
Fix UnboundLocalError in IPDB when running 'context' command without argument

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -815,9 +815,9 @@ class Pdb(OldPdb):
             new_context = int(context)
             if new_context <= 0:
                 raise ValueError()
+            self.context = new_context
         except ValueError:
             self.error("The 'context' command requires a positive integer argument.")
-        self.context = new_context
 
 
 class InterruptiblePdb(Pdb):


### PR DESCRIPTION
Minor issue, doesn't break the main functionality - throughout refactoring and fiddling with initial implementation I managed to bork that, sorry.