### PR TITLE
remove use of deprecated pipes module

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -213,7 +213,7 @@ class ScriptMagics(Magics):
                     *cmd,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
-                    stdin=asyncio.subprocess.PIPE
+                    stdin=asyncio.subprocess.PIPE,
                 )
             )
         except OSError as e:

--- a/IPython/lib/editorhooks.py
+++ b/IPython/lib/editorhooks.py
@@ -6,7 +6,6 @@ Contributions are *very* welcome.
 """
 
 import os
-import pipes
 import shlex
 import subprocess
 import sys
@@ -47,9 +46,9 @@ def install_editor(template, wait=False):
     def call_editor(self, filename, line=0):
         if line is None:
             line = 0
-        cmd = template.format(filename=pipes.quote(filename), line=line)
+        cmd = template.format(filename=shlex.quote(filename), line=line)
         print(">", cmd)
-        # pipes.quote doesn't work right on Windows, but it does after splitting
+        # shlex.quote doesn't work right on Windows, but it does after splitting
         if sys.platform.startswith('win'):
             cmd = shlex.split(cmd)
         proc = subprocess.Popen(cmd, shell=True)


### PR DESCRIPTION
pipes.quote is actually an alias to shlex.quote, so use its true name instead

pipes is (probably) deprecated by [PEP 594](https://www.python.org/dev/peps/pep-0594), to be removed possibly in 3.10.