### PR TITLE
Use Sphinx logging in IPython directive

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -557,14 +557,16 @@ class EmbeddedSphinxShell(object):
         if self.directive.state:
             filename = self.directive.state.document.current_source
             lineno = self.directive.state.document.current_line
-            
+
         # Use sphinx logger for warnings
         logger = logging.getLogger(__name__)
 
         # output any exceptions raised during execution to stdout
         # unless :okexcept: has been specified.
-        if not is_okexcept and (("Traceback" in processed_output) or ("SyntaxError" in processed_output)):
-            s =  '\n>>>' + ('-' * 73) + '\n'
+        if not is_okexcept and (
+            ("Traceback" in processed_output) or ("SyntaxError" in processed_output)
+        ):
+            s = "\n>>>" + ("-" * 73) + "\n"
             s += "Exception in %s at block ending on line %s\n" % (filename, lineno)
             s += "Specify :okexcept: as an option in the ipython:: block to suppress this message\n"
             s += processed_output + "\n"
@@ -577,13 +579,14 @@ class EmbeddedSphinxShell(object):
         # unless :okwarning: has been specified.
         if not is_okwarning:
             for w in ws:
-                s =  '\n>>>' + ('-' * 73) + '\n'
+                s = "\n>>>" + ("-" * 73) + "\n"
                 s += "Warning in %s at block ending on line %s\n" % (filename, lineno)
                 s += "Specify :okwarning: as an option in the ipython:: block to suppress this message\n"
-                s += ('-' * 76) + '\n'
-                s += warnings.formatwarning(w.message, w.category,
-                                            w.filename, w.lineno, w.line)
-                s += '<<<' + ('-' * 73)
+                s += ("-" * 76) + "\n"
+                s += warnings.formatwarning(
+                    w.message, w.category, w.filename, w.lineno, w.line
+                )
+                s += "<<<" + ("-" * 73)
                 logger.warning(s)
                 if self.warning_is_error:
                     raise RuntimeError('Non Expected warning in `{}` line {}'.format(filename, lineno))

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -200,6 +200,7 @@ from io import StringIO
 # Third-party
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
+from sphinx.util import logging
 
 # Our own
 from traitlets.config import Config
@@ -556,16 +557,19 @@ class EmbeddedSphinxShell(object):
         if self.directive.state:
             filename = self.directive.state.document.current_source
             lineno = self.directive.state.document.current_line
+            
+        # Use sphinx logger for warnings
+        logger = logging.getLogger(__name__)
 
         # output any exceptions raised during execution to stdout
         # unless :okexcept: has been specified.
         if not is_okexcept and (("Traceback" in processed_output) or ("SyntaxError" in processed_output)):
-            s =  "\nException in %s at block ending on line %s\n" % (filename, lineno)
+            s =  '\n>>>' + ('-' * 73) + '\n'
+            s += "Exception in %s at block ending on line %s\n" % (filename, lineno)
             s += "Specify :okexcept: as an option in the ipython:: block to suppress this message\n"
-            sys.stdout.write('\n\n>>>' + ('-' * 73))
-            sys.stdout.write(s)
-            sys.stdout.write(processed_output)
-            sys.stdout.write('<<<' + ('-' * 73) + '\n\n')
+            s += processed_output + "\n"
+            s += "<<<" + ("-" * 73)
+            logger.warning(s)
             if self.warning_is_error:
                 raise RuntimeError('Non Expected exception in `{}` line {}'.format(filename, lineno))
 
@@ -573,15 +577,14 @@ class EmbeddedSphinxShell(object):
         # unless :okwarning: has been specified.
         if not is_okwarning:
             for w in ws:
-                s =  "\nWarning in %s at block ending on line %s\n" % (filename, lineno)
+                s =  '\n>>>' + ('-' * 73) + '\n'
+                s += "Warning in %s at block ending on line %s\n" % (filename, lineno)
                 s += "Specify :okwarning: as an option in the ipython:: block to suppress this message\n"
-                sys.stdout.write('\n\n>>>' + ('-' * 73))
-                sys.stdout.write(s)
-                sys.stdout.write(('-' * 76) + '\n')
-                s=warnings.formatwarning(w.message, w.category,
-                                         w.filename, w.lineno, w.line)
-                sys.stdout.write(s)
-                sys.stdout.write('<<<' + ('-' * 73) + '\n')
+                s += ('-' * 76) + '\n'
+                s += warnings.formatwarning(w.message, w.category,
+                                            w.filename, w.lineno, w.line)
+                s += '<<<' + ('-' * 73)
+                logger.warning(s)
                 if self.warning_is_error:
                     raise RuntimeError('Non Expected warning in `{}` line {}'.format(filename, lineno))
 
@@ -1002,6 +1005,9 @@ class IPythonDirective(Directive):
         lines = ['.. code-block:: ipython', '']
         figures = []
 
+        # Use sphinx logger for warnings
+        logger = logging.getLogger(__name__)
+
         for part in parts:
             block = block_parser(part, rgxin, rgxout, promptin, promptout)
             if len(block):
@@ -1020,7 +1026,7 @@ class IPythonDirective(Directive):
                 if self.shell.warning_is_error:
                     raise RuntimeError(message)
                 else:
-                    warnings.warn(message)
+                    logger.warning(message)
 
         for figure in figures:
             lines.append('')

--- a/docs/source/whatsnew/pr/ipython_directive_warnings.rst
+++ b/docs/source/whatsnew/pr/ipython_directive_warnings.rst
@@ -1,0 +1,4 @@
+IPython directive warnings
+--------------------------
+
+The IPython directive now uses Sphinx logging for warnings.


### PR DESCRIPTION
Closes #11547

I couldn't find any tests for the IPythonDirective class, so not sure if they should be added. I tested this locally by introducing warnings into the pandas documentation and got:

```
WARNING: Code input with no code at /home/richard/pandas/pandas/doc/source/user_guide/groupby.rst, line 109
WARNING: Code input with no code at /home/richard/pandas/pandas/doc/source/user_guide/groupby.rst, line 109
WARNING: 
>>>-------------------------------------------------------------------------
Warning in /home/richard/pandas/pandas/doc/source/user_guide/groupby.rst at block ending on line 109
Specify :okwarning: as an option in the ipython:: block to suppress this message
----------------------------------------------------------------------------
<ipython-input-4-a7d915a7056d>:1: UserWarning: foo
  warnings.warn("foo")
<<<-------------------------------------------------------------------------
WARNING: 
>>>-------------------------------------------------------------------------
Exception in /home/richard/pandas/pandas/doc/source/user_guide/groupby.rst at block ending on line 109
Specify :okexcept: as an option in the ipython:: block to suppress this message
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-78cc6f9e8802> in <module>
----> 1 print(1 + 's')

TypeError: unsupported operand type(s) for +: 'int' and 'str'

<<<-------------------------------------------------------------------------
```

The end of the build reported:

> build succeeded, 4 warnings.

whereas master reports:

> build succeeded.