### PR TITLE
Strip vi-mode style prompts from the input

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -89,7 +89,28 @@ classic_prompt = PromptStripper(
     initial_re=re.compile(r'^>>>( |$)')
 )
 
-ipython_prompt = PromptStripper(re.compile(r'^(In \[\d+\]: |\s*\.{3,}: ?)'))
+ipython_prompt = PromptStripper(re.compile(
+    r'''
+    ^(                         # Match from the beginning of a line, either:
+
+                               # 1. First-line prompt:
+    ((\[nav\]|\[ins\])?\ )?    # Vi editing mode prompt, if it's there
+    In\                        # The 'In' of the prompt, with a space
+    \[\d+\]:                   # Command index, as displayed in the prompt
+    \                          # With a mandatory trailing space
+
+    |                          # ... or ...
+
+                               # 2. The three dots of the multiline prompt
+    \s*                        # All leading whitespace characters
+    \.{3,}:                    # The three (or more) dots
+    \ ?                        # With an optional trailing space
+
+    )
+    ''',
+    re.VERBOSE
+))
+
 
 def cell_magic(lines):
     if not lines or not lines[0].startswith('%%'):

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -89,8 +89,9 @@ classic_prompt = PromptStripper(
     initial_re=re.compile(r'^>>>( |$)')
 )
 
-ipython_prompt = PromptStripper(re.compile(
-    r'''
+ipython_prompt = PromptStripper(
+    re.compile(
+        r"""
     ^(                         # Match from the beginning of a line, either:
 
                                # 1. First-line prompt:
@@ -107,9 +108,10 @@ ipython_prompt = PromptStripper(re.compile(
     \ ?                        # With an optional trailing space
 
     )
-    ''',
-    re.VERBOSE
-))
+    """,
+        re.VERBOSE,
+    )
+)
 
 
 def cell_magic(lines):

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -92,23 +92,23 @@ classic_prompt = PromptStripper(
 ipython_prompt = PromptStripper(
     re.compile(
         r"""
-    ^(                         # Match from the beginning of a line, either:
+        ^(                         # Match from the beginning of a line, either:
 
-                               # 1. First-line prompt:
-    ((\[nav\]|\[ins\])?\ )?    # Vi editing mode prompt, if it's there
-    In\                        # The 'In' of the prompt, with a space
-    \[\d+\]:                   # Command index, as displayed in the prompt
-    \                          # With a mandatory trailing space
+                                   # 1. First-line prompt:
+        ((\[nav\]|\[ins\])?\ )?    # Vi editing mode prompt, if it's there
+        In\                        # The 'In' of the prompt, with a space
+        \[\d+\]:                   # Command index, as displayed in the prompt
+        \                          # With a mandatory trailing space
 
-    |                          # ... or ...
+        |                          # ... or ...
 
-                               # 2. The three dots of the multiline prompt
-    \s*                        # All leading whitespace characters
-    \.{3,}:                    # The three (or more) dots
-    \ ?                        # With an optional trailing space
+                                   # 2. The three dots of the multiline prompt
+        \s*                        # All leading whitespace characters
+        \.{3,}:                    # The three (or more) dots
+        \ ?                        # With an optional trailing space
 
-    )
-    """,
+        )
+        """,
         re.VERBOSE,
     )
 )

--- a/IPython/core/tests/test_inputtransformer2_line.py
+++ b/IPython/core/tests/test_inputtransformer2_line.py
@@ -62,36 +62,48 @@ for a in range(5):
 """)
 
 
-IPYTHON_PROMPT_VI_INS = ("""\
+IPYTHON_PROMPT_VI_INS = (
+    """\
 [ins] In [11]: def a():
           ...:     123
           ...:
           ...: 123
-""", """\
+""",
+    """\
 def a():
     123
 
 123
-""")
+""",
+)
 
-IPYTHON_PROMPT_VI_NAV = ("""\
+IPYTHON_PROMPT_VI_NAV = (
+    """\
 [nav] In [11]: def a():
           ...:     123
           ...:
           ...: 123
-""", """\
+""",
+    """\
 def a():
     123
 
 123
-""")
+""",
+)
 
 
 def test_ipython_prompt():
-    for sample, expected in [IPYTHON_PROMPT, IPYTHON_PROMPT_L2,
-                             IPYTHON_PROMPT_VI_INS, IPYTHON_PROMPT_VI_NAV]:
-        nt.assert_equal(ipt2.ipython_prompt(sample.splitlines(keepends=True)),
-                        expected.splitlines(keepends=True))
+    for sample, expected in [
+        IPYTHON_PROMPT,
+        IPYTHON_PROMPT_L2,
+        IPYTHON_PROMPT_VI_INS,
+        IPYTHON_PROMPT_VI_NAV,
+    ]:
+        nt.assert_equal(
+            ipt2.ipython_prompt(sample.splitlines(keepends=True)),
+            expected.splitlines(keepends=True),
+        )
 
 
 INDENT_SPACES = ("""\

--- a/IPython/core/tests/test_inputtransformer2_line.py
+++ b/IPython/core/tests/test_inputtransformer2_line.py
@@ -61,10 +61,38 @@ for a in range(5):
     print(a ** 2)
 """)
 
+
+IPYTHON_PROMPT_VI_INS = ("""\
+[ins] In [11]: def a():
+          ...:     123
+          ...:
+          ...: 123
+""", """\
+def a():
+    123
+
+123
+""")
+
+IPYTHON_PROMPT_VI_NAV = ("""\
+[nav] In [11]: def a():
+          ...:     123
+          ...:
+          ...: 123
+""", """\
+def a():
+    123
+
+123
+""")
+
+
 def test_ipython_prompt():
-    for sample, expected in [IPYTHON_PROMPT, IPYTHON_PROMPT_L2]:
+    for sample, expected in [IPYTHON_PROMPT, IPYTHON_PROMPT_L2,
+                             IPYTHON_PROMPT_VI_INS, IPYTHON_PROMPT_VI_NAV]:
         nt.assert_equal(ipt2.ipython_prompt(sample.splitlines(keepends=True)),
                         expected.splitlines(keepends=True))
+
 
 INDENT_SPACES = ("""\
      if True:

--- a/docs/source/whatsnew/pr/vi-prompt-strip.rst
+++ b/docs/source/whatsnew/pr/vi-prompt-strip.rst
@@ -1,0 +1,29 @@
+Automatic Vi prompt stripping
+=============================
+
+When pasting code into IPython, it will strip the leading prompt characters if
+there are any. For example, you can paste the following code into the console -
+it will still work, even though each line is prefixed with prompts (`In`,
+`Out`)::
+
+    In [1]: 2 * 2 == 4
+    Out[1]: True
+
+    In [2]: print("This still works as pasted")
+
+
+Previously, this was not the case for the Vi-mode prompts::
+
+    In [1]: [ins] In [13]: 2 * 2 == 4
+       ...: Out[13]: True
+       ...: 
+      File "<ipython-input-1-727bb88eaf33>", line 1
+        [ins] In [13]: 2 * 2 == 4
+              ^
+    SyntaxError: invalid syntax
+
+This is now fixed, and Vi prompt prefixes - ``[ins]`` and ``[nav]`` -  are
+skipped just as the normal ``In`` would be.
+
+IPython shell can be started in the Vi mode using ``ipython
+--TerminalInteractiveShell.editing_mode=vi``


### PR DESCRIPTION
This strips `"[ins] "` and `"[nav] "` prefix of the prompt from the commands.

See [this debugex snippet](https://www.debuggex.com/r/4trT0ugmRh0W8VoO) for a visualization of what the regex does now.

To do:
- [x] Single-line paste stripping
- [x] Multiple-line paste stripping
- [x] Tests for both
- ~~Docs? Should this also land in that one sphinxext that does this for doctest?~~

Fixes #12841