### PR TITLE
Accept empty history ranges

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -445,8 +445,11 @@ class HistoryAccessor(HistoryAccessorBase):
         Parameters
         ----------
         rangestr : str
-          A string specifying ranges, e.g. "5 ~2/1-4". See
-          :func:`magic_history` for full details.
+          A string specifying ranges, e.g. "5 ~2/1-4". If empty string is used,
+          this will return everything from current session's history.
+
+          See the documentation of :func:`%history` for the full details.
+
         raw, output : bool
           As :meth:`get_range`
 
@@ -851,11 +854,18 @@ $""", re.VERBOSE)
 def extract_hist_ranges(ranges_str):
     """Turn a string of history ranges into 3-tuples of (session, start, stop).
 
+    Empty string results in a `[(0, 1, None)]`, i.e. "everything from current
+    session".
+
     Examples
     --------
     >>> list(extract_hist_ranges("~8/5-~7/4 2"))
     [(-8, 5, None), (-7, 1, 5), (0, 2, 3)]
     """
+    if ranges_str == '':
+        yield (0, 1, None)  # Everything from current session
+        return
+
     for range_str in ranges_str.split():
         rmatch = range_re.match(range_str)
         if not rmatch:

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -862,7 +862,7 @@ def extract_hist_ranges(ranges_str):
     >>> list(extract_hist_ranges("~8/5-~7/4 2"))
     [(-8, 5, None), (-7, 1, 5), (0, 2, 3)]
     """
-    if ranges_str == '':
+    if ranges_str == "":
         yield (0, 1, None)  # Everything from current session
         return
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3696,7 +3696,7 @@ class InteractiveShell(SingletonConfigurable):
 
         Parameters
         ----------
-        range_str : string
+        range_str : str
             The set of slices is given as a string, like "~5/6-~4/2 4:8 9",
             since this function is for use by magic functions which get their
             arguments as strings. The number before the / is the session

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3702,6 +3702,9 @@ class InteractiveShell(SingletonConfigurable):
             arguments as strings. The number before the / is the session
             number: ~n goes n back from the current session.
 
+            If empty string is given, returns history of current session
+            without the last input.
+
         raw : bool, optional
             By default, the processed input is used.  If this is true, the raw
             input history is used instead.
@@ -3715,7 +3718,16 @@ class InteractiveShell(SingletonConfigurable):
         * ``N-M`` -> include items N..M (closed endpoint).
         """
         lines = self.history_manager.get_range_by_str(range_str, raw=raw)
-        return "\n".join(x for _, _, x in lines)
+        text = "\n".join(x for _, _, x in lines)
+
+        # Skip the last line, as it's probably the magic that called this
+        if not range_str:
+            if '\n' not in text:
+                text = ''
+            else:
+                text = text[:text.rfind('\n')]
+
+        return text
 
     def find_user_code(self, target, raw=True, py_only=False, skip_encoding_cookie=True, search_ns=False):
         """Get a code string from history, file, url, or a string or macro.
@@ -3724,13 +3736,14 @@ class InteractiveShell(SingletonConfigurable):
 
         Parameters
         ----------
-
         target : str
-
           A string specifying code to retrieve. This will be tried respectively
           as: ranges of input history (see %history for syntax), url,
           corresponding .py file, filename, or an expression evaluating to a
           string or Macro in the user namespace.
+
+          If empty string is given, returns complete history of current
+          session, without the last line.
 
         raw : bool
           If true (default), retrieve raw history. Has no effect on the other

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3722,10 +3722,10 @@ class InteractiveShell(SingletonConfigurable):
 
         # Skip the last line, as it's probably the magic that called this
         if not range_str:
-            if '\n' not in text:
-                text = ''
+            if "\n" not in text:
+                text = ""
             else:
-                text = text[:text.rfind('\n')]
+                text = text[: text.rfind("\n")]
 
         return text
 

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -308,6 +308,9 @@ class CodeMagics(Magics):
           where source can be a filename, URL, input history range, macro, or
           element in the user namespace
 
+        If no arguments are given, loads the history of this session up to this
+        point.
+
         Options:
 
           -r <lines>: Specify lines or ranges of lines to load from the source.
@@ -326,6 +329,7 @@ class CodeMagics(Magics):
         confirmation before loading source with more than 200 000 characters, unless
         -y flag is passed or if the frontend does not support raw_input::
 
+        %load
         %load myscript.py
         %load 7-27
         %load myMacro
@@ -337,13 +341,7 @@ class CodeMagics(Magics):
         %load -n my_module.wonder_function
         """
         opts,args = self.parse_options(arg_s,'yns:r:')
-
-        if not args:
-            raise UsageError('Missing filename, URL, input history range, '
-                             'macro, or element in the user namespace.')
-
         search_ns = 'n' in opts
-
         contents = self.shell.find_user_code(args, search_ns=search_ns)
 
         if 's' in opts:

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -202,6 +202,9 @@ class CodeMagics(Magics):
         This function uses the same syntax as %history for input ranges,
         then saves the lines to the filename you specify.
 
+        If no ranges are specified, saves history of the current session up to
+        this point.
+
         It adds a '.py' extension to the file if you don't do so yourself, and
         it asks for confirmation before overwriting existing files.
 

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -257,6 +257,9 @@ class CodeMagics(Magics):
         The argument can be an input history range, a filename, or the name of a
         string or macro.
 
+        If no arguments are given, uploads the history of this session up to
+        this point.
+
         Options:
 
           -d: Pass a custom description. The default will say

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -184,14 +184,11 @@ class HistoryMagics(Magics):
             n = 10 if limit is None else limit
             hist = history_manager.get_tail(n, raw=raw, output=get_output)
         else:
-            if args.range:      # Get history by ranges
-                if args.pattern:
-                    range_pattern = "*" + " ".join(args.pattern) + "*"
-                    print_nums = True
-                hist = history_manager.get_range_by_str(" ".join(args.range),
-                                                        raw, get_output)
-            else:               # Just get history for the current session
-                hist = history_manager.get_range(raw=raw, output=get_output)
+            if args.pattern:
+                range_pattern = "*" + " ".join(args.pattern) + "*"
+                print_nums = True
+            hist = history_manager.get_range_by_str(" ".join(args.range),
+                                                    raw, get_output)
 
         # We could be displaying the entire history, so let's not try to pull
         # it into a list in memory. Anything that needs more space will just

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -187,8 +187,9 @@ class HistoryMagics(Magics):
             if args.pattern:
                 range_pattern = "*" + " ".join(args.pattern) + "*"
                 print_nums = True
-            hist = history_manager.get_range_by_str(" ".join(args.range),
-                                                    raw, get_output)
+            hist = history_manager.get_range_by_str(
+                " ".join(args.range), raw, get_output
+            )
 
         # We could be displaying the entire history, so let's not try to pull
         # it into a list in memory. Anything that needs more space will just

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -808,17 +808,17 @@ class OSMagics(Magics):
         This magic command can either take a local filename, an url,
         an history range (see %history) or a macro as argument ::
 
+        If no parameter is given, prints out history of current session up to
+        this point.
+
         %pycat myscript.py
         %pycat 7-27
         %pycat myMacro
         %pycat http://www.example.com/myscript.py
         """
-        if not parameter_s:
-            raise UsageError('Missing filename, URL, input history range, '
-                             'or macro.')
-
-        try :
-            cont = self.shell.find_user_code(parameter_s, skip_encoding_cookie=False)
+        try:
+            cont = self.shell.find_user_code(parameter_s,
+                                             skip_encoding_cookie=False)
         except (ValueError, IOError):
             print("Error: no such file, variable, URL, history range or macro")
             return

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -817,8 +817,7 @@ class OSMagics(Magics):
         %pycat http://www.example.com/myscript.py
         """
         try:
-            cont = self.shell.find_user_code(parameter_s,
-                                             skip_encoding_cookie=False)
+            cont = self.shell.find_user_code(parameter_s, skip_encoding_cookie=False)
         except (ValueError, IOError):
             print("Error: no such file, variable, URL, history range or macro")
             return

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -806,10 +806,10 @@ class OSMagics(Magics):
         to be Python source and will show it with syntax highlighting.
 
         This magic command can either take a local filename, an url,
-        an history range (see %history) or a macro as argument ::
+        an history range (see %history) or a macro as argument.
 
         If no parameter is given, prints out history of current session up to
-        this point.
+        this point. ::
 
         %pycat myscript.py
         %pycat 7-27

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -162,7 +162,7 @@ def test_extract_hist_ranges():
 
 
 def test_extract_hist_ranges_empty_str():
-    instr = ''
+    instr = ""
     expected = [(0, 1, None)]  # 0 == current session, None == to end
     actual = list(extract_hist_ranges(instr))
     nt.assert_equal(actual, expected)

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -160,6 +160,14 @@ def test_extract_hist_ranges():
     actual = list(extract_hist_ranges(instr))
     nt.assert_equal(actual, expected)
 
+
+def test_extract_hist_ranges_empty_str():
+    instr = ''
+    expected = [(0, 1, None)]  # 0 == current session, None == to end
+    actual = list(extract_hist_ranges(instr))
+    nt.assert_equal(actual, expected)
+
+
 def test_magic_rerun():
     """Simple test for %rerun (no args -> rerun last line)"""
     ip = get_ipython()

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -1091,7 +1091,7 @@ def test_save():
 
 def test_save_with_no_args():
     ip = get_ipython()
-    ip.history_manager.reset()   # Clear any existing history.
+    ip.history_manager.reset()  # Clear any existing history.
     cmds = [u"a=1", u"def b():\n    return a**2", u"print(a, b())", "%save"]
     for i, cmd in enumerate(cmds, start=1):
         ip.history_manager.store_inputs(i, cmd)

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -1089,6 +1089,29 @@ def test_save():
         nt.assert_in("coding: utf-8", content)
 
 
+def test_save_with_no_args():
+    ip = get_ipython()
+    ip.history_manager.reset()   # Clear any existing history.
+    cmds = [u"a=1", u"def b():\n    return a**2", u"print(a, b())", "%save"]
+    for i, cmd in enumerate(cmds, start=1):
+        ip.history_manager.store_inputs(i, cmd)
+
+    with TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "testsave.py")
+        ip.run_line_magic("save", path)
+        content = Path(path).read_text()
+        expected_content = dedent(
+            """\
+            # coding: utf-8
+            a=1
+            def b():
+                return a**2
+            print(a, b())
+            """
+        )
+        nt.assert_equal(content, expected_content)
+
+
 def test_store():
     """Test %store."""
     ip = get_ipython()

--- a/docs/source/whatsnew/pr/empty-hist-range.rst
+++ b/docs/source/whatsnew/pr/empty-hist-range.rst
@@ -1,0 +1,19 @@
+Empty History Ranges
+====================
+
+A number of magics that take history ranges can now be used with an empty
+range. These magics are:
+
+ * ``%save``
+ * ``%load``
+ * ``%pastebin``
+ * ``%pycat``
+
+Using them this way will make them take the history of the current session up
+to the point of the magic call (such that the magic itself will not be
+included).
+
+Therefore it is now possible to save the whole history to a file using simple
+``%save <filename>``, load and edit it using ``%load`` (makes for a nice usage
+when followed with :kbd:`F2`), send it to dpaste.org using ``%pastebin``, or
+view the whole thing syntax-highlighted with a single ``%pycat``.


### PR DESCRIPTION
Makes it possible to use the following magics with empty history ranges:
 - `%save`
 - `%load`
 - `%pastebin`
 - `%pycat`

When an empty range is given, these magics will fetch the whole history up to the point of the magic call (so the call itself is not included).

This enables a number of handy shortcut usages (see [whats-new entry](https://github.com/ipython/ipython/pull/13049/files#diff-85ef0b54c47109325d8764a709cd935b196567cbeb61f48aae8fe709e658d14bR16-R19)).

It is implemented by adding two simple modalities to existing code:
 - [`IPython.core.history.extract_hist_ranges`](https://github.com/ipython/ipython/pull/13049/files#diff-1dfe2aeed55927e6e7dfafed248585e56699f46feb90d7174c0e51f7843e102eR865-R868) will now return a range corresponding to "current session, whole history" (`[(0, 1, None)]`), if given an empty string as `ranges_str`.
 - [`IPython.core.interactiveshell.InteractiveShell.extract_input_lines`](https://github.com/ipython/ipython/pull/13049/files#diff-f0df2d6942c603793b48dc8ba2b3032e7ebedcf05a2d65883c374b5b60ef2eb0L3718-R3730), when given an empty string in `range_str`, uses the above to fetch the whole history, and then remove the last line (the one with the magic call).
 
These two methods exist in call stacks of other magics (see the flowchart below), but the changes have no impact on them. When given empty hist range or no arguments:
 - `%macro` lists existing macros.
 - `%edit` treats it as "open editor inside an empty temp file".
 - `%history` retains the functionality it had before, i.e. lists the whole history (_including_ the magic call).
 - `%recall` treats it as "take output of the last command".
 - `%rerun` treats it as "rerun last command".

The "take the whole history" `if...else` branch in `%history` has been refactored, since with these changes the `else` part is no longer needed.

![image](https://user-images.githubusercontent.com/6691643/125002143-96fd7600-e054-11eb-86de-ed912fce67da.png)

