### PR TITLE
Cleaner shutdown

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3785,26 +3785,30 @@ class InteractiveShell(SingletonConfigurable):
         code that has the appropriate information, rather than trying to
         clutter
         """
+        # Clear all user namespaces to release all references cleanly.
+        self.reset(new_session=False)
         # Close the history session (this stores the end time and line count)
         # this must be *before* the tempfile cleanup, in case of temporary
         # history db
         self.history_manager.end_session()
+        del self.history_manager
 
         # Cleanup all tempfiles and folders left around
         for tfile in self.tempfiles:
             try:
                 tfile.unlink()
+                self.tempfiles.remove(tfile)
             except FileNotFoundError:
                 pass
-
+        del self.tempfiles
         for tdir in self.tempdirs:
             try:
                 tdir.rmdir()
+                self.tempdirs.remove(tdir)
             except FileNotFoundError:
                 pass
+        del self.tempdirs
 
-        # Clear all user namespaces to release all references cleanly.
-        self.reset(new_session=False)
 
         # Run user hooks
         self.hooks.shutdown_hook()

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -146,8 +146,16 @@ def test_import_pylab():
     nt.assert_true('plt' in ns)
     nt.assert_equal(ns['np'], np)
 
+from traitlets.config import Config
+
+
 class TestPylabSwitch(object):
     class Shell(InteractiveShell):
+        def init_history(self):
+            """Sets up the command history, and starts regular autosaves."""
+            self.config.HistoryManager.hist_file = ":memory:"
+            super().init_history()
+
         def enable_gui(self, gui):
             pass
 
@@ -179,6 +187,7 @@ class TestPylabSwitch(object):
         matplotlib.rcParamsOrig = self._saved_rcParamsOrig
 
     def test_qt(self):
+
         s = self.Shell()
         gui, backend = s.enable_matplotlib(None)
         nt.assert_equal(gui, 'qt')

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -615,6 +615,13 @@ class TerminalInteractiveShell(InteractiveShell):
 
                 self.restore_term_title()
 
+        # try to call some at-exit operation optimistically as some things can't
+        # be done during interpreter shutdown. this is technically inaccurate as
+        # this make mainlool not re-callable, but that should be a rare if not
+        # in existent use case.
+
+        self._atexit_once()
+
 
     _inputhook = None
     def inputhook(self, context):


### PR DESCRIPTION
Reset recreate a new history; so ther is no point in calling it after
closing history session.

Unset  class variable to be sure they are not reused.