### PR TITLE
Add a testcase for Image() raising FileNotFoundError on a bad filename

### DIFF
--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -460,4 +460,4 @@ def test_display_handle():
 
 @nt.raises(FileNotFoundError)
 def test_image_bad_filename_raises_proper_exception():
-    display.Image("/this/file/does/not/exist/")
+    display.Image("/this/file/does/not/exist/")._repr_png_()

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -457,3 +457,7 @@ def test_display_handle():
         'update': True,
     })
 
+
+@nt.raises(FileNotFoundError)
+def test_image_bad_filename_raises_proper_exception():
+    display.Image('/this/file/does/not/exist/')

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -460,4 +460,4 @@ def test_display_handle():
 
 @nt.raises(FileNotFoundError)
 def test_image_bad_filename_raises_proper_exception():
-    display.Image('/this/file/does/not/exist/')
+    display.Image("/this/file/does/not/exist/")


### PR DESCRIPTION
Fixes #11535 (i.e. I think that adding this test would be the last thing needed to close that issue).

Proper exception was added in #11663. This tests for if it's actually there, so that whenever the refactor mentioned in that PR comes, we don't accidentally get back to the state from before it.