### PR TITLE
Allow to control if reporting hidden frames

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -282,6 +282,7 @@ class Pdb(OldPdb):
         # Set the prompt - the default prompt is '(Pdb)'
         self.prompt = prompt
         self.skip_hidden = True
+        self.report_skipped = True
 
         # list of predicates we use to skip frames
         self._predicates = {"tbhide": True, "readonly": False, "ipython_internal": True}
@@ -768,9 +769,10 @@ class Pdb(OldPdb):
             if self._wait_for_mainpyfile:
                 return False
         if hidden:
-            Colors = self.color_scheme_table.active_colors
-            ColorsNormal = Colors.Normal
-            print(f"{Colors.excName}    [... skipped 1 hidden frame]{ColorsNormal}\n")
+            if self.report_skipped:
+                Colors = self.color_scheme_table.active_colors
+                ColorsNormal = Colors.Normal
+                print(f"{Colors.excName}    [... skipped 1 hidden frame]{ColorsNormal}\n")
             return False
         return True
 


### PR DESCRIPTION
- This allows downstream projects to decide if they want to show those messages to users.
- We'd really appreciate if this functionality could be included in 7.24.1, so we could use it in Spyder along with PR #12999.
- If this is accepted, I'll create another PR for master because the `stop_here` code is very different there and can't be easily backported.