### PR TITLE
Improve error tracebacks so that it shows the cell prompts [2] 

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -169,28 +169,28 @@ def _format_traceback_lines(lines, Colors, has_colors, lvals):
     return res
 
 
-def _format_filename(file, Colors, ColorNormal):
+def _format_filename(file, ColorFilename, ColorNormal):
     """
-    Format filename lines with `In [n]` if it's the nth code cell or `File *.py` if it's a module...
+    Format filename lines with `In [n]` if it's the nth code cell or `File *.py` if it's a module.
 
     Parameters
     ----------
     file : str
-    Colors
-        ColorScheme used.
-    ColorsNormal
+    ColorFilename
+        ColorScheme's filename coloring to be used.
+    ColorNormal
         ColorScheme's normal coloring to be used.
     """
     ipinst = get_ipython()
 
     if ipinst is not None and file in ipinst.compile._filename_map:
         file = "[%s]" % ipinst.compile._filename_map[file]
-        tpl_link = "In %s%%s%s" % (Colors.filenameEm, ColorNormal)
+        tpl_link = "In %s%%s%s" % (ColorFilename, ColorNormal)
     else:
         file = util_path.compress_user(
             py3compat.cast_unicode(file, util_path.fs_encoding)
         )
-        tpl_link = "File %s%%s%s" % (Colors.filenameEm, ColorNormal)
+        tpl_link = "File %s%%s%s" % (ColorFilename, ColorNormal)
 
     return tpl_link % file
 
@@ -440,7 +440,7 @@ class ListTB(TBTools):
         list = []
         for filename, lineno, name, line in extracted_list[:-1]:
             item = "  %s, line %s%d%s, in %s%s%s\n" % (
-                _format_filename(filename, Colors, Colors.normalEm),
+                _format_filename(filename, Colors.filename, Colors.Normal),
                 Colors.lineno,
                 lineno,
                 Colors.Normal,
@@ -455,7 +455,7 @@ class ListTB(TBTools):
         filename, lineno, name, line = extracted_list[-1]
         item = "%s  %s, line %s%d%s, in %s%s%s%s\n" % (
             Colors.normalEm,
-            _format_filename(filename, Colors, Colors.normalEm),
+            _format_filename(filename, Colors.filenameEm, Colors.normalEm),
             Colors.linenoEm,
             lineno,
             Colors.normalEm,
@@ -504,7 +504,7 @@ class ListTB(TBTools):
                     "%s  %s, line %s%s%s\n"
                     % (
                         Colors.normalEm,
-                        _format_filename(value.filename, Colors, Colors.normalEm),
+                        _format_filename(value.filename, Colors.filenameEm, Colors.normalEm),
                         Colors.linenoEm,
                         lineno,
                         Colors.Normal,
@@ -634,7 +634,7 @@ class VerboseTB(TBTools):
                         (Colors.vName, Colors.valEm, ColorsNormal)
         tpl_name_val = '%%s %s= %%s%s' % (Colors.valEm, ColorsNormal)
 
-        link = _format_filename(frame_info.filename, Colors, ColorsNormal)
+        link = _format_filename(frame_info.filename, Colors.filenameEm, ColorsNormal)
         args, varargs, varkw, locals_ = inspect.getargvalues(frame_info.frame)
 
         func = frame_info.executing.code_qualname()

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -439,21 +439,31 @@ class ListTB(TBTools):
         Colors = self.Colors
         list = []
         for filename, lineno, name, line in extracted_list[:-1]:
-            item = '  %s, line %s%d%s, in %s%s%s\n' % \
-                   (_format_filename(filename, Colors, Colors.normalEm),
-                    Colors.lineno, lineno, Colors.Normal,
-                    Colors.name, name, Colors.Normal)
+            item = "  %s, line %s%d%s, in %s%s%s\n" % (
+                _format_filename(filename, Colors, Colors.normalEm),
+                Colors.lineno,
+                lineno,
+                Colors.Normal,
+                Colors.name,
+                name,
+                Colors.Normal,
+            )
             if line:
                 item += '    %s\n' % line.strip()
             list.append(item)
         # Emphasize the last entry
         filename, lineno, name, line = extracted_list[-1]
-        item = '%s  %s, line %s%d%s, in %s%s%s%s\n' % \
-               (Colors.normalEm,
-                _format_filename(filename, Colors, Colors.normalEm),
-                Colors.linenoEm, lineno, Colors.normalEm,
-                Colors.nameEm, name, Colors.normalEm,
-                Colors.Normal)
+        item = "%s  %s, line %s%d%s, in %s%s%s%s\n" % (
+            Colors.normalEm,
+            _format_filename(filename, Colors, Colors.normalEm),
+            Colors.linenoEm,
+            lineno,
+            Colors.normalEm,
+            Colors.nameEm,
+            name,
+            Colors.normalEm,
+            Colors.Normal,
+        )
         if line:
             item += '%s    %s%s\n' % (Colors.line, line.strip(),
                                       Colors.Normal)
@@ -488,14 +498,19 @@ class ListTB(TBTools):
                     lineno = value.lineno
                     textline = linecache.getline(value.filename, value.lineno)
                 else:
-                    lineno = 'unknown'
-                    textline = ''
-                list.append('%s  %s, line %s%s%s\n' %
-                            (Colors.normalEm,
-                             _format_filename(value.filename, Colors, Colors.normalEm),
-                             Colors.linenoEm, lineno, Colors.Normal
-                             ))
-                if textline == '':
+                    lineno = "unknown"
+                    textline = ""
+                list.append(
+                    "%s  %s, line %s%s%s\n"
+                    % (
+                        Colors.normalEm,
+                        _format_filename(value.filename, Colors, Colors.normalEm),
+                        Colors.linenoEm,
+                        lineno,
+                        Colors.Normal,
+                    )
+                )
+                if textline == "":
                     textline = py3compat.cast_unicode(value.text, "utf-8")
 
                 if textline is not None:
@@ -659,7 +674,7 @@ class VerboseTB(TBTools):
         if lvals_list:
             lvals = '%s%s' % (indent, em_normal.join(lvals_list))
 
-        result = '%s, %s\n' % (link, call)
+        result = "%s, %s\n" % (link, call)
 
         result += ''.join(_format_traceback_lines(frame_info.lines, Colors, self.has_colors, lvals))
         return result

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -504,7 +504,9 @@ class ListTB(TBTools):
                     "%s  %s, line %s%s%s\n"
                     % (
                         Colors.normalEm,
-                        _format_filename(value.filename, Colors.filenameEm, Colors.normalEm),
+                        _format_filename(
+                            value.filename, Colors.filenameEm, Colors.normalEm
+                        ),
                         Colors.linenoEm,
                         lineno,
                         Colors.Normal,


### PR DESCRIPTION
Follow up on this PR #13043 which adds support for SyntaxError tracebacks as well:

```python
In [1]: def foo
  In [1], line 1
    def foo
           ^
SyntaxError: invalid syntax
```