### PR TITLE
Fixed documentation display for line magics' env method

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -439,11 +439,11 @@ class OSMagics(Magics):
 
         Usage:\\
 
-          %env: lists all environment variables/values
-          %env var: get value for var
-          %env var val: set value for var
-          %env var=val: set value for var
-          %env var=$val: set value for var, using python expansion if possible
+          :%env: lists all environment variables/values
+          :%env var: get value for var
+          :%env var val: set value for var
+          :%env var=val: set value for var
+          :%env var=$val: set value for var, using python expansion if possible
         """
         if parameter_s.strip():
             split = '=' if '=' in parameter_s else ' '

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -439,11 +439,11 @@ class OSMagics(Magics):
 
         Usage:\\
 
-          :%env: lists all environment variables/values
-          :%env var: get value for var
-          :%env var val: set value for var
-          :%env var=val: set value for var
-          :%env var=$val: set value for var, using python expansion if possible
+          :``%env``: lists all environment variables/values
+          :``%env var``: get value for var
+          :``%env var val``: set value for var
+          :``%env var=val``: set value for var
+          :``%env var=$val``: set value for var, using python expansion if possible
         """
         if parameter_s.strip():
             split = '=' if '=' in parameter_s else ' '


### PR DESCRIPTION
This fixes #12762. I modified the docstring for `Ipython.core.magics.osm`. For each usage, I added a colon (:) as represented in field lists docstring. Here's how it looks now:

<img width="602" alt="Screen Shot 2021-04-21 at 8 02 06 PM" src="https://user-images.githubusercontent.com/50649079/115649594-74bd4d00-a2dc-11eb-8645-1b141567bfef.png">
