### PR TITLE
Fix formatting for the core.interactiveshell documentation

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1886,6 +1886,9 @@ class InteractiveShell(SingletonConfigurable):
             exception or returns an invalid result, it will be immediately
             disabled.
 
+        Notes
+        -----
+
         WARNING: by putting in your own exception handler into IPython's main
         execution loop, you run a very good chance of nasty crashes.  This
         facility should only be used if you really know what you are doing."""


### PR DESCRIPTION
This fixes the issue desribed in #12981 for 7.x branch.

Before
![Selection_309](https://user-images.githubusercontent.com/1616237/131851318-5095a54c-c58b-4b24-a87b-f165e0c6f072.png)

After
![Selection_308](https://user-images.githubusercontent.com/1616237/131851337-e8286ab4-38e0-459e-a534-ab7e4f788b46.png)
