### PR TITLE
Remove more nose idioms

### DIFF
--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -352,7 +352,7 @@ def test_print_method_weird():
     with capture_output() as captured:
         result = f(call_hat)
 
-    assert result == None
+    assert result is None
 
     class BadReprArgs(object):
         def _repr_html_(self, extra, args):

--- a/IPython/core/tests/test_formatters.py
+++ b/IPython/core/tests/test_formatters.py
@@ -48,16 +48,16 @@ def foo_printer(obj, pp, cycle):
 def test_pretty():
     f = PlainTextFormatter()
     f.for_type(A, foo_printer)
-    nt.assert_equal(f(A()), 'foo')
-    nt.assert_equal(f(B()), 'B()')
-    nt.assert_equal(f(GoodPretty()), 'foo')
+    assert f(A()) == "foo"
+    assert f(B()) == "B()"
+    assert f(GoodPretty()) == "foo"
     # Just don't raise an exception for the following:
     f(BadPretty())
 
     f.pprint = False
-    nt.assert_equal(f(A()), 'A()')
-    nt.assert_equal(f(B()), 'B()')
-    nt.assert_equal(f(GoodPretty()), 'GoodPretty()')
+    assert f(A()) == "A()"
+    assert f(B()) == "B()"
+    assert f(GoodPretty()) == "GoodPretty()"
 
 
 def test_deferred():
@@ -66,29 +66,30 @@ def test_deferred():
 def test_precision():
     """test various values for float_precision."""
     f = PlainTextFormatter()
-    nt.assert_equal(f(pi), repr(pi))
+    assert f(pi) == repr(pi)
     f.float_precision = 0
     if numpy:
         po = numpy.get_printoptions()
-        nt.assert_equal(po['precision'], 0)
-    nt.assert_equal(f(pi), '3')
+        assert po["precision"] == 0
+    assert f(pi) == "3"
     f.float_precision = 2
     if numpy:
         po = numpy.get_printoptions()
-        nt.assert_equal(po['precision'], 2)
-    nt.assert_equal(f(pi), '3.14')
-    f.float_precision = '%g'
+        assert po["precision"] == 2
+    assert f(pi) == "3.14"
+    f.float_precision = "%g"
     if numpy:
         po = numpy.get_printoptions()
-        nt.assert_equal(po['precision'], 2)
-    nt.assert_equal(f(pi), '3.14159')
-    f.float_precision = '%e'
-    nt.assert_equal(f(pi), '3.141593e+00')
-    f.float_precision = ''
+        assert po["precision"] == 2
+    assert f(pi) == "3.14159"
+    f.float_precision = "%e"
+    assert f(pi) == "3.141593e+00"
+    f.float_precision = ""
     if numpy:
         po = numpy.get_printoptions()
-        nt.assert_equal(po['precision'], 8)
-    nt.assert_equal(f(pi), repr(pi))
+        assert po["precision"] == 8
+    assert f(pi) == repr(pi)
+
 
 def test_bad_precision():
     """test various invalid values for float_precision."""
@@ -260,8 +261,9 @@ def test_nowarn_notimplemented():
     with capture_output() as captured:
         result = f(h)
     nt.assert_is(result, None)
-    nt.assert_equal("", captured.stderr)
-    nt.assert_equal("", captured.stdout)
+    assert "" == captured.stderr
+    assert "" == captured.stdout
+
 
 def test_warn_error_for_type():
     f = HTMLFormatter()
@@ -307,7 +309,8 @@ class MakePDF(object):
 def test_pdf_formatter():
     pdf = MakePDF()
     f = PDFFormatter()
-    nt.assert_equal(f(pdf), 'PDF')
+    assert f(pdf) == "PDF"
+
 
 def test_print_method_bound():
     f = HTMLFormatter()
@@ -321,8 +324,9 @@ def test_print_method_bound():
 
     with capture_output() as captured:
         result = f(MyHTML())
-    nt.assert_equal(result, "hello")
-    nt.assert_equal(captured.stderr, "")
+    assert result == "hello"
+    assert captured.stderr == ""
+
 
 def test_print_method_weird():
 
@@ -331,9 +335,9 @@ def test_print_method_weird():
             return key
 
     f = HTMLFormatter()
-    
+
     text_hat = TextMagicHat()
-    nt.assert_equal(text_hat._repr_html_, '_repr_html_')
+    assert text_hat._repr_html_ == "_repr_html_"
     with capture_output() as captured:
         result = f(text_hat)
     
@@ -347,8 +351,8 @@ def test_print_method_weird():
     call_hat = CallableMagicHat()
     with capture_output() as captured:
         result = f(call_hat)
-    
-    nt.assert_equal(result, None)
+
+    assert result == None
 
     class BadReprArgs(object):
         def _repr_html_(self, extra, args):
@@ -369,24 +373,25 @@ def test_format_config():
     with capture_output() as captured:
         result = f(cfg)
     nt.assert_is(result, None)
-    nt.assert_equal(captured.stderr, "")
+    assert captured.stderr == ""
 
     with capture_output() as captured:
         result = f(Config)
     nt.assert_is(result, None)
-    nt.assert_equal(captured.stderr, "")
+    assert captured.stderr == ""
+
 
 def test_pretty_max_seq_length():
     f = PlainTextFormatter(max_seq_length=1)
     lis = list(range(3))
     text = f(lis)
-    nt.assert_equal(text, '[0, ...]')
+    assert text == "[0, ...]"
     f.max_seq_length = 0
     text = f(lis)
-    nt.assert_equal(text, '[0, 1, 2]')
+    assert text == "[0, 1, 2]"
     text = f(list(range(1024)))
     lines = text.splitlines()
-    nt.assert_equal(len(lines), 1024)
+    assert len(lines) == 1024
 
 
 def test_ipython_display_formatter():
@@ -409,16 +414,16 @@ def test_ipython_display_formatter():
     
     yes = SelfDisplaying()
     no = NotSelfDisplaying()
-    
+
     d, md = f.format(no)
-    nt.assert_equal(d, {'text/plain': repr(no)})
-    nt.assert_equal(md, {})
-    nt.assert_equal(catcher, [])
-    
+    assert d == {"text/plain": repr(no)}
+    assert md == {}
+    assert catcher == []
+
     d, md = f.format(yes)
-    nt.assert_equal(d, {})
-    nt.assert_equal(md, {})
-    nt.assert_equal(catcher, [yes])
+    assert d == {}
+    assert md == {}
+    assert catcher == [yes]
 
     f.ipython_display_formatter.enabled = save_enabled
 
@@ -431,8 +436,8 @@ def test_json_as_string_deprecated():
     f = JSONFormatter()
     with warnings.catch_warnings(record=True) as w:
         d = f(JSONString())
-    nt.assert_equal(d, {})
-    nt.assert_equal(len(w), 1)
+    assert d == {}
+    assert len(w) == 1
 
 
 def test_repr_mime():
@@ -458,19 +463,22 @@ def test_repr_mime():
     obj = HasReprMime()
     d, md = f.format(obj)
     html_f.enabled = save_enabled
-    
-    nt.assert_equal(sorted(d), ['application/json+test.v2',
-                                'image/png',
-                                'plain/text',
-                                'text/html',
-                                'text/plain'])
-    nt.assert_equal(md, {})
 
-    d, md = f.format(obj, include={'image/png'})
-    nt.assert_equal(list(d.keys()), ['image/png'],
-                    'Include should filter out even things from repr_mimebundle')
-    nt.assert_equal(d['image/png'], 'i-overwrite', '_repr_mimebundle_ take precedence')
+    assert sorted(d) == [
+        "application/json+test.v2",
+        "image/png",
+        "plain/text",
+        "text/html",
+        "text/plain",
+    ]
+    assert md == {}
 
+    d, md = f.format(obj, include={"image/png"})
+    assert list(d.keys()) == [
+        "image/png"
+    ], "Include should filter out even things from repr_mimebundle"
+
+    assert d["image/png"] == "i-overwrite", "_repr_mimebundle_ take precedence"
 
 
 def test_pass_correct_include_exclude():
@@ -514,13 +522,14 @@ def test_repr_mime_meta():
     f = get_ipython().display_formatter
     obj = HasReprMimeMeta()
     d, md = f.format(obj)
-    nt.assert_equal(sorted(d), ['image/png', 'text/plain'])
-    nt.assert_equal(md, {
-        'image/png': {
-            'width': 5,
-            'height': 10,
+    assert sorted(d) == ["image/png", "text/plain"]
+    assert md == {
+        "image/png": {
+            "width": 5,
+            "height": 10,
         }
-    })
+    }
+
 
 def test_repr_mime_failure():
     class BadReprMime(object):
@@ -530,4 +539,4 @@ def test_repr_mime_failure():
     f = get_ipython().display_formatter
     obj = BadReprMime()
     d, md = f.format(obj)
-    nt.assert_in('text/plain', d)
+    assert "text/plain" in d

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -56,7 +56,7 @@ def pyfile(fname):
 
 
 def match_pyfiles(f1, f2):
-    nt.assert_equal(pyfile(f1), pyfile(f2))
+    assert pyfile(f1) == pyfile(f2)
 
 
 def test_find_file():
@@ -76,7 +76,7 @@ def test_find_file_decorated1():
         "My docstring"
     
     match_pyfiles(oinspect.find_file(f), os.path.abspath(__file__))
-    nt.assert_equal(f.__doc__, "My docstring")
+    assert f.__doc__ == "My docstring"
 
 
 def test_find_file_decorated2():
@@ -92,7 +92,7 @@ def test_find_file_decorated2():
         "My docstring 2"
     
     match_pyfiles(oinspect.find_file(f), os.path.abspath(__file__))
-    nt.assert_equal(f.__doc__, "My docstring 2")
+    assert f.__doc__ == "My docstring 2"
     
 
 def test_find_file_magic():
@@ -167,41 +167,46 @@ class SerialLiar(object):
 
 def test_info():
     "Check that Inspector.info fills out various fields as expected."
-    i = inspector.info(Call, oname='Call')
-    nt.assert_equal(i['type_name'], 'type')
+    i = inspector.info(Call, oname="Call")
+    assert i["type_name"] == "type"
     expted_class = str(type(type))  # <class 'type'> (Python 3) or <type 'type'>
-    nt.assert_equal(i['base_class'], expted_class)
-    nt.assert_regex(i['string_form'], "<class 'IPython.core.tests.test_oinspect.Call'( at 0x[0-9a-f]{1,9})?>")
+    assert i["base_class"] == expted_class
+    nt.assert_regex(
+        i["string_form"],
+        "<class 'IPython.core.tests.test_oinspect.Call'( at 0x[0-9a-f]{1,9})?>",
+    )
     fname = __file__
     if fname.endswith(".pyc"):
         fname = fname[:-1]
     # case-insensitive comparison needed on some filesystems
     # e.g. Windows:
-    nt.assert_equal(i['file'].lower(), compress_user(fname).lower())
-    nt.assert_equal(i['definition'], None)
-    nt.assert_equal(i['docstring'], Call.__doc__)
-    nt.assert_equal(i['source'], None)
-    nt.assert_true(i['isclass'])
-    nt.assert_equal(i['init_definition'], "Call(x, y=1)")
-    nt.assert_equal(i['init_docstring'], Call.__init__.__doc__)
+    assert i["file"].lower() == compress_user(fname).lower()
+    assert i["definition"] == None
+    assert i["docstring"] == Call.__doc__
+    assert i["source"] == None
+    nt.assert_true(i["isclass"])
+    assert i["init_definition"] == "Call(x, y=1)"
+    assert i["init_docstring"] == Call.__init__.__doc__
 
     i = inspector.info(Call, detail_level=1)
-    nt.assert_not_equal(i['source'], None)
-    nt.assert_equal(i['docstring'], None)
+    nt.assert_not_equal(i["source"], None)
+    assert i["docstring"] == None
 
     c = Call(1)
     c.__doc__ = "Modified instance docstring"
     i = inspector.info(c)
-    nt.assert_equal(i['type_name'], 'Call')
-    nt.assert_equal(i['docstring'], "Modified instance docstring")
-    nt.assert_equal(i['class_docstring'], Call.__doc__)
-    nt.assert_equal(i['init_docstring'], Call.__init__.__doc__)
-    nt.assert_equal(i['call_docstring'], Call.__call__.__doc__)
+    assert i["type_name"] == "Call"
+    assert i["docstring"] == "Modified instance docstring"
+    assert i["class_docstring"] == Call.__doc__
+    assert i["init_docstring"] == Call.__init__.__doc__
+    assert i["call_docstring"] == Call.__call__.__doc__
+
 
 def test_class_signature():
-    info = inspector.info(HasSignature, 'HasSignature')
-    nt.assert_equal(info['init_definition'], "HasSignature(test)")
-    nt.assert_equal(info['init_docstring'], HasSignature.__init__.__doc__)
+    info = inspector.info(HasSignature, "HasSignature")
+    assert info["init_definition"] == "HasSignature(test)"
+    assert info["init_docstring"] == HasSignature.__init__.__doc__
+
 
 def test_info_awkward():
     # Just test that this doesn't throw an error.
@@ -231,8 +236,9 @@ def f_kwarg(pos, *, kwonly):
     pass
 
 def test_definition_kwonlyargs():
-    i = inspector.info(f_kwarg, oname='f_kwarg')  # analysis:ignore
-    nt.assert_equal(i['definition'], "f_kwarg(pos, *, kwonly)")
+    i = inspector.info(f_kwarg, oname="f_kwarg")  # analysis:ignore
+    assert i["definition"] == "f_kwarg(pos, *, kwonly)"
+
 
 def test_getdoc():
     class A(object):
@@ -253,9 +259,9 @@ def test_getdoc():
     b = B()
     c = C()
     
-    nt.assert_equal(oinspect.getdoc(a), "standard docstring")
-    nt.assert_equal(oinspect.getdoc(b), "custom docstring")
-    nt.assert_equal(oinspect.getdoc(c), "standard docstring")
+    assert oinspect.getdoc(a) == "standard docstring"
+    assert oinspect.getdoc(b) == "custom docstring"
+    assert oinspect.getdoc(c) == "standard docstring"
 
 
 def test_empty_property_has_no_source():
@@ -299,15 +305,17 @@ def test_property_docstring_is_in_info_for_detail_level_0():
             """This is `foobar` property."""
             pass
 
-    ip.user_ns['a_obj'] = A()
-    nt.assert_equal(
-        'This is `foobar` property.',
-        ip.object_inspect('a_obj.foobar', detail_level=0)['docstring'])
+    ip.user_ns["a_obj"] = A()
+    assert (
+        "This is `foobar` property."
+        == ip.object_inspect("a_obj.foobar", detail_level=0)["docstring"]
+    )
 
-    ip.user_ns['a_cls'] = A
-    nt.assert_equal(
-        'This is `foobar` property.',
-        ip.object_inspect('a_cls.foobar', detail_level=0)['docstring'])
+    ip.user_ns["a_cls"] = A
+    assert (
+        "This is `foobar` property."
+        == ip.object_inspect("a_cls.foobar", detail_level=0)["docstring"]
+    )
 
 
 def test_pdef():
@@ -404,7 +412,7 @@ def test_render_signature_short():
         signature(short_fun),
         short_fun.__name__,
     )
-    nt.assert_equal(sig, 'short_fun(a=1)')
+    assert sig == "short_fun(a=1)"
 
 
 def test_render_signature_long():

--- a/IPython/lib/tests/test_backgroundjobs.py
+++ b/IPython/lib/tests/test_backgroundjobs.py
@@ -15,9 +15,6 @@
 # Stdlib imports
 import time
 
-# Third-party imports
-import nose.tools as nt
-
 # Our own imports
 from IPython.lib import backgroundjobs as bg
 
@@ -49,18 +46,18 @@ def test_result():
     jobs = bg.BackgroundJobManager()
     j = jobs.new(sleeper)
     j.join()
-    nt.assert_equal(j.result['interval'], t_short)
-    
+    assert j.result["interval"] == t_short
+
 
 def test_flush():
     """Test job control"""
     jobs = bg.BackgroundJobManager()
     j = jobs.new(sleeper)
     j.join()
-    nt.assert_equal(len(jobs.completed), 1)
-    nt.assert_equal(len(jobs.dead), 0)
+    assert len(jobs.completed) == 1
+    assert len(jobs.dead) == 0
     jobs.flush()
-    nt.assert_equal(len(jobs.completed), 0)
+    assert len(jobs.completed) == 0
     
 
 def test_dead():
@@ -68,10 +65,10 @@ def test_dead():
     jobs = bg.BackgroundJobManager()
     j = jobs.new(crasher)
     j.join()
-    nt.assert_equal(len(jobs.completed), 0)
-    nt.assert_equal(len(jobs.dead), 1)
+    assert len(jobs.completed) == 0
+    assert len(jobs.dead) == 1
     jobs.flush()    
-    nt.assert_equal(len(jobs.dead), 0)
+    assert len(jobs.dead) == 0
 
 
 def test_longer():
@@ -81,8 +78,8 @@ def test_longer():
     # job as running, but not so long that it makes the test suite noticeably
     # slower. 
     j = jobs.new(sleeper, 0.1)
-    nt.assert_equal(len(jobs.running), 1)
-    nt.assert_equal(len(jobs.completed), 0)
+    assert len(jobs.running) == 1
+    assert len(jobs.completed) == 0
     j.join()
-    nt.assert_equal(len(jobs.running), 0)
-    nt.assert_equal(len(jobs.completed), 1)
+    assert len(jobs.running) == 0
+    assert len(jobs.completed) == 1

--- a/IPython/lib/tests/test_display.py
+++ b/IPython/lib/tests/test_display.py
@@ -59,8 +59,9 @@ def test_existing_path_FileLink():
     tf = NamedTemporaryFile()
     fl = display.FileLink(tf.name)
     actual = fl._repr_html_()
-    expected = "<a href='%s' target='_blank'>%s</a><br>" % (tf.name,tf.name)
-    nt.assert_equal(actual,expected)
+    expected = "<a href='%s' target='_blank'>%s</a><br>" % (tf.name, tf.name)
+    assert actual == expected
+
 
 def test_existing_path_FileLink_repr():
     """FileLink: Calling repr() functions as expected on existing filepath
@@ -69,7 +70,8 @@ def test_existing_path_FileLink_repr():
     fl = display.FileLink(tf.name)
     actual = repr(fl)
     expected = tf.name
-    nt.assert_equal(actual,expected)
+    assert actual == expected
+
 
 def test_error_on_directory_to_FileLink():
     """FileLink: Raises error when passed directory
@@ -111,7 +113,8 @@ def test_existing_path_FileLinks():
                  (tf1.name.replace("\\","/"),split(tf1.name)[1])]
     expected.sort()
     # We compare the sorted list of links here as that's more reliable
-    nt.assert_equal(actual,expected)
+    assert actual == expected
+
 
 def test_existing_path_FileLinks_alt_formatter():
     """FileLinks: Calling _repr_html_ functions as expected w/ an alt formatter
@@ -128,7 +131,8 @@ def test_existing_path_FileLinks_alt_formatter():
     expected = ["hello","world"]
     expected.sort()
     # We compare the sorted list of links here as that's more reliable
-    nt.assert_equal(actual,expected)
+    assert actual == expected
+
 
 def test_existing_path_FileLinks_repr():
     """FileLinks: Calling repr() functions as expected on existing directory """
@@ -142,8 +146,9 @@ def test_existing_path_FileLinks_repr():
     expected = ['%s/' % td, '  %s' % split(tf1.name)[1],'  %s' % split(tf2.name)[1]]
     expected.sort()
     # We compare the sorted list of links here as that's more reliable
-    nt.assert_equal(actual,expected)
-    
+    assert actual == expected
+
+
 def test_existing_path_FileLinks_repr_alt_formatter():
     """FileLinks: Calling repr() functions as expected w/ alt formatter
     """
@@ -159,8 +164,9 @@ def test_existing_path_FileLinks_repr_alt_formatter():
     expected = ["hello","world"]
     expected.sort()
     # We compare the sorted list of links here as that's more reliable
-    nt.assert_equal(actual,expected)
-    
+    assert actual == expected
+
+
 def test_error_on_file_to_FileLinks():
     """FileLinks: Raises error when passed file
     """
@@ -178,11 +184,11 @@ def test_recursive_FileLinks():
     fl = display.FileLinks(td)
     actual = str(fl)
     actual = actual.split('\n')
-    nt.assert_equal(len(actual), 4, actual)
+    assert len(actual) == 4, actual
     fl = display.FileLinks(td, recursive=False)
     actual = str(fl)
     actual = actual.split('\n')
-    nt.assert_equal(len(actual), 2, actual)
+    assert len(actual) == 2, actual
 
 def test_audio_from_file():
     path = pjoin(dirname(__file__), 'test.wav')
@@ -194,13 +200,13 @@ class TestAudioDataWithNumpy(TestCase):
     def test_audio_from_numpy_array(self):
         test_tone = get_test_tone()
         audio = display.Audio(test_tone, rate=44100)
-        nt.assert_equal(len(read_wav(audio.data)), len(test_tone))
+        assert len(read_wav(audio.data)) == len(test_tone)
 
     @skipif_not_numpy
     def test_audio_from_list(self):
         test_tone = get_test_tone()
         audio = display.Audio(list(test_tone), rate=44100)
-        nt.assert_equal(len(read_wav(audio.data)), len(test_tone))
+        assert len(read_wav(audio.data)) == len(test_tone)
 
     @skipif_not_numpy
     def test_audio_from_numpy_array_without_rate_raises(self):
@@ -212,7 +218,7 @@ class TestAudioDataWithNumpy(TestCase):
         for scale in [1, 0.5, 2]:
             audio = display.Audio(get_test_tone(scale), rate=44100)
             actual_max_value = numpy.max(numpy.abs(read_wav(audio.data)))
-            nt.assert_equal(actual_max_value, expected_max_value)
+            assert actual_max_value == expected_max_value
 
     @skipif_not_numpy
     def test_audio_data_without_normalization(self):
@@ -223,7 +229,7 @@ class TestAudioDataWithNumpy(TestCase):
             expected_max_value = int(max_int16 * test_tone_max_abs)
             audio = display.Audio(test_tone, rate=44100, normalize=False)
             actual_max_value = numpy.max(numpy.abs(read_wav(audio.data)))
-            nt.assert_equal(actual_max_value, expected_max_value)
+            assert actual_max_value == expected_max_value
 
     def test_audio_data_without_normalization_raises_for_invalid_data(self):
         nt.assert_raises(

--- a/IPython/lib/tests/test_editorhooks.py
+++ b/IPython/lib/tests/test_editorhooks.py
@@ -2,8 +2,6 @@
 import sys
 from unittest import mock
 
-import nose.tools as nt
-
 from IPython import get_ipython
 from IPython.lib import editorhooks
 
@@ -20,15 +18,15 @@ def test_install_editor():
     with mock.patch('subprocess.Popen', fake_popen):
         get_ipython().hooks.editor('the file', 64)
     
-    nt.assert_equal(len(called), 1)
-    args = called[0]['args']
-    kwargs = called[0]['kwargs']
-    
-    nt.assert_equal(kwargs, {'shell': True})
-    
-    if sys.platform.startswith('win'):
-        expected = ['foo', '-l', '64', '-f', 'the file']
+    assert len(called) == 1
+    args = called[0]["args"]
+    kwargs = called[0]["kwargs"]
+
+    assert kwargs == {"shell": True}
+
+    if sys.platform.startswith("win"):
+        expected = ["foo", "-l", "64", "-f", "the file"]
     else:
         expected = "foo -l 64 -f 'the file'"
     cmd = args[0]
-    nt.assert_equal(cmd, expected)
+    assert cmd == expected

--- a/IPython/lib/tests/test_latextools.py
+++ b/IPython/lib/tests/test_latextools.py
@@ -25,7 +25,7 @@ def test_check_latex_to_png_dvipng_fails_when_no_cmd(command):
             raise FindCmdError
 
     with patch.object(latextools, "find_cmd", mock_find_cmd):
-        assert latextools.latex_to_png_dvipng("whatever", True) == None
+        assert latextools.latex_to_png_dvipng("whatever", True) is None
 
 
 @contextmanager

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -81,7 +81,7 @@ def test_indentation():
     gotoutput = pretty.pretty(MyList(range(count)))
     expectedoutput = "MyList(\n" + ",\n".join("   %d" % i for i in range(count)) + ")"
 
-    nt.assert_equal(gotoutput, expectedoutput)
+    assert gotoutput == expectedoutput
 
 
 def test_dispatch():
@@ -92,7 +92,7 @@ def test_dispatch():
     gotoutput = pretty.pretty(MyDict())
     expectedoutput = "MyDict(...)"
 
-    nt.assert_equal(gotoutput, expectedoutput)
+    assert gotoutput == expectedoutput
 
 
 def test_callability_checking():
@@ -103,7 +103,7 @@ def test_callability_checking():
     gotoutput = pretty.pretty(Dummy2())
     expectedoutput = "Dummy1(...)"
 
-    nt.assert_equal(gotoutput, expectedoutput)
+    assert gotoutput == expectedoutput
 
 
 @pytest.mark.parametrize(
@@ -135,7 +135,7 @@ def test_sets(obj, expected_output):
     Test that set and frozenset use Python 3 formatting.
     """
     got_output = pretty.pretty(obj)
-    nt.assert_equal(got_output, expected_output)
+    assert got_output == expected_output
 
 
 @skip_without('xxlimited')
@@ -145,22 +145,24 @@ def test_pprint_heap_allocated_type():
     """
     import xxlimited
     output = pretty.pretty(xxlimited.Null)
-    nt.assert_equal(output, 'xxlimited.Null')
+    assert output == "xxlimited.Null"
+
 
 def test_pprint_nomod():
     """
     Test that pprint works for classes with no __module__.
     """
     output = pretty.pretty(NoModule)
-    nt.assert_equal(output, 'NoModule')
-    
+    assert output == "NoModule"
+
+
 def test_pprint_break():
     """
     Test that p.break_ produces expected output
     """
     output = pretty.pretty(Breaking())
     expected = "TG: Breaking(\n    ):"
-    nt.assert_equal(output, expected)
+    assert output == expected
 
 def test_pprint_break_repr():
     """
@@ -168,11 +170,11 @@ def test_pprint_break_repr():
     """
     output = pretty.pretty([[BreakingRepr()]])
     expected = "[[Breaking(\n  )]]"
-    nt.assert_equal(output, expected)
+    assert output == expected
 
     output = pretty.pretty([[BreakingRepr()]*2])
     expected = "[[Breaking(\n  ),\n  Breaking(\n  )]]"
-    nt.assert_equal(output, expected)
+    assert output == expected
 
 def test_bad_repr():
     """Don't catch bad repr errors"""
@@ -258,7 +260,7 @@ ClassWithMeta = MetaClass('ClassWithMeta')
 
 def test_metaclass_repr():
     output = pretty.pretty(ClassWithMeta)
-    nt.assert_equal(output, "[CUSTOM REPR FOR CLASS ClassWithMeta]")
+    assert output == "[CUSTOM REPR FOR CLASS ClassWithMeta]"
 
 
 def test_unicode_repr():
@@ -271,9 +273,9 @@ def test_unicode_repr():
     
     c = C()
     p = pretty.pretty(c)
-    nt.assert_equal(p, u)
+    assert p == u
     p = pretty.pretty([c])
-    nt.assert_equal(p, u'[%s]' % u)
+    assert p == u"[%s]" % u
 
 
 def test_basic_class():
@@ -290,10 +292,11 @@ def test_basic_class():
     printer.flush()
     output = stream.getvalue()
 
-    nt.assert_equal(output, '%s.MyObj' % __name__)
+    assert output == "%s.MyObj" % __name__
     nt.assert_true(type_pprint_wrapper.called)
 
 
+# TODO : pytest.mark.parametrise once nose is gone.
 def test_collections_defaultdict():
     # Create defaultdicts with cycles
     a = defaultdict()
@@ -311,9 +314,10 @@ def test_collections_defaultdict():
         (b, "defaultdict(list, {'key': defaultdict(...)})"),
     ]
     for obj, expected in cases:
-        nt.assert_equal(pretty.pretty(obj), expected)
+        assert pretty.pretty(obj) == expected
 
 
+# TODO : pytest.mark.parametrise once nose is gone.
 def test_collections_ordereddict():
     # Create OrderedDict with cycle
     a = OrderedDict()
@@ -335,9 +339,10 @@ def test_collections_ordereddict():
         (a, "OrderedDict([('key', OrderedDict(...))])"),
     ]
     for obj, expected in cases:
-        nt.assert_equal(pretty.pretty(obj), expected)
+        assert pretty.pretty(obj) == expected
 
 
+# TODO : pytest.mark.parametrise once nose is gone.
 def test_collections_deque():
     # Create deque with cycle
     a = deque()
@@ -369,8 +374,10 @@ def test_collections_deque():
         (a, 'deque([deque(...)])'),
     ]
     for obj, expected in cases:
-        nt.assert_equal(pretty.pretty(obj), expected)
+        assert pretty.pretty(obj) == expected
 
+
+# TODO : pytest.mark.parametrise once nose is gone.
 def test_collections_counter():
     class MyCounter(Counter):
         pass
@@ -380,8 +387,9 @@ def test_collections_counter():
         (MyCounter(a=1), "MyCounter({'a': 1})"),
     ]
     for obj, expected in cases:
-        nt.assert_equal(pretty.pretty(obj), expected)
+        assert pretty.pretty(obj) == expected
 
+# TODO : pytest.mark.parametrise once nose is gone.
 def test_mappingproxy():
     MP = types.MappingProxyType
     underlying_dict = {}
@@ -424,9 +432,10 @@ def test_mappingproxy():
          "{2: mappingproxy({2: {...}, 3: {...}}), 3: {...}}"),
     ]
     for obj, expected in cases:
-        nt.assert_equal(pretty.pretty(obj), expected)
+        assert pretty.pretty(obj) == expected
 
 
+# TODO : pytest.mark.parametrise once nose is gone.
 def test_simplenamespace():
     SN = types.SimpleNamespace
 
@@ -444,7 +453,7 @@ def test_simplenamespace():
         (sn_recursive, "namespace(first=namespace(...), second=namespace(...))"),
     ]
     for obj, expected in cases:
-        nt.assert_equal(pretty.pretty(obj), expected)
+        assert pretty.pretty(obj) == expected
 
 
 def test_pretty_environ():
@@ -452,7 +461,7 @@ def test_pretty_environ():
     # reindent to align with 'environ' prefix
     dict_indented = dict_repr.replace('\n', '\n' + (' ' * len('environ')))
     env_repr = pretty.pretty(os.environ)
-    nt.assert_equal(env_repr, 'environ' + dict_indented)
+    assert env_repr == "environ" + dict_indented
 
 
 def test_function_pretty():
@@ -460,8 +469,9 @@ def test_function_pretty():
     # posixpath is a pure python module, its interface is consistent
     # across Python distributions
     import posixpath
-    nt.assert_equal(pretty.pretty(posixpath.join), '<function posixpath.join(a, *p)>')
- 
+
+    assert pretty.pretty(posixpath.join) == "<function posixpath.join(a, *p)>"
+
     # custom function
     def meaning_of_life(question=None):
         if question:
@@ -489,4 +499,4 @@ def test_custom_repr():
     oc = OrderedCounter("abracadabra")
     nt.assert_in("OrderedCounter(OrderedDict", pretty.pretty(oc))
 
-    nt.assert_equal(pretty.pretty(MySet()), 'mine')
+    assert pretty.pretty(MySet()) == "mine"

--- a/IPython/lib/tests/test_security.py
+++ b/IPython/lib/tests/test_security.py
@@ -1,24 +1,25 @@
 # coding: utf-8
 from IPython.lib import passwd
 from IPython.lib.security import passwd_check, salt_len
-import nose.tools as nt
 
 def test_passwd_structure():
-    p = passwd('passphrase')
-    algorithm, salt, hashed = p.split(':')
-    nt.assert_equal(algorithm, 'sha1')
-    nt.assert_equal(len(salt), salt_len)
-    nt.assert_equal(len(hashed), 40)
+    p = passwd("passphrase")
+    algorithm, salt, hashed = p.split(":")
+    assert algorithm == "sha1"
+    assert len(salt) == salt_len
+    assert len(hashed) == 40
 
 def test_roundtrip():
-    p = passwd('passphrase')
-    nt.assert_equal(passwd_check(p, 'passphrase'), True)
+    p = passwd("passphrase")
+    assert passwd_check(p, "passphrase") is True
+
 
 def test_bad():
     p = passwd('passphrase')
-    nt.assert_equal(passwd_check(p, p), False)
-    nt.assert_equal(passwd_check(p, 'a:b:c:d'), False)
-    nt.assert_equal(passwd_check(p, 'a:b'), False)
+    assert passwd_check(p, p) is False
+    assert passwd_check(p, "a:b:c:d") is False
+    assert passwd_check(p, "a:b") is False
+
 
 def test_passwd_check_unicode():
     # GH issue #4524

--- a/IPython/utils/tests/test_capture.py
+++ b/IPython/utils/tests/test_capture.py
@@ -15,7 +15,6 @@
 
 import sys
 
-import nose.tools as nt
 import pytest
 
 from IPython.testing.decorators import skip_iptest_but_not_pytest
@@ -75,18 +74,18 @@ def test_rich_output_empty(method_mime):
     """RichOutput with no args"""
     rich = capture.RichOutput()
     method, mime = method_mime
-    nt.assert_equal(getattr(rich, method)(), None)
+    assert getattr(rich, method)() is None
     
 def test_rich_output():
     """test RichOutput basics"""
     data = basic_data
     metadata = basic_metadata
     rich = capture.RichOutput(data=data, metadata=metadata)
-    nt.assert_equal(rich._repr_html_(), data["text/html"])
-    nt.assert_equal(rich._repr_png_(), (data["image/png"], metadata["image/png"]))
-    nt.assert_equal(rich._repr_latex_(), None)
-    nt.assert_equal(rich._repr_javascript_(), None)
-    nt.assert_equal(rich._repr_svg_(), None)
+    assert rich._repr_html_() == data["text/html"]
+    assert rich._repr_png_() == (data["image/png"], metadata["image/png"])
+    assert rich._repr_latex_() is None
+    assert rich._repr_javascript_() is None
+    assert rich._repr_svg_() is None
 
 
 @skip_iptest_but_not_pytest
@@ -96,7 +95,7 @@ def test_rich_output_no_metadata(method_mime):
     data = full_data
     rich = capture.RichOutput(data=data)
     method, mime = method_mime
-    nt.assert_equal(getattr(rich, method)(), data[mime])
+    assert getattr(rich, method)() == data[mime]
 
 
 @skip_iptest_but_not_pytest
@@ -107,7 +106,7 @@ def test_rich_output_metadata(method_mime):
     metadata = full_metadata
     rich = capture.RichOutput(data=data, metadata=metadata)
     method, mime = method_mime
-    nt.assert_equal(getattr(rich, method)(), (data[mime], metadata[mime]))
+    assert getattr(rich, method)() == (data[mime], metadata[mime])
 
 def test_rich_output_display():
     """test RichOutput.display
@@ -119,10 +118,10 @@ def test_rich_output_display():
     rich = capture.RichOutput(data=data)
     with capture.capture_output() as cap:
         rich.display()
-    nt.assert_equal(len(cap.outputs), 1)
+    assert len(cap.outputs) == 1
     rich2 = cap.outputs[0]
-    nt.assert_equal(rich2.data, rich.data)
-    nt.assert_equal(rich2.metadata, rich.metadata)
+    assert rich2.data == rich.data
+    assert rich2.metadata == rich.metadata
 
 def test_capture_output():
     """capture_output works"""
@@ -131,8 +130,8 @@ def test_capture_output():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    nt.assert_equal(hello_stdout, cap.stdout)
-    nt.assert_equal(hello_stderr, cap.stderr)
+    assert hello_stdout == cap.stdout
+    assert hello_stderr == cap.stderr
 
 
 def test_capture_output_no_stdout():
@@ -142,9 +141,9 @@ def test_capture_output_no_stdout():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    nt.assert_equal("", cap.stdout)
-    nt.assert_equal(hello_stderr, cap.stderr)
-    nt.assert_equal(len(cap.outputs), 1)
+    assert "" == cap.stdout
+    assert hello_stderr == cap.stderr
+    assert len(cap.outputs) == 1
 
 
 def test_capture_output_no_stderr():
@@ -155,9 +154,9 @@ def test_capture_output_no_stderr():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    nt.assert_equal(hello_stdout, cap.stdout)
-    nt.assert_equal("", cap.stderr)
-    nt.assert_equal(len(cap.outputs), 1)
+    assert hello_stdout == cap.stdout
+    assert "" == cap.stderr
+    assert len(cap.outputs) == 1
 
 
 def test_capture_output_no_display():
@@ -167,6 +166,6 @@ def test_capture_output_no_display():
         print(hello_stdout, end="")
         print(hello_stderr, end="", file=sys.stderr)
         rich.display()
-    nt.assert_equal(hello_stdout, cap.stdout)
-    nt.assert_equal(hello_stderr, cap.stderr)
-    nt.assert_equal(cap.outputs, [])
+    assert hello_stdout == cap.stdout
+    assert hello_stderr == cap.stderr
+    assert cap.outputs == []

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -113,7 +113,7 @@ def test_get_home_dir_1():
     IPython.__file__ = abspath(join(HOME_TEST_DIR, "Lib/IPython/__init__.py"))
 
     home_dir = path.get_home_dir()
-    nt.assert_equal(home_dir, unfrozen)
+    assert home_dir == unfrozen
 
 
 @skip_if_not_win32
@@ -127,7 +127,7 @@ def test_get_home_dir_2():
     IPython.__file__ = abspath(join(HOME_TEST_DIR, "Library.zip/IPython/__init__.py")).lower()
 
     home_dir = path.get_home_dir(True)
-    nt.assert_equal(home_dir, unfrozen)
+    assert home_dir == unfrozen
 
 
 @skip_win32_py38
@@ -137,7 +137,7 @@ def test_get_home_dir_3():
     env["HOME"] = HOME_TEST_DIR
     home_dir = path.get_home_dir(True)
     # get_home_dir expands symlinks
-    nt.assert_equal(home_dir, os.path.realpath(env["HOME"]))
+    assert home_dir == os.path.realpath(env["HOME"])
 
 
 @with_environment
@@ -181,7 +181,7 @@ def test_get_home_dir_8():
     with patch.object(wreg, 'OpenKey', return_value=key()), \
          patch.object(wreg, 'QueryValueEx', return_value=[abspath(HOME_TEST_DIR)]):
         home_dir = path.get_home_dir()
-    nt.assert_equal(home_dir, abspath(HOME_TEST_DIR))
+    assert home_dir == abspath(HOME_TEST_DIR)
 
 @with_environment
 def test_get_xdg_dir_0():
@@ -195,7 +195,7 @@ def test_get_xdg_dir_0():
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
 
-    nt.assert_equal(path.get_xdg_dir(), os.path.join('somewhere', '.config'))
+    assert path.get_xdg_dir() == os.path.join("somewhere", ".config")
 
 
 @with_environment
@@ -208,7 +208,7 @@ def test_get_xdg_dir_1():
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)
-    nt.assert_equal(path.get_xdg_dir(), None)
+    assert path.get_xdg_dir() is None
 
 @with_environment
 def test_get_xdg_dir_2():
@@ -224,7 +224,7 @@ def test_get_xdg_dir_2():
     if not os.path.exists(cfgdir):
         os.makedirs(cfgdir)
 
-    nt.assert_equal(path.get_xdg_dir(), cfgdir)
+    assert path.get_xdg_dir() == cfgdir
 
 @with_environment
 def test_get_xdg_dir_3():
@@ -240,7 +240,7 @@ def test_get_xdg_dir_3():
     if not os.path.exists(cfgdir):
         os.makedirs(cfgdir)
 
-    nt.assert_equal(path.get_xdg_dir(), None)
+    assert path.get_xdg_dir() is None
 
 def test_filefind():
     """Various tests for filefind"""
@@ -263,13 +263,13 @@ def test_get_long_path_name_win32():
         # Test to see if the short path evaluates correctly.
         short_path = os.path.join(tmpdir, 'THISIS~1')
         evaluated_path = path.get_long_path_name(short_path)
-        nt.assert_equal(evaluated_path.lower(), long_path.lower())
+        assert evaluated_path.lower() == long_path.lower()
 
 
 @dec.skip_win32
 def test_get_long_path_name():
-    p = path.get_long_path_name('/usr/local')
-    nt.assert_equal(p,'/usr/local')
+    p = path.get_long_path_name("/usr/local")
+    assert p == "/usr/local"
 
 
 class TestRaiseDeprecation(unittest.TestCase):
@@ -300,18 +300,18 @@ class TestRaiseDeprecation(unittest.TestCase):
 @with_environment
 def test_get_py_filename():
     os.chdir(TMP_TEST_DIR)
-    with make_tempfile('foo.py'):
-        nt.assert_equal(path.get_py_filename('foo.py'), 'foo.py')
-        nt.assert_equal(path.get_py_filename('foo'), 'foo.py')
-    with make_tempfile('foo'):
-        nt.assert_equal(path.get_py_filename('foo'), 'foo')
-        nt.assert_raises(IOError, path.get_py_filename, 'foo.py')
-    nt.assert_raises(IOError, path.get_py_filename, 'foo')
-    nt.assert_raises(IOError, path.get_py_filename, 'foo.py')
-    true_fn = 'foo with spaces.py'
+    with make_tempfile("foo.py"):
+        assert path.get_py_filename("foo.py") == "foo.py"
+        assert path.get_py_filename("foo") == "foo.py"
+    with make_tempfile("foo"):
+        assert path.get_py_filename("foo") == "foo"
+        nt.assert_raises(IOError, path.get_py_filename, "foo.py")
+    nt.assert_raises(IOError, path.get_py_filename, "foo")
+    nt.assert_raises(IOError, path.get_py_filename, "foo.py")
+    true_fn = "foo with spaces.py"
     with make_tempfile(true_fn):
-        nt.assert_equal(path.get_py_filename('foo with spaces'), true_fn)
-        nt.assert_equal(path.get_py_filename('foo with spaces.py'), true_fn)
+        assert path.get_py_filename("foo with spaces") == true_fn
+        assert path.get_py_filename("foo with spaces.py") == true_fn
         nt.assert_raises(IOError, path.get_py_filename, '"foo with spaces.py"')
         nt.assert_raises(IOError, path.get_py_filename, "'foo with spaces.py'")
 
@@ -361,8 +361,7 @@ class TestShellGlob(unittest.TestCase):
     def check_match(self, patterns, matches):
         with self.in_tempdir():
             # glob returns unordered list. that's why sorted is required.
-            nt.assert_equal(sorted(path.shellglob(patterns)),
-                            sorted(matches))
+            assert sorted(path.shellglob(patterns)) == sorted(matches)
 
     def common_cases(self):
         return [
@@ -397,12 +396,13 @@ class TestShellGlob(unittest.TestCase):
             yield (self.check_match, patterns, matches)
 
 
+# TODO : pytest.mark.parametrise once nose is gone.
 def test_unescape_glob():
-    nt.assert_equal(path.unescape_glob(r'\*\[\!\]\?'), '*[!]?')
-    nt.assert_equal(path.unescape_glob(r'\\*'), r'\*')
-    nt.assert_equal(path.unescape_glob(r'\\\*'), r'\*')
-    nt.assert_equal(path.unescape_glob(r'\\a'), r'\a')
-    nt.assert_equal(path.unescape_glob(r'\a'), r'\a')
+    assert path.unescape_glob(r"\*\[\!\]\?") == "*[!]?"
+    assert path.unescape_glob(r"\\*") == r"\*"
+    assert path.unescape_glob(r"\\\*") == r"\*"
+    assert path.unescape_glob(r"\\a") == r"\a"
+    assert path.unescape_glob(r"\a") == r"\a"
 
 
 @onlyif_unicode_paths
@@ -431,17 +431,19 @@ class TestLinkOrCopy(unittest.TestCase):
         return os.path.join(self.tempdir.name, *args)
 
     def assert_inode_not_equal(self, a, b):
-        nt.assert_not_equal(os.stat(a).st_ino, os.stat(b).st_ino,
-                            "%r and %r do reference the same indoes" %(a, b))
+        assert (
+            os.stat(a).st_ino != os.stat(b).st_ino
+        ), "%r and %r do reference the same indoes" % (a, b)
 
     def assert_inode_equal(self, a, b):
-        nt.assert_equal(os.stat(a).st_ino, os.stat(b).st_ino,
-                        "%r and %r do not reference the same indoes" %(a, b))
+        assert (
+            os.stat(a).st_ino == os.stat(b).st_ino
+        ), "%r and %r do not reference the same indoes" % (a, b)
 
     def assert_content_equal(self, a, b):
         with open(a) as a_f:
             with open(b) as b_f:
-                nt.assert_equal(a_f.read(), b_f.read())
+                assert a_f.read() == b_f.read()
 
     @skip_win32
     def test_link_successful(self):
@@ -489,4 +491,4 @@ class TestLinkOrCopy(unittest.TestCase):
         path.link_or_copy(self.src, dst)
         path.link_or_copy(self.src, dst)
         self.assert_inode_equal(self.src, dst)
-        nt.assert_equal(sorted(os.listdir(self.tempdir.name)), ['src', 'target'])
+        assert sorted(os.listdir(self.tempdir.name)) == ["src", "target"]

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -66,7 +66,8 @@ def test_find_cmd_fail():
     """Make sure that FindCmdError is raised if we can't find the cmd."""
     nt.assert_raises(FindCmdError,find_cmd,'asdfasdf')
 
-    
+
+# TODO: move to pytest.mark.parametrize once nose gone
 @dec.skip_win32
 def test_arg_split():
     """Ensure that argument lines are correctly split like in a shell."""
@@ -80,8 +81,10 @@ def test_arg_split():
              ['something "with quotes"', ['something', '"with quotes"']],
              ]
     for argstr, argv in tests:
-        nt.assert_equal(arg_split(argstr), argv)
-    
+        assert arg_split(argstr) == argv
+
+
+# TODO: move to pytest.mark.parametrize once nose gone
 @dec.skip_if_not_win32
 def test_arg_split_win32():
     """Ensure that argument lines are correctly split like in a shell."""
@@ -92,7 +95,7 @@ def test_arg_split_win32():
              ['something "with quotes"', ['something', 'with quotes']],
              ]
     for argstr, argv in tests:
-        nt.assert_equal(arg_split(argstr), argv)
+        assert arg_split(argstr) == argv
 
 
 class SubProcessTestCase(tt.TempFileMixin):

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -32,31 +32,31 @@ def test_columnize():
     items = [l*size for l in 'abcd']
 
     out = text.columnize(items, displaywidth=80)
-    nt.assert_equal(out, 'aaaaa  bbbbb  ccccc  ddddd\n')
+    assert out == "aaaaa  bbbbb  ccccc  ddddd\n"
     out = text.columnize(items, displaywidth=25)
-    nt.assert_equal(out, 'aaaaa  ccccc\nbbbbb  ddddd\n')
+    assert out == "aaaaa  ccccc\nbbbbb  ddddd\n"
     out = text.columnize(items, displaywidth=12)
-    nt.assert_equal(out, 'aaaaa  ccccc\nbbbbb  ddddd\n')
+    assert out == "aaaaa  ccccc\nbbbbb  ddddd\n"
     out = text.columnize(items, displaywidth=10)
-    nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\nddddd\n')
+    assert out == "aaaaa\nbbbbb\nccccc\nddddd\n"
 
     out = text.columnize(items, row_first=True, displaywidth=80)
-    nt.assert_equal(out, 'aaaaa  bbbbb  ccccc  ddddd\n')
+    assert out == "aaaaa  bbbbb  ccccc  ddddd\n"
     out = text.columnize(items, row_first=True, displaywidth=25)
-    nt.assert_equal(out, 'aaaaa  bbbbb\nccccc  ddddd\n')
+    assert out == "aaaaa  bbbbb\nccccc  ddddd\n"
     out = text.columnize(items, row_first=True, displaywidth=12)
-    nt.assert_equal(out, 'aaaaa  bbbbb\nccccc  ddddd\n')
+    assert out == "aaaaa  bbbbb\nccccc  ddddd\n"
     out = text.columnize(items, row_first=True, displaywidth=10)
-    nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\nddddd\n')
+    assert out == "aaaaa\nbbbbb\nccccc\nddddd\n"
 
     out = text.columnize(items, displaywidth=40, spread=True)
-    nt.assert_equal(out, 'aaaaa      bbbbb      ccccc      ddddd\n')
+    assert out == "aaaaa      bbbbb      ccccc      ddddd\n"
     out = text.columnize(items, displaywidth=20, spread=True)
-    nt.assert_equal(out, 'aaaaa          ccccc\nbbbbb          ddddd\n')
+    assert out == "aaaaa          ccccc\nbbbbb          ddddd\n"
     out = text.columnize(items, displaywidth=12, spread=True)
-    nt.assert_equal(out, 'aaaaa  ccccc\nbbbbb  ddddd\n')
+    assert out == "aaaaa  ccccc\nbbbbb  ddddd\n"
     out = text.columnize(items, displaywidth=10, spread=True)
-    nt.assert_equal(out, 'aaaaa\nbbbbb\nccccc\nddddd\n')
+    assert out == "aaaaa\nbbbbb\nccccc\nddddd\n"
 
 
 def test_columnize_random():
@@ -77,38 +77,43 @@ def test_columnize_random():
                 print("size of each element :\n %s" % rand_len)
                 assert False, "row_first={0}".format(row_first)
 
+
+# TODO: pytest mark.parametrize once nose removed.
 def test_columnize_medium():
     """Test with inputs than shouldn't be wider than 80"""
     size = 40
     items = [l*size for l in 'abc']
     for row_first in [True, False]:
         out = text.columnize(items, row_first=row_first, displaywidth=80)
-        nt.assert_equal(out, '\n'.join(items+['']), "row_first={0}".format(row_first))
+        assert out == "\n".join(items + [""]), "row_first={0}".format(row_first)
 
+
+# TODO: pytest mark.parametrize once nose removed.
 def test_columnize_long():
     """Test columnize with inputs longer than the display window"""
     size = 11
     items = [l*size for l in 'abc']
     for row_first in [True, False]:
-        out = text.columnize(items, row_first=row_first, displaywidth=size-1)
-        nt.assert_equal(out, '\n'.join(items+['']), "row_first={0}".format(row_first))
+        out = text.columnize(items, row_first=row_first, displaywidth=size - 1)
+        assert out == "\n".join(items + [""]), "row_first={0}".format(row_first)
+
 
 def eval_formatter_check(f):
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os, u=u"café", b="café")
     s = f.format("{n} {n//4} {stuff.split()[0]}", **ns)
-    nt.assert_equal(s, "12 3 hello")
+    assert s == "12 3 hello"
     s = f.format(' '.join(['{n//%i}'%i for i in range(1,8)]), **ns)
-    nt.assert_equal(s, "12 6 4 3 2 2 1")
+    assert s == "12 6 4 3 2 2 1"
     s = f.format('{[n//i for i in range(1,8)]}', **ns)
-    nt.assert_equal(s, "[12, 6, 4, 3, 2, 2, 1]")
+    assert s == "[12, 6, 4, 3, 2, 2, 1]"
     s = f.format("{stuff!s}", **ns)
-    nt.assert_equal(s, ns['stuff'])
+    assert s == ns["stuff"]
     s = f.format("{stuff!r}", **ns)
-    nt.assert_equal(s, repr(ns['stuff']))
-    
+    assert s == repr(ns["stuff"])
+
     # Check with unicode:
     s = f.format("{u}", **ns)
-    nt.assert_equal(s, ns['u'])
+    assert s == ns["u"]
     # This decodes in a platform dependent manner, but it shouldn't error out
     s = f.format("{b}", **ns)
         
@@ -117,25 +122,25 @@ def eval_formatter_check(f):
 def eval_formatter_slicing_check(f):
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
     s = f.format(" {stuff.split()[:]} ", **ns)
-    nt.assert_equal(s, " ['hello', 'there'] ")
+    assert s == " ['hello', 'there'] "
     s = f.format(" {stuff.split()[::-1]} ", **ns)
-    nt.assert_equal(s, " ['there', 'hello'] ")
+    assert s == " ['there', 'hello'] "
     s = f.format("{stuff[::2]}", **ns)
-    nt.assert_equal(s, ns['stuff'][::2])
-    
+    assert s == ns["stuff"][::2]
+
     nt.assert_raises(SyntaxError, f.format, "{n:x}", **ns)
 
 def eval_formatter_no_slicing_check(f):
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
     
     s = f.format('{n:x} {pi**2:+f}', **ns)
-    nt.assert_equal(s, "c +9.869604")
-    
-    s = f.format('{stuff[slice(1,4)]}', **ns)
-    nt.assert_equal(s, 'ell')
+    assert s == "c +9.869604"
+
+    s = f.format("{stuff[slice(1,4)]}", **ns)
+    assert s == "ell"
 
     s = f.format("{a[:]}", a=[1, 2])
-    nt.assert_equal(s, "[1, 2]")
+    assert s == "[1, 2]"
 
 def test_eval_formatter():
     f = text.EvalFormatter()
@@ -154,15 +159,15 @@ def test_dollar_formatter():
     
     ns = dict(n=12, pi=math.pi, stuff='hello there', os=os)
     s = f.format("$n", **ns)
-    nt.assert_equal(s, "12")
+    assert s == "12"
     s = f.format("$n.real", **ns)
-    nt.assert_equal(s, "12")
+    assert s == "12"
     s = f.format("$n/{stuff[:5]}", **ns)
-    nt.assert_equal(s, "12/hello")
+    assert s == "12/hello"
     s = f.format("$n $$HOME", **ns)
-    nt.assert_equal(s, "12 $HOME")
+    assert s == "12 $HOME"
     s = f.format("${foo}", foo="HOME")
-    nt.assert_equal(s, "$HOME")
+    assert s == "$HOME"
 
 
 def test_strip_email():
@@ -176,25 +181,25 @@ def test_strip_email():
 ...   return x+1
 ... 
 >>> zz = f(2.5)"""
-    nt.assert_equal(text.strip_email_quotes(src), cln)
+    assert text.strip_email_quotes(src) == cln
 
 
 def test_strip_email2():
     src = '> > > list()'
     cln = 'list()'
-    nt.assert_equal(text.strip_email_quotes(src), cln)
+    assert text.strip_email_quotes(src) == cln
 
 def test_LSString():
     lss = text.LSString("abc\ndef")
-    nt.assert_equal(lss.l, ['abc', 'def'])
-    nt.assert_equal(lss.s, 'abc def')
+    assert lss.l == ["abc", "def"]
+    assert lss.s == "abc def"
     lss = text.LSString(os.getcwd())
     nt.assert_is_instance(lss.p[0], Path)
 
 def test_SList():
-    sl = text.SList(['a 11', 'b 1', 'a 2'])
-    nt.assert_equal(sl.n, 'a 11\nb 1\na 2')
-    nt.assert_equal(sl.s, 'a 11 b 1 a 2')
-    nt.assert_equal(sl.grep(lambda x: x.startswith('a')), text.SList(['a 11', 'a 2']))
-    nt.assert_equal(sl.fields(0), text.SList(['a', 'b', 'a']))
-    nt.assert_equal(sl.sort(field=1, nums=True), text.SList(['b 1', 'a 2', 'a 11']))
+    sl = text.SList(["a 11", "b 1", "a 2"])
+    assert sl.n == "a 11\nb 1\na 2"
+    assert sl.s == "a 11 b 1 a 2"
+    assert sl.grep(lambda x: x.startswith("a")) == text.SList(["a 11", "a 2"])
+    assert sl.fields(0) == text.SList(["a", "b", "a"])
+    assert sl.sort(field=1, nums=True) == text.SList(["b 1", "a 2", "a 11"])


### PR DESCRIPTION
This tries semi-automatically (aka vim macro with quick visual inspection), to replace many `nt.assert_equal(ex1, ex2)`, with the equivalent `assert ex1 == ex2` for pytest,  with a couple of other changes when I saw the opportunity. for example `is None`, instead of `== None`, and a couple of annotations with `TODO :@pytest.mark.parametrize`