### PR TITLE
Convert WindowsPath to str in init_virtualenv.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -932,7 +932,7 @@ class InteractiveShell(SingletonConfigurable):
             return
 
         if sys.platform == "win32":
-            virtual_env = Path(os.environ["VIRTUAL_ENV"], "Lib", "site-packages")
+            virtual_env = str(Path(os.environ["VIRTUAL_ENV"], "Lib", "site-packages"))
         else:
             virtual_env_path = Path(
                 os.environ["VIRTUAL_ENV"], "lib", "python{}.{}", "site-packages"


### PR DESCRIPTION
Hi, I was investigating problems described in #13165 and I have found similar behavior in current master on windows. I have also prepared backport for 7.x, but it might be a greater issue.