### PR TITLE
Hist rangepattern Issue 12451

### DIFF
--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -171,21 +171,14 @@ class HistoryMagics(Magics):
         pattern = None
         limit = None if args.limit is _unspecified else args.limit
 
-        print('args.pattern=',args.pattern)
-        print('args.limit=',args.limit)
-        print('type(args.limit)=',type(args.limit))
-        print('args.range=',args.range)
-
         range_pattern = False
         if args.pattern is not None and not args.range:
             if args.pattern:
                 pattern = "*" + " ".join(args.pattern) + "*"
             else:
                 pattern = "*"
-            print('pattern=',pattern)
             hist = history_manager.search(pattern, raw=raw, output=get_output,
                                           n=limit, unique=args.unique)
-            print('type(hist)=',type(hist))
             print_nums = True
         elif args.limit is not _unspecified:
             n = 10 if limit is None else limit
@@ -195,10 +188,8 @@ class HistoryMagics(Magics):
                 if args.pattern:
                     range_pattern = "*" + " ".join(args.pattern) + "*"
                     print_nums = True
-                    print('range_pattern=',range_pattern)
                 hist = history_manager.get_range_by_str(" ".join(args.range),
                                                         raw, get_output)
-                print('type(hist)=',type(hist))
             else:               # Just get history for the current session
                 hist = history_manager.get_range(raw=raw, output=get_output)
 

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -206,7 +206,8 @@ class HistoryMagics(Magics):
             if get_output:
                 inline, output = inline
             if range_pattern:
-                if not fnmatch.fnmatch(inline,range_pattern): continue;
+                if not fnmatch.fnmatch(inline, range_pattern):
+                    continue
             inline = inline.expandtabs(4).rstrip()
 
             multiline = "\n" in inline

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -16,6 +16,7 @@
 import os
 import sys
 from io import open as io_open
+import fnmatch
 
 # Our own packages
 from IPython.core.error import StdinNotImplementedError
@@ -170,21 +171,34 @@ class HistoryMagics(Magics):
         pattern = None
         limit = None if args.limit is _unspecified else args.limit
 
-        if args.pattern is not None:
+        print('args.pattern=',args.pattern)
+        print('args.limit=',args.limit)
+        print('type(args.limit)=',type(args.limit))
+        print('args.range=',args.range)
+
+        range_pattern = False
+        if args.pattern is not None and not args.range:
             if args.pattern:
                 pattern = "*" + " ".join(args.pattern) + "*"
             else:
                 pattern = "*"
+            print('pattern=',pattern)
             hist = history_manager.search(pattern, raw=raw, output=get_output,
                                           n=limit, unique=args.unique)
+            print('type(hist)=',type(hist))
             print_nums = True
         elif args.limit is not _unspecified:
             n = 10 if limit is None else limit
             hist = history_manager.get_tail(n, raw=raw, output=get_output)
         else:
             if args.range:      # Get history by ranges
+                if args.pattern:
+                    range_pattern = "*" + " ".join(args.pattern) + "*"
+                    print_nums = True
+                    print('range_pattern=',range_pattern)
                 hist = history_manager.get_range_by_str(" ".join(args.range),
                                                         raw, get_output)
+                print('type(hist)=',type(hist))
             else:               # Just get history for the current session
                 hist = history_manager.get_range(raw=raw, output=get_output)
 
@@ -200,6 +214,8 @@ class HistoryMagics(Magics):
             # into an editor.
             if get_output:
                 inline, output = inline
+            if range_pattern:
+                if not fnmatch.fnmatch(inline,range_pattern): continue;
             inline = inline.expandtabs(4).rstrip()
 
             multiline = "\n" in inline

--- a/docs/source/whatsnew/pr/hist-range-glob-feature.rst
+++ b/docs/source/whatsnew/pr/hist-range-glob-feature.rst
@@ -1,18 +1,25 @@
 History Range Glob feature
 ==========================
 
-Previously, when using ``%history`` users could specify either
+Previously, when using ``%history``, users could specify either
 a range of sessions and lines, for example:
 
-``~8/1-~6/5`` see history from the first line of 8 sessions ago,
-              to the fifth line of 6 sessions ago.
+.. code-block:: python
 
-Or users could specify ``-g <pattern>`` to glob ALL history for
-the specified pattern.
+   ~8/1-~6/5   # see history from the first line of 8 sessions ago,
+               # to the fifth line of 6 sessions ago.``
 
-However users could *not* specify both.
-If a user *did* specify both a range, and a glob pattern,
-then the glob pattern would be used *but the range would be ignored*.
+Or users could specify a glob pattern:
 
-With this enhancment, if a user specifies both a range and a glob pattern,
-the glob pattern will be applied to the specified range of history.
+.. code-block:: python
+
+   -g <pattern>  # glob ALL history for the specified pattern.
+
+However users could *not* specify both.  
+
+If a user *did* specify both a range and a glob pattern,
+then the glob pattern would be used (globbing *all* history) *and the range would be ignored*.
+
+---
+
+With this enhancment, if a user specifies both a range and a glob pattern, then the glob pattern will be applied to the specified range of history.

--- a/docs/source/whatsnew/pr/hist-range-glob-feature.rst
+++ b/docs/source/whatsnew/pr/hist-range-glob-feature.rst
@@ -1,0 +1,18 @@
+History Range Glob feature
+==========================
+
+Previously, when using ``%history`` users could specify either
+a range of sessions and lines, for example:
+
+``~8/1-~6/5`` see history from the first line of 8 sessions ago,
+              to the fifth line of 6 sessions ago.
+
+Or users could specify ``-g <pattern>`` to glob ALL history for
+the specified pattern.
+
+However users could **\ *not*\ ** specify both.
+If a user did specify both a range, and a glob pattern,
+then the glob pattern would be used *but the range would be ignored*.
+
+With this enhancment, if a user specifies both a range and a glob pattern,
+the glob pattern will be applied to the specified range of history.

--- a/docs/source/whatsnew/pr/hist-range-glob-feature.rst
+++ b/docs/source/whatsnew/pr/hist-range-glob-feature.rst
@@ -10,8 +10,8 @@ a range of sessions and lines, for example:
 Or users could specify ``-g <pattern>`` to glob ALL history for
 the specified pattern.
 
-However users could **\ *not*\ ** specify both.
-If a user did specify both a range, and a glob pattern,
+However users could *not* specify both.
+If a user *did* specify both a range, and a glob pattern,
 then the glob pattern would be used *but the range would be ignored*.
 
 With this enhancment, if a user specifies both a range and a glob pattern,


### PR DESCRIPTION
This enhancement is for https://github.com/ipython/ipython/issues/12451

I have implemented the ability to specify a range of sessions/lines simultaneously with a `-g` glob pattern, for example:

`hist ~4/1-~0/10 -g <pattern>`  to glob for `<pattern>` only from line 1 of four sessions ago, until the present session line 10.

