### PR TITLE
Fix formatting typo in `%time` docstring

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1235,11 +1235,11 @@ class ExecutionMagics(Magics):
           CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
           Wall time: 0.00
 
-          Note that the time needed by Python to compile the given expression
-          will be reported if it is more than 0.1s.  In this example, the
-          actual exponentiation is done by Python at compilation time, so while
-          the expression can take a noticeable amount of time to compute, that
-          time is purely due to the compilation:
+        Note that the time needed by Python to compile the given expression
+        will be reported if it is more than 0.1s.  In this example, the
+        actual exponentiation is done by Python at compilation time, so while
+        the expression can take a noticeable amount of time to compute, that
+        time is purely due to the compilation:
 
           In [5]: %time 3**9999;
           CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
@@ -1249,7 +1249,7 @@ class ExecutionMagics(Magics):
           CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
           Wall time: 0.00 s
           Compiler : 0.78 s
-          """
+        """
 
         # fail immediately if the given expression can't be compiled
         


### PR DESCRIPTION
This paragraph shouldn't be formatted as code.

I have barely any experience with Sphinx, so please check my work before pulling.