### PR TITLE
nose2pytest migration batch 1

### DIFF
--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -38,7 +38,8 @@ def test_alias_args_error():
     with capture_output() as cap:
         _ip.run_cell('parts 1')
 
-    assert cap.stderr.split(':')[0] == 'UsageError'
+    assert cap.stderr.split(":")[0] == "UsageError"
+
 
 def test_alias_args_commented():
     """Check that alias correctly ignores 'commented out' args"""

--- a/IPython/core/tests/test_alias.py
+++ b/IPython/core/tests/test_alias.py
@@ -1,6 +1,6 @@
 from IPython.utils.capture import capture_output
 
-import nose.tools as nt
+import pytest
 
 def test_alias_lifecycle():
     name = 'test_alias1'
@@ -9,8 +9,8 @@ def test_alias_lifecycle():
     am.clear_aliases()
     am.define_alias(name, cmd)
     assert am.is_alias(name)
-    nt.assert_equal(am.retrieve_alias(name), cmd)
-    nt.assert_in((name, cmd), am.aliases)
+    assert am.retrieve_alias(name) == cmd
+    assert (name, cmd) in am.aliases
     
     # Test running the alias
     orig_system = _ip.system
@@ -19,16 +19,16 @@ def test_alias_lifecycle():
     try:
         _ip.run_cell('%{}'.format(name))
         result = [c.strip() for c in result]
-        nt.assert_equal(result, [cmd])
+        assert result == [cmd]
     finally:
         _ip.system = orig_system
     
     # Test removing the alias
     am.undefine_alias(name)
     assert not am.is_alias(name)
-    with nt.assert_raises(ValueError):
+    with pytest.raises(ValueError):
         am.retrieve_alias(name)
-    nt.assert_not_in((name, cmd), am.aliases)
+    assert (name, cmd) not in am.aliases
     
 
 def test_alias_args_error():
@@ -38,7 +38,7 @@ def test_alias_args_error():
     with capture_output() as cap:
         _ip.run_cell('parts 1')
 
-    nt.assert_equal(cap.stderr.split(':')[0], 'UsageError')
+    assert cap.stderr.split(':')[0] == 'UsageError'
 
 def test_alias_args_commented():
     """Check that alias correctly ignores 'commented out' args"""
@@ -62,4 +62,4 @@ def test_alias_args_commented_nargs():
     assert am.is_alias(alias_name)
     
     thealias = am.get_alias(alias_name)
-    nt.assert_equal(thealias.nargs, 1)
+    assert thealias.nargs == 1

--- a/IPython/core/tests/test_compilerop.py
+++ b/IPython/core/tests/test_compilerop.py
@@ -30,13 +30,13 @@ from IPython.core import compilerop
 def test_code_name():
     code = 'x=1'
     name = compilerop.code_name(code)
-    assert name.startswith('<ipython-input-0')
+    assert name.startswith("<ipython-input-0")
 
 
 def test_code_name2():
     code = 'x=1'
     name = compilerop.code_name(code, 9)
-    assert name.startswith('<ipython-input-9')
+    assert name.startswith("<ipython-input-9")
 
 
 def test_cache():

--- a/IPython/core/tests/test_compilerop.py
+++ b/IPython/core/tests/test_compilerop.py
@@ -18,7 +18,7 @@ import linecache
 import sys
 
 # Third-party imports
-import nose.tools as nt
+import pytest
 
 # Our own imports
 from IPython.core import compilerop
@@ -30,13 +30,13 @@ from IPython.core import compilerop
 def test_code_name():
     code = 'x=1'
     name = compilerop.code_name(code)
-    nt.assert_true(name.startswith('<ipython-input-0'))
+    assert name.startswith('<ipython-input-0')
 
 
 def test_code_name2():
     code = 'x=1'
     name = compilerop.code_name(code, 9)
-    nt.assert_true(name.startswith('<ipython-input-9'))
+    assert name.startswith('<ipython-input-9')
 
 
 def test_cache():
@@ -45,18 +45,18 @@ def test_cache():
     cp = compilerop.CachingCompiler()
     ncache = len(linecache.cache)
     cp.cache('x=1')
-    nt.assert_true(len(linecache.cache) > ncache)
+    assert len(linecache.cache) > ncache
 
 def test_proper_default_encoding():
     # Check we're in a proper Python 2 environment (some imports, such
     # as GTK, can change the default encoding, which can hide bugs.)
-    nt.assert_equal(sys.getdefaultencoding(), "utf-8")
+    assert sys.getdefaultencoding() == "utf-8"
 
 def test_cache_unicode():
     cp = compilerop.CachingCompiler()
     ncache = len(linecache.cache)
     cp.cache(u"t = 'žćčšđ'")
-    nt.assert_true(len(linecache.cache) > ncache)
+    assert len(linecache.cache) > ncache
 
 def test_compiler_check_cache():
     """Test the compiler properly manages the cache.

--- a/IPython/core/tests/test_inputtransformer2_line.py
+++ b/IPython/core/tests/test_inputtransformer2_line.py
@@ -3,7 +3,7 @@
 Line-based transformers are the simpler ones; token-based transformers are
 more complex. See test_inputtransformer2 for tests for token-based transformers.
 """
-import nose.tools as nt
+import pytest
 
 from IPython.core import inputtransformer2 as ipt2
 
@@ -17,7 +17,7 @@ get_ipython().run_cell_magic('foo', 'arg', 'body 1\\nbody 2\\n')
 
 def test_cell_magic():
     for sample, expected in [CELL_MAGIC]:
-        nt.assert_equal(ipt2.cell_magic(sample.splitlines(keepends=True)),
+        assert (ipt2.cell_magic(sample.splitlines(keepends=True)) ==
                         expected.splitlines(keepends=True))
 
 CLASSIC_PROMPT = ("""\
@@ -40,7 +40,7 @@ for a in range(5):
 
 def test_classic_prompt():
     for sample, expected in [CLASSIC_PROMPT, CLASSIC_PROMPT_L2]:
-        nt.assert_equal(ipt2.classic_prompt(sample.splitlines(keepends=True)),
+        assert (ipt2.classic_prompt(sample.splitlines(keepends=True)) ==
                         expected.splitlines(keepends=True))
 
 IPYTHON_PROMPT = ("""\
@@ -100,10 +100,9 @@ def test_ipython_prompt():
         IPYTHON_PROMPT_VI_INS,
         IPYTHON_PROMPT_VI_NAV,
     ]:
-        nt.assert_equal(
-            ipt2.ipython_prompt(sample.splitlines(keepends=True)),
-            expected.splitlines(keepends=True),
-        )
+        assert (
+            ipt2.ipython_prompt(sample.splitlines(keepends=True)) ==
+            expected.splitlines(keepends=True))
 
 
 INDENT_SPACES = ("""\
@@ -124,7 +123,7 @@ if True:
 
 def test_leading_indent():
     for sample, expected in [INDENT_SPACES, INDENT_TABS]:
-        nt.assert_equal(ipt2.leading_indent(sample.splitlines(keepends=True)),
+        assert (ipt2.leading_indent(sample.splitlines(keepends=True)) ==
                         expected.splitlines(keepends=True))
 
 LEADING_EMPTY_LINES = ("""\
@@ -151,8 +150,8 @@ ONLY_EMPTY_LINES = ("""\
 
 def test_leading_empty_lines():
     for sample, expected in [LEADING_EMPTY_LINES, ONLY_EMPTY_LINES]:
-        nt.assert_equal(
-                ipt2.leading_empty_lines(sample.splitlines(keepends=True)),
+        assert (
+                ipt2.leading_empty_lines(sample.splitlines(keepends=True)) ==
                 expected.splitlines(keepends=True))
 
 CRLF_MAGIC = ([
@@ -163,4 +162,4 @@ CRLF_MAGIC = ([
 
 def test_crlf_magic():
     for sample, expected in [CRLF_MAGIC]:
-        nt.assert_equal(ipt2.cell_magic(sample), expected)
+        assert ipt2.cell_magic(sample) == expected

--- a/IPython/core/tests/test_inputtransformer2_line.py
+++ b/IPython/core/tests/test_inputtransformer2_line.py
@@ -17,8 +17,9 @@ get_ipython().run_cell_magic('foo', 'arg', 'body 1\\nbody 2\\n')
 
 def test_cell_magic():
     for sample, expected in [CELL_MAGIC]:
-        assert (ipt2.cell_magic(sample.splitlines(keepends=True)) ==
-                        expected.splitlines(keepends=True))
+        assert ipt2.cell_magic(sample.splitlines(keepends=True)) == expected.splitlines(
+            keepends=True
+        )
 
 CLASSIC_PROMPT = ("""\
 >>> for a in range(5):
@@ -40,8 +41,9 @@ for a in range(5):
 
 def test_classic_prompt():
     for sample, expected in [CLASSIC_PROMPT, CLASSIC_PROMPT_L2]:
-        assert (ipt2.classic_prompt(sample.splitlines(keepends=True)) ==
-                        expected.splitlines(keepends=True))
+        assert ipt2.classic_prompt(
+            sample.splitlines(keepends=True)
+        ) == expected.splitlines(keepends=True)
 
 IPYTHON_PROMPT = ("""\
 In [1]: for a in range(5):
@@ -100,9 +102,9 @@ def test_ipython_prompt():
         IPYTHON_PROMPT_VI_INS,
         IPYTHON_PROMPT_VI_NAV,
     ]:
-        assert (
-            ipt2.ipython_prompt(sample.splitlines(keepends=True)) ==
-            expected.splitlines(keepends=True))
+        assert ipt2.ipython_prompt(
+            sample.splitlines(keepends=True)
+        ) == expected.splitlines(keepends=True)
 
 
 INDENT_SPACES = ("""\
@@ -123,8 +125,9 @@ if True:
 
 def test_leading_indent():
     for sample, expected in [INDENT_SPACES, INDENT_TABS]:
-        assert (ipt2.leading_indent(sample.splitlines(keepends=True)) ==
-                        expected.splitlines(keepends=True))
+        assert ipt2.leading_indent(
+            sample.splitlines(keepends=True)
+        ) == expected.splitlines(keepends=True)
 
 LEADING_EMPTY_LINES = ("""\
     \t
@@ -150,9 +153,9 @@ ONLY_EMPTY_LINES = ("""\
 
 def test_leading_empty_lines():
     for sample, expected in [LEADING_EMPTY_LINES, ONLY_EMPTY_LINES]:
-        assert (
-                ipt2.leading_empty_lines(sample.splitlines(keepends=True)) ==
-                expected.splitlines(keepends=True))
+        assert ipt2.leading_empty_lines(
+            sample.splitlines(keepends=True)
+        ) == expected.splitlines(keepends=True)
 
 CRLF_MAGIC = ([
     "%%ls\r\n"

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -5,7 +5,7 @@
 #-----------------------------------------------------------------------------
 
 # third party
-import nose.tools as nt
+import pytest
 
 # our own packages
 
@@ -31,8 +31,8 @@ def test_reset():
     
     # Finally, check that all namespaces have only as many variables as we
     # expect to find in them:
-    nt.assert_equal(len(ip.user_ns), nvars_user_ns)
-    nt.assert_equal(len(ip.user_ns_hidden), nvars_hidden)
+    assert len(ip.user_ns) == nvars_user_ns
+    assert len(ip.user_ns_hidden) == nvars_hidden
 
 
 # Tests for reporting of exceptions in various modes, handling of SystemExit,
@@ -209,7 +209,7 @@ def test_run_cell():
     ip.run_cell('a = 10\na+=1')
     ip.run_cell('assert a == 11\nassert 1')
 
-    nt.assert_equal(ip.user_ns['a'], 11)
+    assert ip.user_ns['a'] == 11
     complex = textwrap.dedent("""
     if 1:
         print "hello"
@@ -233,6 +233,6 @@ def test_run_cell():
 def test_db():
     """Test the internal database used for variable persistence."""
     ip.db['__unittest_'] = 12
-    nt.assert_equal(ip.db['__unittest_'], 12)
+    assert ip.db['__unittest_'] == 12
     del ip.db['__unittest_']
     assert '__unittest_' not in ip.db

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -87,35 +87,36 @@ ZeroDivisionError: ...
 
 def doctest_tb_verbose():
     """
-In [5]: xmode verbose
-Exception reporting mode: Verbose
+    In [5]: xmode verbose
+    Exception reporting mode: Verbose
 
-In [6]: run simpleerr.py
----------------------------------------------------------------------------
-ZeroDivisionError                         Traceback (most recent call last)
-<BLANKLINE>
-... in <module>
-     29     except IndexError:
-     30         mode = 'div'
----> 32     bar(mode)
-        mode = 'div'
-<BLANKLINE>
-... in bar(mode='div')
-     14     "bar"
-     15     if mode=='div':
----> 16         div0()
-     17     elif mode=='exit':
-     18         try:
-<BLANKLINE>
-... in div0()
-      6     x = 1
-      7     y = 0
-----> 8     x/y
-        x = 1
-        y = 0
-<BLANKLINE>
-ZeroDivisionError: ...
-      """
+    In [6]: run simpleerr.py
+    ---------------------------------------------------------------------------
+    ZeroDivisionError                         Traceback (most recent call last)
+    <BLANKLINE>
+    ... in <module>
+         29     except IndexError:
+         30         mode = 'div'
+    ---> 32     bar(mode)
+            mode = 'div'
+    <BLANKLINE>
+    ... in bar(mode='div')
+         14     "bar"
+         15     if mode=='div':
+    ---> 16         div0()
+         17     elif mode=='exit':
+         18         try:
+    <BLANKLINE>
+    ... in div0()
+          6     x = 1
+          7     y = 0
+    ----> 8     x/y
+            x = 1
+            y = 0
+    <BLANKLINE>
+    ZeroDivisionError: ...
+    """
+
 
 # TODO : Marc 2021 – this seem to fail due
 # to upstream changes in CI for whatever reason.
@@ -206,11 +207,13 @@ ZeroDivisionError: ...
 
 def test_run_cell():
     import textwrap
-    ip.run_cell('a = 10\na+=1')
-    ip.run_cell('assert a == 11\nassert 1')
 
-    assert ip.user_ns['a'] == 11
-    complex = textwrap.dedent("""
+    ip.run_cell("a = 10\na+=1")
+    ip.run_cell("assert a == 11\nassert 1")
+
+    assert ip.user_ns["a"] == 11
+    complex = textwrap.dedent(
+        """
     if 1:
         print "hello"
         if 1:
@@ -232,7 +235,7 @@ def test_run_cell():
 
 def test_db():
     """Test the internal database used for variable persistence."""
-    ip.db['__unittest_'] = 12
-    assert ip.db['__unittest_'] == 12
-    del ip.db['__unittest_']
-    assert '__unittest_' not in ip.db
+    ip.db["__unittest_"] = 12
+    assert ip.db["__unittest_"] == 12
+    del ip.db["__unittest_"]
+    assert "__unittest_" not in ip.db

--- a/IPython/core/tests/test_logger.py
+++ b/IPython/core/tests/test_logger.py
@@ -12,8 +12,8 @@ def test_logstart_inaccessible_file():
     except IOError:
         pass
     else:
-        assert False                    # The try block should never pass.
-    
+        assert False  # The try block should never pass.
+
     try:
         _ip.run_cell("a=1")                 # Check it doesn't try to log this
     finally:

--- a/IPython/core/tests/test_logger.py
+++ b/IPython/core/tests/test_logger.py
@@ -2,8 +2,8 @@
 """Test IPython.core.logger"""
 
 import os.path
+import pytest
 
-import nose.tools as nt
 from IPython.utils.tempdir import TemporaryDirectory
 
 def test_logstart_inaccessible_file():
@@ -12,7 +12,7 @@ def test_logstart_inaccessible_file():
     except IOError:
         pass
     else:
-        nt.assert_true(False)           # The try block should never pass.
+        assert False                    # The try block should never pass.
     
     try:
         _ip.run_cell("a=1")                 # Check it doesn't try to log this

--- a/IPython/core/tests/test_magic_arguments.py
+++ b/IPython/core/tests/test_magic_arguments.py
@@ -74,45 +74,62 @@ def foo(self, args):
 
 
 def test_magic_arguments():
-    assert magic_foo1.__doc__ == '::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
-    assert getattr(magic_foo1, 'argcmd_name', None) == None
-    assert real_name(magic_foo1) == 'foo1'
-    assert magic_foo1(None, '') == argparse.Namespace(foo=None)
-    assert hasattr(magic_foo1, 'has_arguments')
+    assert (
+        magic_foo1.__doc__
+        == "::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n"
+    )
+    assert getattr(magic_foo1, "argcmd_name", None) == None
+    assert real_name(magic_foo1) == "foo1"
+    assert magic_foo1(None, "") == argparse.Namespace(foo=None)
+    assert hasattr(magic_foo1, "has_arguments")
 
-    assert magic_foo2.__doc__ == '::\n\n  %foo2\n\n A docstring.\n'
-    assert getattr(magic_foo2, 'argcmd_name', None) == None
-    assert real_name(magic_foo2) == 'foo2'
-    assert magic_foo2(None, '') == argparse.Namespace()
-    assert hasattr(magic_foo2, 'has_arguments')
+    assert magic_foo2.__doc__ == "::\n\n  %foo2\n\n A docstring.\n"
+    assert getattr(magic_foo2, "argcmd_name", None) == None
+    assert real_name(magic_foo2) == "foo2"
+    assert magic_foo2(None, "") == argparse.Namespace()
+    assert hasattr(magic_foo2, "has_arguments")
 
-    assert magic_foo3.__doc__ == '::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n'
-    assert getattr(magic_foo3, 'argcmd_name', None) == None
-    assert real_name(magic_foo3) == 'foo3'
-    assert (magic_foo3(None, '') ==
-                       argparse.Namespace(bar=None, baz=None, foo=None))
-    assert hasattr(magic_foo3, 'has_arguments')
+    assert (
+        magic_foo3.__doc__
+        == "::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n"
+    )
+    assert getattr(magic_foo3, "argcmd_name", None) == None
+    assert real_name(magic_foo3) == "foo3"
+    assert magic_foo3(None, "") == argparse.Namespace(bar=None, baz=None, foo=None)
+    assert hasattr(magic_foo3, "has_arguments")
 
-    assert magic_foo4.__doc__ == '::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
-    assert getattr(magic_foo4, 'argcmd_name', None) == None
-    assert real_name(magic_foo4) == 'foo4'
-    assert magic_foo4(None, '') == argparse.Namespace()
-    assert hasattr(magic_foo4, 'has_arguments')
+    assert (
+        magic_foo4.__doc__
+        == "::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n"
+    )
+    assert getattr(magic_foo4, "argcmd_name", None) == None
+    assert real_name(magic_foo4) == "foo4"
+    assert magic_foo4(None, "") == argparse.Namespace()
+    assert hasattr(magic_foo4, "has_arguments")
 
-    assert magic_foo5.__doc__ == '::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
-    assert getattr(magic_foo5, 'argcmd_name', None) == 'frobnicate'
-    assert real_name(magic_foo5) == 'frobnicate'
-    assert magic_foo5(None, '') == argparse.Namespace(foo=None)
-    assert hasattr(magic_foo5, 'has_arguments')
+    assert (
+        magic_foo5.__doc__
+        == "::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n"
+    )
+    assert getattr(magic_foo5, "argcmd_name", None) == "frobnicate"
+    assert real_name(magic_foo5) == "frobnicate"
+    assert magic_foo5(None, "") == argparse.Namespace(foo=None)
+    assert hasattr(magic_foo5, "has_arguments")
 
-    assert magic_magic_foo.__doc__ == '::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
-    assert getattr(magic_magic_foo, 'argcmd_name', None) == None
-    assert real_name(magic_magic_foo) == 'magic_foo'
-    assert magic_magic_foo(None, '') == argparse.Namespace(foo=None)
-    assert hasattr(magic_magic_foo, 'has_arguments')
+    assert (
+        magic_magic_foo.__doc__
+        == "::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n"
+    )
+    assert getattr(magic_magic_foo, "argcmd_name", None) == None
+    assert real_name(magic_magic_foo) == "magic_foo"
+    assert magic_magic_foo(None, "") == argparse.Namespace(foo=None)
+    assert hasattr(magic_magic_foo, "has_arguments")
 
-    assert foo.__doc__ == '::\n\n  %foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
-    assert getattr(foo, 'argcmd_name', None) == None
-    assert real_name(foo) == 'foo'
-    assert foo(None, '') == argparse.Namespace(foo=None)
-    assert hasattr(foo, 'has_arguments')
+    assert (
+        foo.__doc__
+        == "::\n\n  %foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n"
+    )
+    assert getattr(foo, "argcmd_name", None) == None
+    assert real_name(foo) == "foo"
+    assert foo(None, "") == argparse.Namespace(foo=None)
+    assert hasattr(foo, "has_arguments")

--- a/IPython/core/tests/test_magic_arguments.py
+++ b/IPython/core/tests/test_magic_arguments.py
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------
 
 import argparse
-from nose.tools import assert_equal
+import pytest
 
 from IPython.core.magic_arguments import (argument, argument_group, kwds,
     magic_arguments, parse_argstring, real_name)
@@ -74,45 +74,45 @@ def foo(self, args):
 
 
 def test_magic_arguments():
-    assert_equal(magic_foo1.__doc__, '::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_foo1, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_foo1), 'foo1')
-    assert_equal(magic_foo1(None, ''), argparse.Namespace(foo=None))
+    assert magic_foo1.__doc__ == '::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
+    assert getattr(magic_foo1, 'argcmd_name', None) == None
+    assert real_name(magic_foo1) == 'foo1'
+    assert magic_foo1(None, '') == argparse.Namespace(foo=None)
     assert hasattr(magic_foo1, 'has_arguments')
 
-    assert_equal(magic_foo2.__doc__, '::\n\n  %foo2\n\n A docstring.\n')
-    assert_equal(getattr(magic_foo2, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_foo2), 'foo2')
-    assert_equal(magic_foo2(None, ''), argparse.Namespace())
+    assert magic_foo2.__doc__ == '::\n\n  %foo2\n\n A docstring.\n'
+    assert getattr(magic_foo2, 'argcmd_name', None) == None
+    assert real_name(magic_foo2) == 'foo2'
+    assert magic_foo2(None, '') == argparse.Namespace()
     assert hasattr(magic_foo2, 'has_arguments')
 
-    assert_equal(magic_foo3.__doc__, '::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n')
-    assert_equal(getattr(magic_foo3, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_foo3), 'foo3')
-    assert_equal(magic_foo3(None, ''),
+    assert magic_foo3.__doc__ == '::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n'
+    assert getattr(magic_foo3, 'argcmd_name', None) == None
+    assert real_name(magic_foo3) == 'foo3'
+    assert (magic_foo3(None, '') ==
                        argparse.Namespace(bar=None, baz=None, foo=None))
     assert hasattr(magic_foo3, 'has_arguments')
 
-    assert_equal(magic_foo4.__doc__, '::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_foo4, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_foo4), 'foo4')
-    assert_equal(magic_foo4(None, ''), argparse.Namespace())
+    assert magic_foo4.__doc__ == '::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
+    assert getattr(magic_foo4, 'argcmd_name', None) == None
+    assert real_name(magic_foo4) == 'foo4'
+    assert magic_foo4(None, '') == argparse.Namespace()
     assert hasattr(magic_foo4, 'has_arguments')
 
-    assert_equal(magic_foo5.__doc__, '::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_foo5, 'argcmd_name', None), 'frobnicate')
-    assert_equal(real_name(magic_foo5), 'frobnicate')
-    assert_equal(magic_foo5(None, ''), argparse.Namespace(foo=None))
+    assert magic_foo5.__doc__ == '::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
+    assert getattr(magic_foo5, 'argcmd_name', None) == 'frobnicate'
+    assert real_name(magic_foo5) == 'frobnicate'
+    assert magic_foo5(None, '') == argparse.Namespace(foo=None)
     assert hasattr(magic_foo5, 'has_arguments')
 
-    assert_equal(magic_magic_foo.__doc__, '::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(magic_magic_foo, 'argcmd_name', None), None)
-    assert_equal(real_name(magic_magic_foo), 'magic_foo')
-    assert_equal(magic_magic_foo(None, ''), argparse.Namespace(foo=None))
+    assert magic_magic_foo.__doc__ == '::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
+    assert getattr(magic_magic_foo, 'argcmd_name', None) == None
+    assert real_name(magic_magic_foo) == 'magic_foo'
+    assert magic_magic_foo(None, '') == argparse.Namespace(foo=None)
     assert hasattr(magic_magic_foo, 'has_arguments')
 
-    assert_equal(foo.__doc__, '::\n\n  %foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n')
-    assert_equal(getattr(foo, 'argcmd_name', None), None)
-    assert_equal(real_name(foo), 'foo')
-    assert_equal(foo(None, ''), argparse.Namespace(foo=None))
+    assert foo.__doc__ == '::\n\n  %foo [-f FOO]\n\n A docstring.\n\noptional arguments:\n  -f FOO, --foo FOO  an argument\n'
+    assert getattr(foo, 'argcmd_name', None) == None
+    assert real_name(foo) == 'foo'
+    assert foo(None, '') == argparse.Namespace(foo=None)
     assert hasattr(foo, 'has_arguments')

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
-import nose.tools as nt
+import pytest
 
 from IPython.core.prefilter import AutocallChecker
 
@@ -19,7 +19,7 @@ def test_prefilter():
              ]
 
     for raw, correct in pairs:
-        nt.assert_equal(ip.prefilter(raw), correct)
+        assert ip.prefilter(raw) == correct
 
 def test_prefilter_shadowed():
     def dummy_magic(line): pass
@@ -33,14 +33,14 @@ def test_prefilter_shadowed():
         for name in ['if', 'zip', 'get_ipython']: # keyword, builtin, global
             ip.register_magic_function(dummy_magic, magic_name=name)
             res = ip.prefilter(name+' foo')
-            nt.assert_equal(res, name+' foo')
+            assert res == name+' foo'
             del ip.magics_manager.magics['line'][name]
 
         # These should be transformed
         for name in ['fi', 'piz', 'nohtypi_teg']:
             ip.register_magic_function(dummy_magic, magic_name=name)
             res = ip.prefilter(name+' foo')
-            nt.assert_not_equal(res, name+' foo')
+            assert res != name+' foo'
             del ip.magics_manager.magics['line'][name]
 
     finally:
@@ -52,9 +52,9 @@ def test_autocall_binops():
     f = lambda x: x
     ip.user_ns['f'] = f
     try:
-        nt.assert_equal(ip.prefilter('f 1'),'f(1)')
+        assert ip.prefilter('f 1') =='f(1)'
         for t in ['f +1', 'f -1']:
-            nt.assert_equal(ip.prefilter(t), t)
+            assert ip.prefilter(t) == t
 
         # Run tests again with a more permissive exclude_regexp, which will
         # allow transformation of binary operations ('f -1' -> 'f(-1)').
@@ -66,8 +66,8 @@ def test_autocall_binops():
             ac.exclude_regexp = r'^[,&^\|\*/]|^is |^not |^in |^and |^or '
             pm.sort_checkers()
 
-            nt.assert_equal(ip.prefilter('f -1'), 'f(-1)')
-            nt.assert_equal(ip.prefilter('f +1'), 'f(+1)')
+            assert ip.prefilter('f -1') == 'f(-1)'
+            assert ip.prefilter('f +1') == 'f(+1)'
         finally:
             pm.unregister_checker(ac)
     finally:
@@ -88,7 +88,7 @@ def test_issue_114():
     try:
         for mgk in ip.magics_manager.lsmagic()['line']:
             raw = template % mgk
-            nt.assert_equal(ip.prefilter(raw), raw)
+            assert ip.prefilter(raw) == raw
     finally:
         ip.prefilter_manager.multi_line_specials = msp
 
@@ -121,7 +121,7 @@ def test_autocall_should_support_unicode():
     ip.magic('autocall 2')
     ip.user_ns['π'] = lambda x: x
     try:
-        nt.assert_equal(ip.prefilter('π 3'),'π(3)')
+        assert ip.prefilter('π 3') =='π(3)'
     finally:
         ip.magic('autocall 0')
         del ip.user_ns['π']

--- a/IPython/core/tests/test_prefilter.py
+++ b/IPython/core/tests/test_prefilter.py
@@ -32,16 +32,16 @@ def test_prefilter_shadowed():
         # These should not be transformed - they are shadowed by other names
         for name in ['if', 'zip', 'get_ipython']: # keyword, builtin, global
             ip.register_magic_function(dummy_magic, magic_name=name)
-            res = ip.prefilter(name+' foo')
-            assert res == name+' foo'
-            del ip.magics_manager.magics['line'][name]
+            res = ip.prefilter(name + " foo")
+            assert res == name + " foo"
+            del ip.magics_manager.magics["line"][name]
 
         # These should be transformed
         for name in ['fi', 'piz', 'nohtypi_teg']:
             ip.register_magic_function(dummy_magic, magic_name=name)
-            res = ip.prefilter(name+' foo')
-            assert res != name+' foo'
-            del ip.magics_manager.magics['line'][name]
+            res = ip.prefilter(name + " foo")
+            assert res != name + " foo"
+            del ip.magics_manager.magics["line"][name]
 
     finally:
         ip.automagic = prev_automagic_state
@@ -52,8 +52,8 @@ def test_autocall_binops():
     f = lambda x: x
     ip.user_ns['f'] = f
     try:
-        assert ip.prefilter('f 1') =='f(1)'
-        for t in ['f +1', 'f -1']:
+        assert ip.prefilter("f 1") == "f(1)"
+        for t in ["f +1", "f -1"]:
             assert ip.prefilter(t) == t
 
         # Run tests again with a more permissive exclude_regexp, which will
@@ -66,8 +66,8 @@ def test_autocall_binops():
             ac.exclude_regexp = r'^[,&^\|\*/]|^is |^not |^in |^and |^or '
             pm.sort_checkers()
 
-            assert ip.prefilter('f -1') == 'f(-1)'
-            assert ip.prefilter('f +1') == 'f(+1)'
+            assert ip.prefilter("f -1") == "f(-1)"
+            assert ip.prefilter("f +1") == "f(+1)"
         finally:
             pm.unregister_checker(ac)
     finally:
@@ -121,7 +121,7 @@ def test_autocall_should_support_unicode():
     ip.magic('autocall 2')
     ip.user_ns['π'] = lambda x: x
     try:
-        assert ip.prefilter('π 3') =='π(3)'
+        assert ip.prefilter("π 3") == "π(3)"
     finally:
         ip.magic('autocall 0')
         del ip.user_ns['π']


### PR DESCRIPTION
Most of the changes done by sed -i s/nt.assert/assert/ -> use
nose2pytest script from `nose2pytest` module from
https://github.com/schollii/nose2pytest/
At the end some manual changes (mostly about proper pytest module
import).

Signed-off-by: Tomasz Kłoczko <kloczek@github.com>