### PR TITLE
Make %precision work for numpy.float64 type

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -636,7 +636,6 @@ class PlainTextFormatter(BaseFormatter):
 
         This parameter can be set via the '%precision' magic.
         """
-
         new = change['new']
         if '%' in new:
             # got explicit format string
@@ -678,7 +677,9 @@ class PlainTextFormatter(BaseFormatter):
     def _type_printers_default(self):
         d = pretty._type_pprinters.copy()
         d[float] = lambda obj,p,cycle: p.text(self.float_format%obj)
+        # if NumPy is used, set precision for its float64 type
         if 'numpy' in sys.modules:
+            import numpy
             d[numpy.float64] = lambda obj,p,cycle: p.text(self.float_format%obj)
         return d
 

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -678,6 +678,8 @@ class PlainTextFormatter(BaseFormatter):
     def _type_printers_default(self):
         d = pretty._type_pprinters.copy()
         d[float] = lambda obj,p,cycle: p.text(self.float_format%obj)
+        if 'numpy' in sys.modules:
+            d[numpy.float64] = lambda obj,p,cycle: p.text(self.float_format%obj)
         return d
 
     @default('deferred_printers')

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -678,9 +678,10 @@ class PlainTextFormatter(BaseFormatter):
         d = pretty._type_pprinters.copy()
         d[float] = lambda obj,p,cycle: p.text(self.float_format%obj)
         # if NumPy is used, set precision for its float64 type
-        if 'numpy' in sys.modules:
+        if "numpy" in sys.modules:
             import numpy
-            d[numpy.float64] = lambda obj,p,cycle: p.text(self.float_format%obj)
+
+            d[numpy.float64] = lambda obj, p, cycle: p.text(self.float_format % obj)
         return d
 
     @default('deferred_printers')


### PR DESCRIPTION
Many NumPy functions return a `float64` type whose display does not obey `%precision`, for example:

```
In [4]: precision 2
Out[4]: '%.2f'

In [5]: np.linalg.norm([1,2])
Out[5]: 2.23606797749979
```

IPython already sets precision for NumPy **arrays** using `set_printoptions()` but this does not affect the format for scalars.

This simple change sets the formatter for `float64` to be the same as for `float` so that any changes to precision will take effect for `float64`.
