### PR TITLE
Start embedded IPython shell for ipdb interact, #12913

### DIFF
--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -136,7 +136,7 @@ class TerminalPdb(Pdb):
         ipshell = embed.InteractiveShellEmbed(
             config=self.shell.config,
             banner1="*interactive*",
-            exit_msg="now exiting InteractiveConsole...",
+            exit_msg="*exiting interactive console...*",
         )
         global_ns = self.curframe.f_globals
         ipshell(

--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -7,6 +7,7 @@ from IPython.core.debugger import Pdb
 from IPython.core.completer import IPCompleter
 from .ptutils import IPythonPTCompleter
 from .shortcuts import create_ipython_shortcuts
+from . import embed
 
 from pygments.token import Token
 from prompt_toolkit.shortcuts.prompt import PromptSession
@@ -130,6 +131,18 @@ class TerminalPdb(Pdb):
             self.postloop()
         except Exception:
             raise
+
+    def do_interact(self, arg):
+        ipshell = embed.InteractiveShellEmbed(
+            config=self.shell.config,
+            banner1="*interactive*",
+            exit_msg="now exiting InteractiveConsole...",
+        )
+        global_ns = self.curframe.f_globals
+        ipshell(
+            module=sys.modules.get(global_ns["__name__"], None),
+            local_ns=self.curframe_locals,
+        )
 
 
 def set_trace(frame=None):

--- a/docs/source/whatsnew/pr/ipdb-interact.rst
+++ b/docs/source/whatsnew/pr/ipdb-interact.rst
@@ -1,0 +1,4 @@
+IPython shell for ipdb interact
+-------------------------------
+
+The ipdb ``interact`` starts an IPython shell instead of Python's built-in ``code.interact()``.


### PR DESCRIPTION
Gets into a recursive embedded IPython shell when you type "interact" inside the debugger, instead of `code.interact()`.

I'm not sure that's the right way to implement it but it works. It might be better to reuse `self.shell`.

```
ipython
Python 3.9.3 (default, Apr  8 2021, 23:35:02) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.0.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: %debug on
NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
> <string>(1)<module>()

ipdb> interact
*interactive*
In [1]: %debug on
NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
NameError: name 'on' is not defined

In [2]: %debug
ERROR:root:No traceback has been produced, nothing to debug.

In [3]: %pdb on
Automatic pdb calling has been turned ON

In [4]: raise Exception()

---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-4-32c500991385> in <module>
----> 1 raise Exception()

Exception: 
> <ipython-input-4-32c500991385>(1)<module>()
----> 1 raise Exception()

ipdb> 
ipdb> interact
*interactive*
In [1]:                                                                         
Do you really want to exit ([y]/n)? 
now exiting InteractiveConsole...
ipdb>                                                                           


In [5]:                                                                         
Do you really want to exit ([y]/n)? 
now exiting InteractiveConsole...
ipdb>                                                                           


In [2]:                                                                         
Do you really want to exit ([y]/n)? 
```

@MrMino 