### PR TITLE
create ipython_dir if not exists

### DIFF
--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -160,7 +160,7 @@ def test_get_ipython_dir_7():
 @skip_win32
 def test_get_ipython_dir_8():
     """test_get_ipython_dir_8, test / home directory"""
-    if not os.path.isdir('/') or not os.access('/', os.W_OK):
+    if not os.access('/', os.W_OK):
         # test only when HOME directory actually writable
         return
 

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -160,7 +160,7 @@ def test_get_ipython_dir_7():
 @skip_win32
 def test_get_ipython_dir_8():
     """test_get_ipython_dir_8, test / home directory"""
-    if not os.access('/', os.W_OK):
+    if not os.access("/", os.W_OK):
         # test only when HOME directory actually writable
         return
 

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -160,6 +160,10 @@ def test_get_ipython_dir_7():
 @skip_win32
 def test_get_ipython_dir_8():
     """test_get_ipython_dir_8, test / home directory"""
+    if not os.path.isdir('/') or not os.access('/', os.W_OK):
+        # test only when HOME directory actually writable
+        return
+
     with patch.object(paths, '_writable_dir', lambda path: bool(path)), \
             patch.object(paths, 'get_xdg_dir', return_value=None), \
             modified_env({

--- a/IPython/paths.py
+++ b/IPython/paths.py
@@ -71,6 +71,8 @@ def get_ipython_dir() -> str:
             warn("IPython parent '{0}' is not a writable location,"
                     " using a temp directory.".format(parent))
             ipdir = tempfile.mkdtemp()
+        else:
+            os.makedirs(ipdir)
     assert isinstance(ipdir, str), "all path manipulation should be str(unicode), but are not."
     return ipdir
 


### PR DESCRIPTION
Create the ipython_dir (e.g.: `~/.ipython`) if it does not exists.
Encountered this issue when using ipyparallel, which scans  `ipython_dir` directly: https://github.com/ipython/ipyparallel/blob/main/ipyparallel/util.py#L666