### PR TITLE
Protect against failure to show local data.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -634,8 +634,16 @@ class VerboseTB(TBTools):
         lvals = ''
         lvals_list = []
         if self.include_vars:
-            for var in frame_info.variables_in_executing_piece:
-                lvals_list.append(tpl_name_val % (var.name, repr(var.value)))
+            try:
+                # we likely want to fix stackdata at some point, but
+                # still need a workaround.
+                fibp = frame_info.variables_in_executing_piece
+                for var in fibp:
+                    lvals_list.append(tpl_name_val % (var.name, repr(var.value)))
+            except Exception:
+                lvals_list.append(
+                    "Exception trying to inspect frame. No more locals available."
+                )
         if lvals_list:
             lvals = '%s%s' % (indent, em_normal.join(lvals_list))
 


### PR DESCRIPTION
See https://github.com/napari/napari/pull/3201 where formatting
traceback was failing and lead to silenced errors.

With this change we  instead get the rest of the traceback but without
the local variables, which is still better.