### PR TITLE
Bail on sunken brackets

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -678,7 +678,11 @@ class TransformerManager:
 
         # Bail if we got one line and there are more closing parentheses than
         # the opening ones
-        if len(lines) == 1 and has_sunken_brackets(tokens_by_line[0]):
+        if (
+            len(lines) == 1
+            and tokens_by_line
+            and has_sunken_brackets(tokens_by_line[0])
+        ):
             return "invalid", None
 
         if not tokens_by_line:

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -508,6 +508,20 @@ def make_tokens_by_line(lines:List[str]):
 
     return tokens_by_line
 
+
+def has_sunken_brackets(tokens: List[tokenize.TokenInfo]):
+    """Check if the depth of brackets in the list of tokens drops below 0"""
+    parenlev = 0
+    for token in tokens:
+        if token.string in {"(", "[", "{"}:
+            parenlev += 1
+        elif token.string in {")", "]", "}"}:
+            parenlev -= 1
+            if parenlev < 0:
+                return True
+    return False
+
+
 def show_linewise_tokens(s: str):
     """For investigation and debugging"""
     if not s.endswith('\n'):
@@ -661,6 +675,11 @@ class TransformerManager:
             return 'invalid', None
 
         tokens_by_line = make_tokens_by_line(lines)
+
+        # Bail if we got one line and there are more closing parentheses than
+        # the opening ones
+        if len(lines) == 1 and has_sunken_brackets(tokens_by_line[0]):
+            return "invalid", None
 
         if not tokens_by_line:
             return 'incomplete', find_last_indent(lines)

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -309,7 +309,7 @@ def test_check_complete_invalidates_sunken_brackets():
     nt.assert_equal(cc(")("), ("invalid", None))
     nt.assert_equal(cc("]["), ("invalid", None))
     nt.assert_equal(cc("}{"), ("invalid", None))
-    nt.assert_equal(cc("[()("), ("invalid", None))
+    nt.assert_equal(cc("]()("), ("invalid", None))
     nt.assert_equal(cc("())("), ("invalid", None))
     nt.assert_equal(cc(")[]("), ("invalid", None))
     nt.assert_equal(cc("()]("), ("invalid", None))

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -255,18 +255,18 @@ def test_find_assign_op_dedent():
 
 def test_check_complete():
     cc = ipt2.TransformerManager().check_complete
-    nt.assert_equal(cc("a = 1"), ('complete', None))
-    nt.assert_equal(cc("for a in range(5):"), ('incomplete', 4))
-    nt.assert_equal(cc("for a in range(5):\n    if a > 0:"), ('incomplete', 8))
-    nt.assert_equal(cc("raise = 2"), ('invalid', None))
-    nt.assert_equal(cc("a = [1,\n2,"), ('incomplete', 0))
-    nt.assert_equal(cc("(\n))"), ('incomplete', 0))
-    nt.assert_equal(cc("\\\r\n"), ('incomplete', 0))
-    nt.assert_equal(cc("a = '''\n   hi"), ('incomplete', 3))
-    nt.assert_equal(cc("def a():\n x=1\n global x"), ('invalid', None))
-    nt.assert_equal(cc("a \\ "), ('invalid', None))  # Nothing allowed after backslash
-    nt.assert_equal(cc("1\\\n+2"), ('complete', None))
-    nt.assert_equal(cc("exit"), ('complete', None))
+    nt.assert_equal(cc("a = 1"), ("complete", None))
+    nt.assert_equal(cc("for a in range(5):"), ("incomplete", 4))
+    nt.assert_equal(cc("for a in range(5):\n    if a > 0:"), ("incomplete", 8))
+    nt.assert_equal(cc("raise = 2"), ("invalid", None))
+    nt.assert_equal(cc("a = [1,\n2,"), ("incomplete", 0))
+    nt.assert_equal(cc("(\n))"), ("incomplete", 0))
+    nt.assert_equal(cc("\\\r\n"), ("incomplete", 0))
+    nt.assert_equal(cc("a = '''\n   hi"), ("incomplete", 3))
+    nt.assert_equal(cc("def a():\n x=1\n global x"), ("invalid", None))
+    nt.assert_equal(cc("a \\ "), ("invalid", None))  # Nothing allowed after backslash
+    nt.assert_equal(cc("1\\\n+2"), ("complete", None))
+    nt.assert_equal(cc("exit"), ("complete", None))
 
     example = dedent("""
         if True:

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -297,6 +297,24 @@ def test_check_complete_II():
     nt.assert_equal(cc('''def foo():\n    """'''), ('incomplete', 4))
 
 
+def test_check_complete_invalidates_sunken_brackets():
+    """
+    Test that a single line with more closing brackets than the opening ones is
+    interpretted as invalid
+    """
+    cc = ipt2.TransformerManager().check_complete
+    nt.assert_equal(cc(")"), ("invalid", None))
+    nt.assert_equal(cc("]"), ("invalid", None))
+    nt.assert_equal(cc("}"), ("invalid", None))
+    nt.assert_equal(cc(")("), ("invalid", None))
+    nt.assert_equal(cc("]["), ("invalid", None))
+    nt.assert_equal(cc("}{"), ("invalid", None))
+    nt.assert_equal(cc("[()("), ("invalid", None))
+    nt.assert_equal(cc("())("), ("invalid", None))
+    nt.assert_equal(cc(")[]("), ("invalid", None))
+    nt.assert_equal(cc("()]("), ("invalid", None))
+
+
 def test_null_cleanup_transformer():
     manager = ipt2.TransformerManager()
     manager.cleanup_transforms.insert(0, null_cleanup_transformer)

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -260,7 +260,7 @@ def test_check_complete():
     nt.assert_equal(cc("for a in range(5):\n    if a > 0:"), ('incomplete', 8))
     nt.assert_equal(cc("raise = 2"), ('invalid', None))
     nt.assert_equal(cc("a = [1,\n2,"), ('incomplete', 0))
-    nt.assert_equal(cc(")"), ('incomplete', 0))
+    nt.assert_equal(cc("(\n))"), ('incomplete', 0))
     nt.assert_equal(cc("\\\r\n"), ('incomplete', 0))
     nt.assert_equal(cc("a = '''\n   hi"), ('incomplete', 3))
     nt.assert_equal(cc("def a():\n x=1\n global x"), ('invalid', None))

--- a/docs/source/whatsnew/pr/sunken-brackets.rst
+++ b/docs/source/whatsnew/pr/sunken-brackets.rst
@@ -1,0 +1,7 @@
+Don't start a multiline cell with sunken parenthesis
+----------------------------------------------------
+
+From now on IPython will not ask for the next line of input when given a single
+line with more closing than opening brackets. For example, this means that if
+you (mis)type ']]' instead of '[]', a ``SyntaxError`` will show up, instead of
+the ``...:`` prompt continuation.


### PR DESCRIPTION
Fixes #12859.

TL;DR - instead of:
```
In [1]: ]
   ...: 
```

Do:
```
In [1]: ]
  File "<ipython-input-1-de603c91038f>", line 1
    ]
    ^
SyntaxError: unmatched ']'
```