### PR TITLE
Remove pickleutils alias,

### DIFF
--- a/IPython/utils/pickleutil.py
+++ b/IPython/utils/pickleutil.py
@@ -1,5 +1,0 @@
-from warnings import warn
-
-warn("IPython.utils.pickleutil has moved to ipykernel.pickleutil", stacklevel=2)
-
-from ipykernel.pickleutil import *


### PR DESCRIPTION
It has also been deprecated in ipykernel and is now part of ipyparallel