### PR TITLE
Fix typo in IPython.lib.pretty._seq_pprinter_factory doc

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -626,7 +626,7 @@ def _default_pprint(obj, p, cycle):
 def _seq_pprinter_factory(start, end):
     """
     Factory that returns a pprint function useful for sequences.  Used by
-    the default pprint for tuples, dicts, and lists.
+    the default pprint for tuples and lists.
     """
     def inner(obj, p, cycle):
         if cycle:


### PR DESCRIPTION
The `_seq_pprinter_factory` docstring stated it is used for the default pprint for dicts, but dicts use `_dict_pprinter_factory` instead.