### PR TITLE
Fix virtual environment user warning for lower case pathes

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -928,7 +928,12 @@ class InteractiveShell(SingletonConfigurable):
         elif len(str(p_venv)) >= 2 and str(p_venv)[1] == ":":
             p_venv = Path(str(p_venv)[2:])
 
-        if any(os.fspath(p_venv).lower() in os.fspath(p).lower() for p in paths):
+        if sys.platform == "win32":
+            # In Windows there might be a mixture of lower-case and mixed-case pathes
+            p_venv = Path(str(p_venv).lower())
+            paths = [Path(str(p).lower()) for p in paths]
+
+        if any(os.fspath(p_venv) in os.fspath(p) for p in paths):
             # Our exe is inside or has access to the virtualenv, don't need to do anything.
             return
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -929,7 +929,7 @@ class InteractiveShell(SingletonConfigurable):
             p_venv = Path(str(p_venv)[2:])
 
         if sys.platform == "win32":
-            # In Windows there might be a mixture of lower-case and mixed-case pathes
+            # On Windows there might be a mixture of lower-case and mixed-case paths
             p_venv = Path(str(p_venv).lower())
             paths = [Path(str(p).lower()) for p in paths]
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -928,7 +928,7 @@ class InteractiveShell(SingletonConfigurable):
         elif len(str(p_venv)) >= 2 and str(p_venv)[1] == ":":
             p_venv = Path(str(p_venv)[2:])
 
-        if any(os.fspath(p_venv) in os.fspath(p) for p in paths):
+        if any(os.fspath(p_venv).lower() in os.fspath(p).lower() for p in paths):
             # Our exe is inside or has access to the virtualenv, don't need to do anything.
             return
 


### PR DESCRIPTION
In my environment the pathes "p" and "p_venv" from lines 913 and 914 of `IPython/core/interactiveshell.py` are:
> p: "c:/users/marcus.wirtz/venvs/dlapptrainer/scripts/python.exe"
> p_venv: "C:/Users/marcus.wirtz/VEnvs/dlapptrainer"

thus, even though ipython is installed within the virtual env and all libraries are available, ipython will give me the UserWarning "Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv." Here a screenshot:

![image](https://user-images.githubusercontent.com/24655255/129740149-0cb66151-293b-48c1-98f2-43cd9a6f7d55.png)

I don't exactly understand why the pathes are in one case lower-case and in the other one mixed case - Windows path's are always messy... However, I guess given the path chaos in Windows it might be good to only compare the ".lower()" versions of the pathes.

Best,
Marcus