### PR TITLE
enable autoplay in embed youtube player

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -263,13 +263,15 @@ class IFrame(object):
             src="{src}{params}"
             frameborder="0"
             allowfullscreen
+            {extra}
         ></iframe>
         """
 
-    def __init__(self, src, width, height, **kwargs):
+    def __init__(self, src, width, height, extra="", **kwargs):
         self.src = src
         self.width = width
         self.height = height
+        self.extra = extra
         self.params = kwargs
 
     def _repr_html_(self):
@@ -282,7 +284,9 @@ class IFrame(object):
         return self.iframe.format(src=self.src,
                                   width=self.width,
                                   height=self.height,
-                                  params=params)
+                                  params=params,
+                                  extra=self.extra)
+
 
 class YouTubeVideo(IFrame):
     """Class for embedding a YouTube Video in an IPython session, based on its video id.
@@ -310,11 +314,13 @@ class YouTubeVideo(IFrame):
     will be inserted in the document.
     """
 
-    def __init__(self, id, width=400, height=300, **kwargs):
+    def __init__(self, id, width=400, height=300, allow_autoplay=False, **kwargs):
         self.id=id
         src = "https://www.youtube.com/embed/{0}".format(id)
+        if allow_autoplay:
+            kwargs.update(autoplay=1, extra='allow="autoplay"')
         super(YouTubeVideo, self).__init__(src, width, height, **kwargs)
-    
+
     def _repr_jpeg_(self):
         # Deferred import
         from urllib.request import urlopen

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -8,7 +8,7 @@ from os import walk, sep, fsdecode
 
 from IPython.core.display import DisplayObject, TextDisplayObject
 
-from typing import Tuple
+from typing import Tuple, Iterable
 
 __all__ = ['Audio', 'IFrame', 'YouTubeVideo', 'VimeoVideo', 'ScribdDocument',
            'FileLink', 'FileLinks', 'Code']
@@ -263,15 +263,18 @@ class IFrame(object):
             src="{src}{params}"
             frameborder="0"
             allowfullscreen
-            {extra}
+            {extras}
         ></iframe>
         """
 
-    def __init__(self, src, width, height, extra="", **kwargs):
+    def __init__(self, src, width, height, extras: Iterable[str] = None, **kwargs):
+        if extras is None:
+            extras = []
+
         self.src = src
         self.width = width
         self.height = height
-        self.extra = extra
+        self.extras = extras
         self.params = kwargs
 
     def _repr_html_(self):
@@ -286,7 +289,7 @@ class IFrame(object):
             width=self.width,
             height=self.height,
             params=params,
-            extra=self.extra,
+            extras=" ".join(self.extras),
         )
 
 
@@ -320,7 +323,7 @@ class YouTubeVideo(IFrame):
         self.id=id
         src = "https://www.youtube.com/embed/{0}".format(id)
         if allow_autoplay:
-            kwargs.update(autoplay=1, extra='allow="autoplay"')
+            kwargs.update(autoplay=1, extras=['allow="autoplay"'])
         super(YouTubeVideo, self).__init__(src, width, height, **kwargs)
 
     def _repr_jpeg_(self):

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -281,11 +281,13 @@ class IFrame(object):
             params = "?" + urlencode(self.params)
         else:
             params = ""
-        return self.iframe.format(src=self.src,
-                                  width=self.width,
-                                  height=self.height,
-                                  params=params,
-                                  extra=self.extra)
+        return self.iframe.format(
+            src=self.src,
+            width=self.width,
+            height=self.height,
+            params=params,
+            extra=self.extra,
+        )
 
 
 class YouTubeVideo(IFrame):

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -323,7 +323,8 @@ class YouTubeVideo(IFrame):
         self.id=id
         src = "https://www.youtube.com/embed/{0}".format(id)
         if allow_autoplay:
-            kwargs.update(autoplay=1, extras=['allow="autoplay"'])
+            extras = list(kwargs.get("extras", [])) + ['allow="autoplay"']
+            kwargs.update(autoplay=1, extras=extras)
         super(YouTubeVideo, self).__init__(src, width, height, **kwargs)
 
     def _repr_jpeg_(self):

--- a/docs/source/whatsnew/pr/enable-to-add-extra-attrs-to-iframe.rst
+++ b/docs/source/whatsnew/pr/enable-to-add-extra-attrs-to-iframe.rst
@@ -1,0 +1,37 @@
+Enable to add extra attributes to iframe
+========================================
+
+You can add any extra attributes to the ``<iframe>`` tag
+since the argument ``extras`` has been added to the ``IFrame`` class.
+for example::
+
+    In [1]: from IPython.display import IFrame
+
+    In [2]: print(IFrame(src="src", width=300, height=300, extras=["hello", "world"])._repr_html_())
+
+            <iframe
+                width="300"
+                height="300"
+                src="src"
+                frameborder="0"
+                allowfullscreen
+                hello world
+            ></iframe>
+
+Using it, you can autoplay ``YouTubeVideo`` by adding ``'allow="autoplay"'``,
+even in browsers that disable it by default, such as Google Chrome.
+And, you can write it more briefly by using the argument ``allow_autoplay``.
+::
+
+    In [1]: from IPython.display import YouTubeVideo
+
+    In [2]: print(YouTubeVideo("video-id", allow_autoplay=True)._repr_html_())
+
+            <iframe
+                width="400"
+                height="300"
+                src="https://www.youtube.com/embed/video-id?autoplay=1"
+                frameborder="0"
+                allowfullscreen
+                allow="autoplay"
+            ></iframe>


### PR DESCRIPTION
Added a new argument to autoplay YouTubeVideo in Chrome without muting it.
The official Chrome Developers blog on this topic is here:
https://developer.chrome.com/blog/autoplay/