### PR TITLE
Nicer output for erroneous args to %rerun -l

### DIFF
--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -301,6 +301,14 @@ class HistoryMagics(Magics):
         opts, args = self.parse_options(parameter_s, 'l:g:', mode='string')
         if "l" in opts:         # Last n lines
             n = int(opts['l'])
+
+            if n == 0:
+                print("Requested 0 last lines - nothing to run")
+                return
+            elif n < 0:
+                print("Number of lines to rerun cannot be negative")
+                return
+
             hist = self.shell.history_manager.get_tail(n)
         elif "g" in opts:       # Search
             p = "*"+opts['g']+"*"


### PR DESCRIPTION
Fixes #12947

Not sure if I should add a `pr/` entry for it, it seems too small to land inside the changelog.