### PR TITLE
Improve formatting of %time documentation

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1235,22 +1235,25 @@ class ExecutionMagics(Magics):
           CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
           Wall time: 0.00
 
-          Note that the time needed by Python to compile the given expression
-          will be reported if it is more than 0.1s.  In this example, the
-          actual exponentiation is done by Python at compilation time, so while
-          the expression can take a noticeable amount of time to compute, that
-          time is purely due to the compilation:
 
-          In [5]: %time 3**9999;
-          CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
-          Wall time: 0.00 s
+        .. note::
+            The time needed by Python to compile the given expression will be
+            reported if it is more than 0.1s.
 
-          In [6]: %time 3**999999;
-          CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
-          Wall time: 0.00 s
-          Compiler : 0.78 s
-          """
+            In the example below, the actual exponentiation is done by Python
+            at compilation time, so while the expression can take a noticeable
+            amount of time to compute, that time is purely due to the
+            compilation::
 
+                In [5]: %time 3**9999;
+                CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
+                Wall time: 0.00 s
+
+                In [6]: %time 3**999999;
+                CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
+                Wall time: 0.00 s
+                Compiler : 0.78 s
+        """
         # fail immediately if the given expression can't be compiled
         
         if line and cell:


### PR DESCRIPTION
Improves the formatting of `%time` docs by fixing the issues with code blocks and adding an actual admonition.

Before:

![image](https://user-images.githubusercontent.com/6691643/132428546-3f016347-0340-4464-938a-7344f7480e8f.png)

After:

![image](https://user-images.githubusercontent.com/6691643/132428400-3a790010-b174-41c2-8d1c-300123c9af4c.png)
