### PR TITLE
Reformat and improve the wording of %cd docstring

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -302,33 +302,36 @@ class OSMagics(Magics):
         """Change the current working directory.
 
         This command automatically maintains an internal list of directories
-        you visit during your IPython session, in the variable _dh. The
-        command %dhist shows this history nicely formatted. You can also
-        do 'cd -<tab>' to see directory history conveniently.
-
+        you visit during your IPython session, in the variable ``_dh``. The
+        command :magic:`%dhist` shows this history nicely formatted. You can
+        also do ``cd -<tab>`` to see directory history conveniently.
         Usage:
 
-          cd 'dir': changes to directory 'dir'.
+          - ``cd 'dir'``: changes to directory 'dir'.
+          - ``cd -``: changes to the last visited directory.
+          - ``cd -<n>``: changes to the n-th directory in the directory history.
+          - ``cd --foo``: change to directory that matches 'foo' in history
+          - ``cd -b <bookmark_name>``: jump to a bookmark set by %bookmark
+          - Hitting a tab key after ``cd -b`` allows you to tab-complete
+            bookmark names.
 
-          cd -: changes to the last visited directory.
+          .. note::
+            ``cd <bookmark_name>`` is enough if there is no directory
+            ``<bookmark_name>``, but a bookmark with the name exists.
 
-          cd -<n>: changes to the n-th directory in the directory history.
-
-          cd --foo: change to directory that matches 'foo' in history
-
-          cd -b <bookmark_name>: jump to a bookmark set by %bookmark
-             (note: cd <bookmark_name> is enough if there is no
-              directory <bookmark_name>, but a bookmark with the name exists.)
-              'cd -b <tab>' allows you to tab-complete bookmark names.
 
         Options:
 
-        -q: quiet.  Do not print the working directory after the cd command is
-        executed.  By default IPython's cd command does print this directory,
-        since the default prompts do not display path information.
+        -q               Be quiet. Do not print the working directory after the
+                         cd command is executed. By default IPython's cd
+                         command does print this directory, since the default
+                         prompts do not display path information.
 
-        Note that !cd doesn't work for this purpose because the shell where
-        !command runs is immediately discarded after executing 'command'.
+        .. note::
+           Note that ``!cd`` doesn't work for this purpose because the shell
+           where ``!command`` runs is immediately discarded after executing
+           'command'.
+
 
         Examples
         --------


### PR DESCRIPTION
Fixes #12885.

This has been a bit of a wild ride. Trying to compile docs locally creates an html page with most of the magics undocumented. I managed to fix it by (I think) downgrading `decorator` from `5.0.3` to `4.4.2` - v5 has been released yesterday.

Anyway, this is how this doc looked before:
![image](https://user-images.githubusercontent.com/6691643/113491161-018b9c80-94cf-11eb-8c55-f6174bd7cdc7.png)

This is how it looks after the changes from this PR:

![image](https://user-images.githubusercontent.com/6691643/113491174-16683000-94cf-11eb-8791-7a89155f238a.png)
