### PR TITLE
Make Ipython.utils.timing work with jupyterlite

### DIFF
--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -23,6 +23,11 @@ import time
 # If possible (Unix), use the resource module instead of time.clock()
 try:
     import resource
+except ImportError:
+    resource = None
+
+# Some implementations (like jyputerlite) don't have getrusage
+if resource not None and hasattr(resource, "getrusage"):
     def clocku():
         """clocku() -> floating point number
 

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -61,6 +61,8 @@ if resource is not None and hasattr(resource, "getrusage"):
 
         Similar to clock(), but return a tuple of user/system times."""
         return resource.getrusage(resource.RUSAGE_SELF)[:2]
+
+
 else:
     # There is no distinction of user/system time under windows, so we just use
     # time.perff_counter() for everything...

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -61,7 +61,7 @@ if resource is not None and hasattr(resource, "getrusage"):
 
         Similar to clock(), but return a tuple of user/system times."""
         return resource.getrusage(resource.RUSAGE_SELF)[:2]
-except ImportError:
+else:
     # There is no distinction of user/system time under windows, so we just use
     # time.perff_counter() for everything...
     clocku = clocks = clock = time.perf_counter

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -27,7 +27,7 @@ except ImportError:
     resource = None
 
 # Some implementations (like jyputerlite) don't have getrusage
-if resource not None and hasattr(resource, "getrusage"):
+if resource is not None and hasattr(resource, "getrusage"):
     def clocku():
         """clocku() -> floating point number
 


### PR DESCRIPTION
JupyterLite has a resource, but not getrusage(). This make the code a little more general.