### PR TITLE
Fix broken ipyparallel's refs

### DIFF
--- a/docs/source/development/parallel_connections.rst
+++ b/docs/source/development/parallel_connections.rst
@@ -5,4 +5,4 @@ Connection Diagrams of The IPython ZMQ Cluster
 ==============================================
 
 IPython parallel has moved to ipyparallel -
-see :ref:`ipyparallel:parallel_connections` for the documentation.
+see :ref:`ipyparallel:/reference/connections.md` for the documentation.

--- a/docs/source/development/parallel_messages.rst
+++ b/docs/source/development/parallel_messages.rst
@@ -5,4 +5,4 @@ Messaging for Parallel Computing
 ================================
 
 IPython parallel has moved to ipyparallel -
-see :ref:`ipyparallel:parallel_messages` for the documentation.
+see :ref:`ipyparallel:/reference/messages.md` for the documentation.

--- a/docs/source/whatsnew/version0.11.rst
+++ b/docs/source/whatsnew/version0.11.rst
@@ -309,7 +309,7 @@ be started by calling ``ipython qtconsole``. The protocol is :ref:`documented
 <messaging>`.
 
 The parallel computing framework has also been rewritten using ZMQ. The
-protocol is described :ref:`here <parallel_messages>`, and the code is in the
+protocol is described :ref:`here <ipyparallel:/reference/messages.md>`, and the code is in the
 new :mod:`IPython.parallel` module.
 
 .. _python3_011:


### PR DESCRIPTION
Looks like the newest version of `ipyparallel` changed some refs in the docs, breaking the build here. See ipython/ipyparallel#575

Big thanks to @yuji96 for providing this fix!