### PR TITLE
Minor syntax cleanup and simplification.

### DIFF
--- a/IPython/core/display_functions.py
+++ b/IPython/core/display_functions.py
@@ -85,7 +85,17 @@ def _new_id():
     return b2a_hex(os.urandom(16)).decode('ascii')
 
 
-def display(*objs, include=None, exclude=None, metadata=None, transient=None, display_id=None, **kwargs):
+def display(
+    *objs,
+    include=None,
+    exclude=None,
+    metadata=None,
+    transient=None,
+    display_id=None,
+    raw=False,
+    clear=False,
+    **kwargs
+):
     """Display a Python object in all frontends.
 
     By default all representations will be computed and sent to the frontends.
@@ -242,8 +252,6 @@ def display(*objs, include=None, exclude=None, metadata=None, transient=None, di
         print(*objs)
         return
 
-    raw = kwargs.pop("raw", False)
-    clear = kwargs.pop("clear", False)
     if transient is None:
         transient = {}
     if metadata is None:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -636,7 +636,7 @@ class Magics(Configurable):
                     '%s ( allowed: "%s" %s)' % (e.msg, opt_str, " ".join(long_opts))
                 ) from e
             for o, a in opts:
-                if mode is "string" and preserve_non_opts:
+                if mode == "string" and preserve_non_opts:
                     # remove option-parts from the original args-string and preserve remaining-part.
                     # This relies on the arg_split(...) and getopt(...)'s impl spec, that the parsed options are
                     # returned in the original order.

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -334,7 +334,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         self.compile.flags = orig_compile_flags
 
 
-def embed(**kwargs):
+def embed(*, header="", compile_flags=None, **kwargs):
     """Call this to embed IPython at the current point in your program.
 
     The first invocation of this will create an :class:`InteractiveShellEmbed`
@@ -360,8 +360,6 @@ def embed(**kwargs):
     config argument.
     """
     config = kwargs.get('config')
-    header = kwargs.pop('header', u'')
-    compile_flags = kwargs.pop('compile_flags', None)
     if config is None:
         config = load_default_config()
         config.InteractiveShellEmbed = config.TerminalInteractiveShell


### PR DESCRIPTION
Remove a syntax warning; and use explicit kwargs instead of kwargs.pop.