### PR TITLE
Turn Readonly predicates to false.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -283,7 +283,7 @@ class Pdb(OldPdb):
         self.skip_hidden = True
 
         # list of predicates we use to skip frames
-        self._predicates = {"tbhide": True, "readonly": True, "ipython_internal": True}
+        self._predicates = {"tbhide": True, "readonly": False, "ipython_internal": True}
 
     def set_colors(self, scheme):
         """Shorthand access to the color table scheme selector method."""


### PR DESCRIPTION
It has been pointed to me privately that this is a change of default which is
potentially hard to understand, or discover how to change the values.
Turning back to False by default.