### PR TITLE
Changing the compiler that caches to the same one that works with AST

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3122,7 +3122,7 @@ class InteractiveShell(SingletonConfigurable):
         _run_async = False
 
         with self.builtin_trap:
-            cell_name = self.compile.cache(
+            cell_name = compiler.cache(
                 cell, self.execution_count, raw_code=raw_cell
             )
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3122,9 +3122,7 @@ class InteractiveShell(SingletonConfigurable):
         _run_async = False
 
         with self.builtin_trap:
-            cell_name = compiler.cache(
-                cell, self.execution_count, raw_code=raw_cell
-            )
+            cell_name = compiler.cache(cell, self.execution_count, raw_code=raw_cell)
 
             with self.display_trap:
                 # Compile to bytecode


### PR DESCRIPTION
I just noticed that there is a chance that `run_async_cell` would use a different compiler for caching and visiting the AST. Just felt weird to me.