### PR TITLE
Adapt to all sorts of drive names for cygwin

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -924,7 +924,9 @@ class InteractiveShell(SingletonConfigurable):
         
         # In Cygwin paths like "c:\..." and '\cygdrive\c\...' are possible
         if str(p_venv).startswith("\\cygdrive"):
-            p_venv = "C:" / Path(str(p_venv)[11:])
+            p_venv = Path(str(p_venv))
+            drive_name = p_venv.parts[2]
+            p_venv = (drive_name + ":/") / Path(*p_venv.parts[3:])
 
         if any(p_venv == p.parents[1] for p in paths):
             # Our exe is inside or has access to the virtualenv, don't need to do anything.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -923,8 +923,7 @@ class InteractiveShell(SingletonConfigurable):
             paths.append(p.resolve())
         
         # In Cygwin paths like "c:\..." and '\cygdrive\c\...' are possible
-        if str(p_venv).startswith("\\cygdrive"):
-            p_venv = Path(str(p_venv))
+        if p_venv.parts[1] == "cygdrive":
             drive_name = p_venv.parts[2]
             p_venv = (drive_name + ":/") / Path(*p_venv.parts[3:])
 


### PR DESCRIPTION
Earlier implementation (from https://github.com/ipython/ipython/pull/13140) assumed the drive name to be `C` and ignored the possibility of it being different. Drive names could also be greater than 1 in length. This possibility should also be considered.

The old implementation of taking `p_venv[11:]` to get rid of "\cygdrive\c" won't work with drives having names greater than 1.