### PR TITLE
use _exec wrapper for qt win32 inputhook

### DIFF
--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -64,7 +64,7 @@ def inputhook(context):
         timer.timeout.connect(event_loop.quit)
         while not context.input_is_ready():
             timer.start(50)  # 50 ms
-            event_loop.exec_()
+            _exec(event_loop)
             timer.stop()
     else:
         # On POSIX platforms, we can use a file descriptor to quit the event


### PR DESCRIPTION
fixes #13116

PyQt6 does not have ```exec_()```.
PySide6 >= 6.1.x deprecates ```exec_()```.