### PR TITLE
Drop support for numpy 1.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ extras_require = dict(
         "pygments",
         "nbformat",
         "ipykernel",
-        "numpy>=1.16",
+        "numpy>=1.17",
     ],
     terminal=[],
     kernel=["ipykernel"],


### PR DESCRIPTION
We said we would do that some time ago and havent.

Likely for 7.24