### PR TITLE
Add history file to debugger

### DIFF
--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -1,18 +1,22 @@
 import asyncio
+import os
 import sys
 import threading
 
 from IPython.core.debugger import Pdb
+
 
 from IPython.core.completer import IPCompleter
 from .ptutils import IPythonPTCompleter
 from .shortcuts import create_ipython_shortcuts
 from . import embed
 
+from pathlib import Path
 from pygments.token import Token
 from prompt_toolkit.shortcuts.prompt import PromptSession
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.formatted_text import PygmentsTokens
+from prompt_toolkit.history import InMemoryHistory, FileHistory
 
 from prompt_toolkit import __version__ as ptk_version
 PTK3 = ptk_version.startswith('3.')
@@ -54,6 +58,17 @@ class TerminalPdb(Pdb):
             # end add completer.
 
             self._ptcomp = IPythonPTCompleter(compl)
+
+        # setup history only when we start pdb
+        if self.shell.debugger_history is None:
+            if self.shell.debugger_history_file is not None:
+
+                p = Path(self.shell.debugger_history_file).expanduser()
+                if not p.exists():
+                    p.touch()
+                self.debugger_history = FileHistory(os.path.expanduser(str(p)))
+            else:
+                self.debugger_history = InMemoryHistory()
 
         options = dict(
             message=(lambda: PygmentsTokens(get_prompt_tokens())),

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -124,6 +124,10 @@ class TerminalInteractiveShell(InteractiveShell):
     pt_app = None
     debugger_history = None
 
+    debugger_history_file = Unicode(
+        "~/.pdbhistory", help="File in which to store and read history"
+    ).tag(config=True)
+
     simple_prompt = Bool(_use_simple_prompt,
         help="""Use `raw_input` for the REPL, without completion and prompt colors.
 
@@ -566,7 +570,6 @@ class TerminalInteractiveShell(InteractiveShell):
         self.init_term_title()
         self.keep_running = True
 
-        self.debugger_history = InMemoryHistory()
 
     def ask_exit(self):
         self.keep_running = False


### PR DESCRIPTION
This adds a configurable
`InteractiveShell.debugger_history_file=...` which default to
`~/.pdbhistory`, that store what is typed in ipdb;
this make it easy to persist across sessions.

Some of the logic is moved into the debugger itself so that existence
and creation of file is used only once Pdb is started.
