### PR TITLE
Deadheading `IPython.utils.py3compat`

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -31,7 +31,6 @@ from IPython.lib.pretty import pretty
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import PyColorize
 from IPython.utils import openpy
-from IPython.utils import py3compat
 from IPython.utils.dir2 import safe_hasattr
 from IPython.utils.path import compress_user
 from IPython.utils.text import indent

--- a/IPython/lib/clipboard.py
+++ b/IPython/lib/clipboard.py
@@ -40,7 +40,7 @@ def osx_clipboard_get() -> str:
     bytes_, stderr = p.communicate()
     # Text comes in with old Mac \r line endings. Change them to \n.
     bytes_ = bytes_.replace(b'\r', b'\n')
-    text = py3compat.decode(bytes_)
+    text = bytes_.decode(errors="replace")
     return text
 
 def tkinter_clipboard_get():

--- a/IPython/lib/security.py
+++ b/IPython/lib/security.py
@@ -11,7 +11,6 @@ import random
 
 # Our own
 from IPython.core.error import UsageError
-from IPython.utils.py3compat import encode
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -65,7 +64,9 @@ def passwd(passphrase=None, algorithm='sha1'):
 
     h = hashlib.new(algorithm)
     salt = ('%0' + str(salt_len) + 'x') % random.getrandbits(4 * salt_len)
-    h.update(encode(passphrase, 'utf-8') + encode(salt, 'ascii'))
+    h.update(
+        passphrase.encode(errors="replace") + salt.encode("ascii", errors="replace")
+    )
 
     return ':'.join((algorithm, salt, h.hexdigest()))
 
@@ -109,6 +110,8 @@ def passwd_check(hashed_passphrase, passphrase):
     if len(pw_digest) == 0:
         return False
 
-    h.update(encode(passphrase, 'utf-8') + encode(salt, 'ascii'))
+    h.update(
+        passphrase.encode(errors="replace") + salt.encode("ascii", errors="replace")
+    )
 
     return h.hexdigest() == pw_digest

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -34,7 +34,6 @@ from nose.plugins import Plugin
 from nose.util import safe_str
 
 from IPython import version_info
-from IPython.utils.py3compat import decode
 from IPython.utils.importstring import import_item
 from IPython.testing.plugin.ipdoctest import IPythonDoctest
 from IPython.external.decorators import KnownFailure, knownfailureif
@@ -296,7 +295,7 @@ class StreamCapturer(Thread):
             with self.buffer_lock:
                 self.buffer.write(chunk)
             if self.echo:
-                sys.stdout.write(decode(chunk))
+                sys.stdout.write(chunk.decode(errors="replace"))
 
         os.close(self.readfd)
         os.close(self.writefd)

--- a/IPython/testing/iptestcontroller.py
+++ b/IPython/testing/iptestcontroller.py
@@ -24,7 +24,6 @@ from .iptest import (
     have, test_group_names as py_test_group_names, test_sections, StreamCapturer,
 )
 from IPython.utils.path import compress_user
-from IPython.utils.py3compat import decode
 from IPython.utils.sysinfo import get_sys_info
 from IPython.utils.tempdir import TemporaryDirectory
 from pathlib import Path
@@ -358,7 +357,7 @@ def run_iptestall(options):
                 res_string = 'OK' if res == 0 else 'FAILED'
                 print(justify('Test group: ' + controller.section, res_string))
                 if res:
-                    print(decode(controller.stdout))
+                    print(controller.stdout.decode(errors="replace"))
                     failed.append(controller)
                     if res == -signal.SIGINT:
                         print("Interrupted")

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -34,7 +34,6 @@ from traitlets.config.loader import Config
 from IPython.utils.process import get_output_error_code
 from IPython.utils.text import list_strings
 from IPython.utils.io import temp_pyfile, Tee
-from IPython.utils import py3compat
 
 from . import decorators as dec
 from . import skipdoctest
@@ -210,9 +209,10 @@ def ipexec(fname, options=None, commands=()):
         # TypeError: environment can only contain strings
         if not isinstance(v, str):
             print(k, v)
-    p = Popen(full_cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE, env=env)
-    out, err = p.communicate(input=py3compat.encode('\n'.join(commands)) or None)
-    out, err = py3compat.decode(out), py3compat.decode(err)
+
+    p = Popen(full_cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE, env=env, errors="replace")
+    out, err = p.communicate("\n".join(commands))
+
     # `import readline` causes 'ESC[?1034h' to be output sometimes,
     # so strip that out before doing comparisons
     if out:

--- a/IPython/utils/_process_cli.py
+++ b/IPython/utils/_process_cli.py
@@ -19,7 +19,6 @@ import System
 import os
 
 # Import IPython libraries:
-from IPython.utils import py3compat
 from ._process_common import arg_split
 
 def _find_cmd(cmd):
@@ -28,7 +27,7 @@ def _find_cmd(cmd):
     for path in paths:
         filename = os.path.join(path, cmd)
         if System.IO.File.Exists(filename):
-            return py3compat.decode(filename)
+            return filename.decode(errors="replace")
     raise OSError("command %r not found" % cmd)
 
 def system(cmd):

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -19,7 +19,6 @@ import shlex
 import sys
 import os
 
-from IPython.utils import py3compat
 
 #-----------------------------------------------------------------------------
 # Function definitions
@@ -128,7 +127,7 @@ def getoutput(cmd):
     out = process_handler(cmd, lambda p: p.communicate()[0], subprocess.STDOUT)
     if out is None:
         return ''
-    return py3compat.decode(out)
+    return out.decode(errors="replace")
 
 
 def getoutputerror(cmd):
@@ -170,7 +169,8 @@ def get_output_error_code(cmd):
     if out_err is None:
         return '', '', p.returncode
     out, err = out_err
-    return py3compat.decode(out), py3compat.decode(err), p.returncode
+    return (out.decode(errors="replace"), err.decode(errors="replace"), p.returncode)
+
 
 def arg_split(s, posix=False, strict=True):
     """Split a command line's arguments in a shell-like manner.

--- a/IPython/utils/_process_posix.py
+++ b/IPython/utils/_process_posix.py
@@ -24,7 +24,6 @@ import pexpect
 
 # Our own
 from ._process_common import getoutput, arg_split
-from IPython.utils import py3compat
 from IPython.utils.encoding import DEFAULT_ENCODING
 
 #-----------------------------------------------------------------------------
@@ -34,9 +33,10 @@ from IPython.utils.encoding import DEFAULT_ENCODING
 def _find_cmd(cmd):
     """Find the full path to a command using which."""
 
-    path = sp.Popen(['/usr/bin/env', 'which', cmd],
-                    stdout=sp.PIPE, stderr=sp.PIPE).communicate()[0]
-    return py3compat.decode(path)
+    path = sp.Popen(
+        ["/usr/bin/env", "which", cmd], text=True, stdout=sp.PIPE, stderr=sp.PIPE
+    ).communicate()[0]
+    return path
 
 
 class ProcessHandler(object):

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -166,7 +166,7 @@ def getoutput(cmd):
 
     if out is None:
         out = b''
-    return py3compat.decode(out)
+    return out.decode(errors="replace")
 
 try:
     CommandLineToArgvW = ctypes.windll.shell32.CommandLineToArgvW

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -3,11 +3,6 @@
 
 This file is deprecated and will be removed in a future version.
 """
-import functools
-import os
-import sys
-import re
-import shutil
 import types
 import platform
 
@@ -20,11 +15,6 @@ def cast_unicode(s, encoding=None):
         return s.decode(encoding, errors="replace")
     return s
 
-def buffer_to_bytes(buf):
-    """Cast a buffer object to bytes"""
-    if not isinstance(buf, bytes):
-        buf = bytes(buf)
-    return buf
 
 def safe_unicode(e):
     """unicode(e) with various fallbacks. Used for exceptions, which may not be
@@ -66,4 +56,3 @@ PYPY = platform.python_implementation() == "PyPy"
 def no_code(x, encoding=None):
         return x
 unicode_to_str = cast_bytes_py2 = no_code
-

--- a/IPython/utils/py3compat.py
+++ b/IPython/utils/py3compat.py
@@ -14,23 +14,10 @@ import platform
 from .encoding import DEFAULT_ENCODING
 
 
-def decode(s, encoding=None):
-    encoding = encoding or DEFAULT_ENCODING
-    return s.decode(encoding, "replace")
-
-def encode(u, encoding=None):
-    encoding = encoding or DEFAULT_ENCODING
-    return u.encode(encoding, "replace")
-
-
 def cast_unicode(s, encoding=None):
+    encoding = encoding or DEFAULT_ENCODING
     if isinstance(s, bytes):
-        return decode(s, encoding)
-    return s
-
-def cast_bytes(s, encoding=None):
-    if not isinstance(s, bytes):
-        return encode(s, encoding)
+        return s.decode(encoding, errors="replace")
     return s
 
 def buffer_to_bytes(buf):


### PR DESCRIPTION
During review of another PR I noticed, that there's a bunch of code in `IPython.utils.py3compat` that looks unused / unnecessary.

The module itself is deprecated. I removed most of its usage, then I realized that simply replacing `decode(s)` with `s.decode(errors="replace")` might not be the way to go, given that `DEFAULT_ENCODING` of `decode` isn't necessarily `"utf-8"`.

I'm still looking into it. I'd be really pleased if we'd be able to get rid of this module in 8.0. The way it uses `IPython.utils.encoding` to come up with the default encoding is magical and surprising, and its difficult to wrap one's head around what happens there.