### PR TITLE
Handle ValueError in magic %rerun

### DIFF
--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -301,7 +301,11 @@ class HistoryMagics(Magics):
         """
         opts, args = self.parse_options(parameter_s, 'l:g:', mode='string')
         if "l" in opts:         # Last n lines
-            n = int(opts['l'])
+            try:
+                n = int(opts['l'])
+            except ValueError:
+                print("Argument must be an integer.")
+                return
 
             if n == 0:
                 print("Requested 0 last lines - nothing to run")


### PR DESCRIPTION
Fixes: #12948 

Added a try/except block to handle non-integer arguments.

```
(venv) ipython$ ipython
Python 3.9.5 (default, May  5 2021, 02:58:34)
Type 'copyright', 'credits' or 'license' for more information
IPython 8.0.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: %rerun -l one
Argument must be an integer.
```

All tests pass after running `iptest`:

```
IPython version: 8.0.0.dev
IPython commit : 90c1297 (repository)
IPython package: /mnt/c/Users/James/Documents/git_projects/ipython/IPython
Python version : 3.9.5 (default, May  5 2021, 02:58:34) [GCC 7.5.0]
sys.executable : /mnt/c/Users/James/Documents/git_projects/ipython/venv/bin/python3.9
Platform       : Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.27

Tools and libraries available at test time:
   pygments

Tools and libraries NOT available at test time:
   matplotlib

Status: OK (7 test groups). Took 77.172s.
```