### PR TITLE
Make the virtualenv warning informative

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -948,9 +948,15 @@ class InteractiveShell(SingletonConfigurable):
             virtual_env = str(virtual_env_path).format(*p_ver)
 
         warn(
-            "Attempting to work in a virtualenv. If you encounter problems, "
-            "please install IPython inside the virtualenv."
+            "IPython is running from a different environment than the "
+            "currently active one.\n"
+
+            # Paths in these two f-strings start in the same column to aid in
+            # differentiating between them.
+            f"Active environment: {p_venv}\n"
+            f"This interpretter:  {sys.executable}\n"
         )
+
         import site
         sys.path.insert(0, virtual_env)
         site.addsitedir(virtual_env)


### PR DESCRIPTION
This is something that will make more sense after I finish prettifying the warnings. Sending it as a draft so that I don't forget about it.

This is the warning that is probably the most often triggered one, and so it deserves to be a bit more revealing.
I'm wondering if I'll be able to fit an instruction to use `hash -d`/`rehash` somewhere in there, since it's a virtualenv gotcha that many people don't know about, we'll see.