### PR TITLE
fix grammar/typos in docs/interactive

### DIFF
--- a/docs/source/interactive/python-ipython-diff.rst
+++ b/docs/source/interactive/python-ipython-diff.rst
@@ -3,20 +3,20 @@ Python vs IPython
 =================
 
 This document is meant to highlight the main differences between the Python
-language and what are the specific construct you can do only in IPython.
+language and what are the specific constructs you can do only in IPython.
 
-Unless expressed otherwise all of the construct you will see here will raise a
+Unless expressed otherwise all of the constructs you will see here will raise a
 ``SyntaxError`` if run in a pure Python shell, or if executing in a Python
 script.
 
-Each of these features are described more in detail in further part of the documentation.
+Each of these features is described more in detail in the further parts of the documentation.
 
 
 Quick overview:
 ===============
 
 
-All the following construct are valid IPython syntax:
+All the following constructs are valid IPython syntax:
 
 .. code-block:: ipython
 
@@ -58,8 +58,8 @@ All the following construct are valid IPython syntax:
        ...: print $months[0];
 
 
-Each of these construct is compiled by IPython into valid python code and will
-do most of the time what you expect it will do. Let see each of these example
+Each of these constructs is compiled by IPython into valid python code and will
+do most of the time what you expect it will do. Let see each of these examples
 in more detail.
 
 
@@ -89,8 +89,8 @@ shortcut to get help. A question mark alone will bring up the IPython help:
     -------------
     ...
 
-A single question mark before, or after an object available in current
-namespace will show help relative to this object:
+A single question mark before or after an object available in the current
+name-space will show help relative to this object:
 
 .. code-block:: ipython
 
@@ -126,8 +126,8 @@ and if possible display the python source code of this object.
 
 
 
-If you are looking for an object, the use of wildcards ``*`` in conjunction
-with question mark will allow you to search current namespace for object with
+If you are looking for an object the use of wildcards ``*`` in conjunction
+with a question mark will allow you to search the current name-space for objects with
 matching names:
 
 .. code-block:: ipython
@@ -142,10 +142,10 @@ Shell Assignment
 ================
 
 
-When doing interactive computing it is common to need to access the underlying shell.
+When doing interactive computing it is a common need is accessing the underlying shell.
 This is doable through the use of the exclamation mark ``!`` (or bang).
 
-This allow to execute simple command when present in beginning of line:
+This allows to execute simple commands when present in beginning of the line:
 
 .. code-block:: ipython
 
@@ -167,7 +167,7 @@ Or edit file:
 
 The line after the bang can call any program installed in the underlying
 shell, and support variable expansion in the form of ``$variable`` or ``{variable}``.
-The later form of expansion supports arbitrary python expression:
+The later form of expansion supports arbitrary python expressions:
 
 .. code-block:: ipython
 
@@ -176,19 +176,19 @@ The later form of expansion supports arbitrary python expression:
     In[2]: !mv $file {file.upper()}
 
 
-The bang can also be present in the right hand side of an assignment, just
-after the equal sign, or separated from it by a white space. In which case the
-standard output of the command after the bang ``!`` will be split out into lines
-in a list-like object and assign to the left hand side.
+The bang (``!``) can also be present on the right hand side of an assignment, just
+after the equal sign, or separated from it by a white space. In this case the
+standard output of the command after the bang will be split out into lines
+in a list-like object and assigned to the left hand side.
 
-This allow you for example to put the list of files of the current working directory in a variable:
+This allows you, for example, to put the list of files of the current working directory in a variable:
 
 .. code-block:: ipython
 
     In[1]: my_files = !ls
 
 
-You can combine the different possibilities in for loops, condition, functions...:
+You can combine the different possibilities in for loops, conditions, functions...:
 
 .. code-block:: ipython
 
@@ -202,19 +202,19 @@ You can combine the different possibilities in for loops, condition, functions..
 Magics
 ------
 
-Magics function are often present in the form of shell-like syntax, but are
-under the hood python function. The syntax and assignment possibility are
+Magics function are often present in the form of shell-like syntax, but they are
+python functions under the hood. The syntax and assignment possibilities are
 similar to the one with the bang (``!``) syntax, but with more flexibility and
-power. Magic function start with a percent sign (``%``) or double percent (``%%``).
+power. Magic functions start with a percent sign (``%``) or double percent (``%%``).
 
-A magic call with a sign percent will act only on one line:
+A magic call with a percent sign will act only on one line:
 
 .. code-block:: ipython
 
     In[1]: %xmode
     Exception reporting mode: Verbose
 
-And support assignment:
+Magics support assignment:
 
 .. code-block:: ipython
 
@@ -224,7 +224,7 @@ And support assignment:
     In [2]: results
     Out[2]: <TimeitResult : 1 loops, best of 1: 21.1 µs per loop>
 
-Magic with two percent sign can spread over multiple lines, but does not support assignment:
+Magics with double percent signs (``%%``) can spread over multiple lines, but they do not support assignments:
 
 .. code-block:: ipython
 

--- a/docs/source/interactive/python-ipython-diff.rst
+++ b/docs/source/interactive/python-ipython-diff.rst
@@ -59,7 +59,7 @@ All the following constructs are valid IPython syntax:
 
 
 Each of these constructs is compiled by IPython into valid python code and will
-do most of the time what you expect it will do. Let see each of these examples
+do most of the time what you expect it will do. Let's see each of these examples
 in more detail.
 
 
@@ -90,7 +90,7 @@ shortcut to get help. A question mark alone will bring up the IPython help:
     ...
 
 A single question mark before or after an object available in the current
-name-space will show help relative to this object:
+namespace will show help relative to this object:
 
 .. code-block:: ipython
 
@@ -126,8 +126,8 @@ and if possible display the python source code of this object.
 
 
 
-If you are looking for an object the use of wildcards ``*`` in conjunction
-with a question mark will allow you to search the current name-space for objects with
+If you are looking for an object, the use of wildcards ``*`` in conjunction
+with a question mark will allow you to search the current namespace for objects with
 matching names:
 
 .. code-block:: ipython
@@ -142,7 +142,7 @@ Shell Assignment
 ================
 
 
-When doing interactive computing it is a common need is accessing the underlying shell.
+When doing interactive computing it is a common need to access the underlying shell.
 This is doable through the use of the exclamation mark ``!`` (or bang).
 
 This allows to execute simple commands when present in beginning of the line:
@@ -202,12 +202,12 @@ You can combine the different possibilities in for loops, conditions, functions.
 Magics
 ------
 
-Magics function are often present in the form of shell-like syntax, but they are
+Magic functions (magics) are often present in the form of shell-like syntax, but they are
 python functions under the hood. The syntax and assignment possibilities are
 similar to the one with the bang (``!``) syntax, but with more flexibility and
-power. Magic functions start with a percent sign (``%``) or double percent (``%%``).
+power. Magic functions start with a percent sign (``%``) or double percent signs (``%%``).
 
-A magic call with a percent sign will act only on one line:
+A magic call with a single percent sign will act only on one line:
 
 .. code-block:: ipython
 


### PR DESCRIPTION
Hello,

This PR just has a few quick (low-level) grammar and typo fixes for a doc page that I was reading.
Feel free to integrate/change whatever you see fit.