### PR TITLE
Fix #13084

### DIFF
--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -12,7 +12,7 @@ import re
 import shlex
 import sys
 from pathlib import Path
-from multiprocessing import list2cmdline
+from subprocess import list2cmdline
 from IPython.core.magic import Magics, magics_class, line_magic
 
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -69,7 +69,7 @@ class PackagingMagics(Magics):
         python = sys.executable
         if " " in python:
             if sys.platform == "win32":
-                python = "\"" + python + "\""
+                python = '"' + python + '"'
             else:
                 python = shlex.quote(python)
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -12,7 +12,7 @@ import re
 import shlex
 import sys
 from pathlib import Path
-from subprocess import list2cmdline
+from multiprocessing import list2cmdline
 from IPython.core.magic import Magics, magics_class, line_magic
 
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -66,11 +66,12 @@ class PackagingMagics(Magics):
         Usage:
           %pip install [pkgs]
         """
+        python = sys.executable
         if " " in sys.executable:
             if sys.platform == "win32":
-                python = "\"" + sys.executable + "\""
+                python = "\"" + python + "\""
             else:
-                python = shlex.quote(sys.executable)
+                python = shlex.quote(python)
 
         self.shell.system(" ".join([python, "-m", "pip", line]))
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -67,11 +67,10 @@ class PackagingMagics(Magics):
           %pip install [pkgs]
         """
         python = sys.executable
-        if " " in python:
-            if sys.platform == "win32":
-                python = '"' + python + '"'
-            else:
-                python = shlex.quote(python)
+        if sys.platform == "win32":
+            python = '"' + python + '"'
+        else:
+            python = shlex.quote(python)
 
         self.shell.system(" ".join([python, "-m", "pip", line]))
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -12,7 +12,7 @@ import re
 import shlex
 import sys
 from pathlib import Path
-from multiprocessing import list2cmdline
+
 from IPython.core.magic import Magics, magics_class, line_magic
 
 
@@ -66,7 +66,8 @@ class PackagingMagics(Magics):
         Usage:
           %pip install [pkgs]
         """
-        self.shell.system(list2cmdline([sys.executable, "-m", "pip"]) + " " + line)
+        python = shlex.quote(sys.executable)
+        self.shell.system(" ".join([python, "-m", "pip", line]))
 
         print("Note: you may need to restart the kernel to use updated packages.")
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -66,7 +66,12 @@ class PackagingMagics(Magics):
         Usage:
           %pip install [pkgs]
         """
-        python = shlex.quote(sys.executable)
+        if " " in sys.executable:
+            if sys.platform == "win32":
+                python = "\"" + sys.executable + "\""
+            else:
+                python = shlex.quote(sys.executable)
+
         self.shell.system(" ".join([python, "-m", "pip", line]))
 
         print("Note: you may need to restart the kernel to use updated packages.")

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -12,7 +12,7 @@ import re
 import shlex
 import sys
 from pathlib import Path
-
+from multiprocessing import list2cmdline
 from IPython.core.magic import Magics, magics_class, line_magic
 
 
@@ -66,8 +66,7 @@ class PackagingMagics(Magics):
         Usage:
           %pip install [pkgs]
         """
-        python = shlex.quote(sys.executable)
-        self.shell.system(" ".join([python, "-m", "pip", line]))
+        self.shell.system(list2cmdline([sys.executable, "-m", "pip"]) + " " + line)
 
         print("Note: you may need to restart the kernel to use updated packages.")
 

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -67,7 +67,7 @@ class PackagingMagics(Magics):
           %pip install [pkgs]
         """
         python = sys.executable
-        if " " in sys.executable:
+        if " " in python:
             if sys.platform == "win32":
                 python = "\"" + python + "\""
             else:


### PR DESCRIPTION
Fix for [issue](https://github.com/ipython/ipython/issues/13084) caused by using shlex to quote executable path.
Sorry, [I've introduced this bug](https://github.com/ipython/ipython/pull/13052).
To fix this, let's replace shlex.quote with `subprocess.list2cmd()`. It
- uses `"` to quote path,
- performs quoting only if necessary

@MrMino , could you take a look please?
![image](https://user-images.githubusercontent.com/18216480/129494342-9d5874c4-7421-4740-8f97-2959d2972089.png)
