### PR TITLE
IPython.core.pylabtools: fix configure_inline_support import

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -383,6 +383,6 @@ def configure_inline_support(shell, backend):
         stacklevel=2,
     )
 
-    from matplotlib_inline.backend_inline import configure_inline_support_orig
+    from matplotlib_inline.backend_inline import configure_inline_support as configure_inline_support_orig
 
     configure_inline_support_orig(shell, backend)


### PR DESCRIPTION
The deprecated function `IPython.core.pylabtools.configure_inline_support` attempts to import `configure_inline_support_orig` from the module `matplotlib_inline.backend_inline`, but the actual function name is `configure_inline_support`. Correct the import.