### PR TITLE
failing attempt at using Qt6 for %gui

### DIFF
--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -34,10 +34,11 @@ import sys
 from IPython.utils.version import check_version
 from IPython.external.qt_loaders import (load_qt, loaded_api, QT_API_PYSIDE,
                                          QT_API_PYSIDE2, QT_API_PYQT, QT_API_PYQT5,
-                                         QT_API_PYQTv1, QT_API_PYQT_DEFAULT)
+                                         QT_API_PYQT6, QT_API_PYQTv1,
+                                         QT_API_PYQT_DEFAULT)
 
-_qt_apis = (QT_API_PYSIDE, QT_API_PYSIDE2, QT_API_PYQT, QT_API_PYQT5, QT_API_PYQTv1,
-            QT_API_PYQT_DEFAULT)
+_qt_apis = (QT_API_PYSIDE, QT_API_PYSIDE2, QT_API_PYQT, QT_API_PYQT5, QT_API_PYQT6,
+            QT_API_PYQTv1, QT_API_PYQT_DEFAULT)
 
 #Constraints placed on an imported matplotlib
 def matplotlib_options(mpl):
@@ -84,7 +85,7 @@ def get_options():
     if qt_api is None:
         #no ETS variable. Ask mpl, then use default fallback path
         return matplotlib_options(mpl) or [QT_API_PYQT_DEFAULT, QT_API_PYSIDE,
-                                           QT_API_PYQT5, QT_API_PYSIDE2]
+                                           QT_API_PYQT5, QT_API_PYQT6, QT_API_PYSIDE2]
     elif qt_api not in _qt_apis:
         raise RuntimeError("Invalid Qt API %r, valid values are: %r" %
                            (qt_api, ', '.join(_qt_apis)))

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -32,7 +32,7 @@ def inputhook(context):
                         'variable. Deactivate Qt5 code.'
                     )
                 return
-        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+        # QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
         _appref = app = QtGui.QApplication([" "])
 
         # "reclaim" IPython sys.excepthook after event loop starts
@@ -55,8 +55,11 @@ def inputhook(context):
     else:
         # On POSIX platforms, we can use a file descriptor to quit the event
         # loop when there is input ready to read.
-        notifier = QtCore.QSocketNotifier(context.fileno(),
-                                          QtCore.QSocketNotifier.Read)
+        if hasattr(QtCore.QSocketNotifier, "Read"):
+            mode = QtCore.QSocketNotifier.Read
+        else:
+            mode = QtCore.QSocketNotifier.Type.Read
+        notifier = QtCore.QSocketNotifier(context.fileno(), mode)
         try:
             # connect the callback we care about before we turn it on
             # lambda is necessary as PyQT inspect the function signature to know
@@ -65,6 +68,6 @@ def inputhook(context):
             notifier.setEnabled(True)
             # only start the event loop we are not already flipped
             if not context.input_is_ready():
-                event_loop.exec_()
+                event_loop.exec()
         finally:
             notifier.setEnabled(False)


### PR DESCRIPTION
From my efforts on #13058, though it's not to the point of working yet.

- [ ] HiDPI ( research where Qt6 keeps this option )
- [ ] exit behavior
- [ ] maintain backwards compatibility
- [ ] test?
- [ ] style?
- [ ] documentation?
- [ ] QA?

Oh, and if it helps, the code I'm using to make a gui is:

```python
import pyqtgraph as pg
pg.plot([0, 1, 1])
```

That should open a simple interactive line plot ( it requires pyqtgraph be installed, though ).