### PR TITLE
use time.process_time instead of perf_counter

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1326,19 +1326,22 @@ class ExecutionMagics(Magics):
 
         wall_end = wtime()
         # Compute actual times and report
-        wall_time = wall_end-wall_st
-        cpu_user = end[0]-st[0]
-        cpu_sys = end[1]-st[1]
-        cpu_tot = cpu_user+cpu_sys
-        # On windows cpu_sys is always zero, so no new information to the next print 
-        if sys.platform != 'win32':
-            print("CPU times: user %s, sys: %s, total: %s" % \
-                (_format_time(cpu_user),_format_time(cpu_sys),_format_time(cpu_tot)))
-        print("Wall time: %s" % _format_time(wall_time))
+        wall_time = wall_end - wall_st
+        cpu_user = end[0] - st[0]
+        cpu_sys = end[1] - st[1]
+        cpu_tot = cpu_user + cpu_sys
+        # On windows cpu_sys is always zero, so only total is displayed
+        if sys.platform != "win32":
+            print(
+                f"CPU times: user {_format_time(cpu_user)}, sys: {_format_time(cpu_sys)}, total: {_format_time(cpu_tot)}"
+            )
+        else:
+            print(f"CPU times: total: {_format_time(cpu_tot)}")
+        print(f"Wall time: {_format_time(wall_time)}")
         if tc > tc_min:
-            print("Compiler : %s" % _format_time(tc))
+            print(f"Compiler : {_format_time(tc)}")
         if tp > tp_min:
-            print("Parser   : %s" % _format_time(tp))
+            print(f"Parser   : {_format_time(tp)}")
         return out
 
     @skip_doctest

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -64,14 +64,14 @@ if resource is not None and hasattr(resource, "getrusage"):
 
 else:
     # There is no distinction of user/system time under windows, so we just use
-    # time.perff_counter() for everything...
-    clocku = clocks = clock = time.perf_counter
+    # time.process_time() for everything...
+    clocku = clocks = clock = time.process_time
 
     def clock2():
         """Under windows, system CPU time can't be measured.
 
-        This just returns perf_counter() and zero."""
-        return time.perf_counter(),0.0
+        This just returns process_time() and zero."""
+        return time.process_time(), 0.0
 
     
 def timings_out(reps,func,*args,**kw):

--- a/docs/source/whatsnew/development.rst
+++ b/docs/source/whatsnew/development.rst
@@ -23,6 +23,8 @@ Need to be updated:
    pr/*
 
 
+
+
 .. DO NOT EDIT THIS LINE BEFORE RELEASE. FEATURE INSERTION POINT.
 
 Backwards incompatible changes

--- a/docs/source/whatsnew/pr/12984-process-time.rst
+++ b/docs/source/whatsnew/pr/12984-process-time.rst
@@ -1,0 +1,6 @@
+windows time-implementation: Switch to process_time
+===================================================
+Timing for example with ``%%time`` on windows is based on ``time.perf_counter``.
+This is at the end the same as W-All.
+To be a bit tighter to linux one could change to ``time.process_time`` instead.
+Thus for example one would no longer count periods of sleep and further.


### PR DESCRIPTION
changed windows timing to using time.process_time instead of time.perf_counter to be aware of sleep.
Further enabled display of total cpu-time on windows (as now differs from WALL)

This requests adresses the issue #12983 