### PR TITLE
fix darker version 1.2.3 linting

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install darker
+        pip install darker isort
     - name: Lint with darker
       run: |
         darker -r 60625f241f298b5039cb2debc365db38aa7bb522 --check --diff . || (

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -383,6 +383,8 @@ def configure_inline_support(shell, backend):
         stacklevel=2,
     )
 
-    from matplotlib_inline.backend_inline import configure_inline_support as configure_inline_support_orig
+    from matplotlib_inline.backend_inline import (
+        configure_inline_support as configure_inline_support_orig,
+    )
 
     configure_inline_support_orig(shell, backend)


### PR DESCRIPTION
it looks like the current version of darker doesn't work properly if
isort isn't installed - see https://github.com/akaihola/darker/pull/132
so let's just install isort to fix it.

found via https://github.com/ipython/ipython/pull/12952#issuecomment-833855862 and https://github.com/ipython/ipython/pull/12940#issuecomment-832757006