### PR TITLE
Backport PR #13094 on branch 7.x (Fix virtual environment user warning for lower case pathes)"

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -931,7 +931,7 @@ class InteractiveShell(SingletonConfigurable):
             p_venv = p_venv[2:]
 
         if sys.platform == "win32":
-            # In Windows there might be a mixture of lower-case and mixed-case pathes
+            # On Windows there might be a mixture of lower-case and mixed-case paths
             p_venv = str(p_venv).lower()
             paths = [str(p).lower() for p in paths]
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -930,6 +930,11 @@ class InteractiveShell(SingletonConfigurable):
         elif len(p_venv) >= 2 and p_venv[1] == ':':
             p_venv = p_venv[2:]
 
+        if sys.platform == "win32":
+            # In Windows there might be a mixture of lower-case and mixed-case pathes
+            p_venv = str(p_venv).lower()
+            paths = [str(p).lower() for p in paths]
+
         if any(p_venv in p for p in paths):
             # Running properly in the virtualenv, don't need to do anything
             return


### PR DESCRIPTION
See #13094.

Slight changes were required since 7.x is not pathlibed, but it does not have impact on the overall behavior.