### PR TITLE
Allow to stop in frames when _wait_for_mainpyfile is defined

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -765,8 +765,6 @@ class Pdb(OldPdb):
         hidden = False
         if self.skip_hidden:
             hidden = self._hidden_predicate(frame)
-            if self._wait_for_mainpyfile:
-                return False
         if hidden:
             Colors = self.color_scheme_table.active_colors
             ColorsNormal = Colors.Normal


### PR DESCRIPTION
- This fixes the Spyder debugger after the release of 7.24.0. Otherwise, all frames are skipped and the debugger exits immediately for us.
- I did this PR against `7.x` because these lines are not present in `master`.