### PR TITLE
DOC: Use https for readthedocs.io

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 import sys, os
 from pathlib import Path
 
-# http://read-the-docs.readthedocs.io/en/latest/faq.html
+# https://read-the-docs.readthedocs.io/en/latest/faq.html
 ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 
 if ON_RTD:

--- a/docs/source/config/custommagics.rst
+++ b/docs/source/config/custommagics.rst
@@ -151,7 +151,7 @@ Complete Example
 
 Here is a full example of a magic package. You can distribute magics using
 setuptools, distutils, or any other distribution tools like `flit
-<http://flit.readthedocs.io>`_ for pure Python packages.
+<https://flit.readthedocs.io>`_ for pure Python packages.
 
 When distributing magics as part of a package, recommended best practice is to
 execute the registration inside the `load_ipython_extension` as demonstrated in

--- a/docs/source/config/integrating.rst
+++ b/docs/source/config/integrating.rst
@@ -103,7 +103,7 @@ Rarely, you might want to display a custom traceback when reporting an
 exception. To do this, define the custom traceback using
 `_render_traceback_(self)` method which returns a list of strings, one string
 for each line of the traceback. For example, the `ipyparallel
-<http://ipyparallel.readthedocs.io/>`__ a parallel computing framework for
+<https://ipyparallel.readthedocs.io/>`__ a parallel computing framework for
 IPython, does this to display errors from multiple engines.
 
 Please be conservative in using this feature; by replacing the default traceback

--- a/docs/source/development/wrapperkernels.rst
+++ b/docs/source/development/wrapperkernels.rst
@@ -7,7 +7,7 @@ You can now re-use the kernel machinery in IPython to easily make new kernels.
 This is useful for languages that have Python bindings, such as `Octave
 <http://www.gnu.org/software/octave/>`_ (via
 `Oct2Py <http://blink1073.github.io/oct2py/>`_), or languages
-where the REPL can be controlled in a tty using `pexpect <http://pexpect.readthedocs.io/en/latest/>`_,
+where the REPL can be controlled in a tty using `pexpect <https://pexpect.readthedocs.io/en/latest/>`_,
 such as bash.
 
 .. seealso::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,7 +57,7 @@ features:
 
 The Command line interface inherits the above functionality and adds 
  
-* real multi-line editing thanks to `prompt_toolkit <http://python-prompt-toolkit.readthedocs.io/en/stable/>`_.
+* real multi-line editing thanks to `prompt_toolkit <https://python-prompt-toolkit.readthedocs.io/en/stable/>`_.
  
 * syntax highlighting as you type.
 
@@ -69,7 +69,7 @@ it allows:
 * the object to create a rich display of Html, Images, Latex, Sound and
   Video.
 
-* interactive widgets with the use of the `ipywidgets <http://ipywidgets.readthedocs.io/en/stable/>`_ package.
+* interactive widgets with the use of the `ipywidgets <https://ipywidgets.readthedocs.io/en/stable/>`_ package.
 
 
 This documentation will walk you through most of the features of the IPython
@@ -102,9 +102,9 @@ repository <http://github.com/ipython/ipython>`_.
 
 .. seealso::
 
-   `Jupyter documentation <http://jupyter.readthedocs.io/en/latest/>`__
+   `Jupyter documentation <https://jupyter.readthedocs.io/en/latest/>`__
      The Jupyter documentation provides information about the Notebook code and other Jupyter sub-projects.
-   `ipyparallel documentation <http://ipyparallel.readthedocs.io/en/latest/>`__
+   `ipyparallel documentation <https://ipyparallel.readthedocs.io/en/latest/>`__
      Formerly ``IPython.parallel``.
 
 

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -51,7 +51,7 @@ for more help see
 
 .. seealso::
 
-   `Installing Jupyter <http://jupyter.readthedocs.io/en/latest/install.html>`__
+   `Installing Jupyter <https://jupyter.readthedocs.io/en/latest/install.html>`__
      The Notebook, nbconvert, and many other former pieces of IPython are now
      part of Project Jupyter.
 

--- a/docs/source/interactive/index.rst
+++ b/docs/source/interactive/index.rst
@@ -29,4 +29,4 @@ done some work in the classic Python REPL.
 .. seealso::
 
     `A Qt Console for Jupyter <https://jupyter.org/qtconsole/>`__
-    `The Jupyter Notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`__
+    `The Jupyter Notebook <https://jupyter-notebook.readthedocs.io/en/latest/>`__

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -219,7 +219,7 @@ different numbers which correspond to the Process ID of the kernel.
 
 You can read more about using `jupyter qtconsole
 <https://jupyter.org/qtconsole/>`_, and
-`jupyter notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_. There
+`jupyter notebook <https://jupyter-notebook.readthedocs.io/en/latest/>`_. There
 is also a :ref:`message spec <messaging>` which documents the protocol for
 communication between kernels
 and clients.
@@ -234,7 +234,7 @@ Interactive parallel computing
 
 
 This functionality is optional and now part of the `ipyparallel
-<http://ipyparallel.readthedocs.io/>`_ project.
+<https://ipyparallel.readthedocs.io/>`_ project.
 
 Portability and Python requirements
 -----------------------------------

--- a/docs/source/whatsnew/github-stats-1.0.rst
+++ b/docs/source/whatsnew/github-stats-1.0.rst
@@ -1099,7 +1099,7 @@ Pull Requests (793):
 * :ghpull:`2274`: CLN: Use name to id mapping of notebooks instead of searching.
 * :ghpull:`2270`: SSHLauncher tweaks
 * :ghpull:`2269`: add missing location when disambiguating controller IP
-* :ghpull:`2263`: Allow docs to build on http://readthedocs.io/
+* :ghpull:`2263`: Allow docs to build on https://readthedocs.io/
 * :ghpull:`2256`: Adding data publication example notebook.
 * :ghpull:`2255`: better flush iopub with AsyncResults
 * :ghpull:`2261`: Fix: longest_substr([]) -> ''

--- a/docs/source/whatsnew/version5.rst
+++ b/docs/source/whatsnew/version5.rst
@@ -307,7 +307,7 @@ and tab completions that don't clutter up your history.
     :target: ../_images/ptshell_features.png
 
 These features are provided by the Python library `prompt_toolkit
-<http://python-prompt-toolkit.readthedocs.io/en/stable/>`__, which replaces
+<https://python-prompt-toolkit.readthedocs.io/en/stable/>`__, which replaces
 ``readline`` throughout our terminal interface.
 
 Relying on this pure-Python, cross platform module also makes it simpler to


### PR DESCRIPTION
https is better.

Replaced `http://(.*?readthedocs\.io)` with `https://$1`.