### PR TITLE
Fix wrong inspect.signature call

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1542,7 +1542,7 @@ class IPCompleter(Completer):
                   inspect.Parameter.POSITIONAL_OR_KEYWORD)
 
         try:
-            sig = inspect.signature(call_obj)
+            sig = inspect.signature(obj)
             ret.extend(k for k, v in sig.parameters.items() if
                        v.kind in _keeps)
         except ValueError:


### PR DESCRIPTION
This PR lets CPython find the best signature for a class, because it does so with *a much more complete solution* than IPython does (support for `__signature__`, `__text_signature__`...)

Since at least Python 3.6, CPython uses https://github.com/python/cpython/blob/2c56c97f015a7ea81719615ddcf3c745fba5b4f3/Lib/inspect.py#L2284 which already takes care of finding all the `__call__`, `__new__` and `__init__` functions when the type is a class (IPython is using its own code for that, just above). The only reason to not remove IPython's custom logic is because it also checks the `__doc__`, which `inspect.signature` does not, but assuming this fails, it is much more reliable to call `inspect.signature` on the class directly rather than on its `__init__` or `__new__` function.

As a matter of fact, we're having a bug in our CLI due to `__signature__` being not supported: `Class.__signature__` is never looked at which creates inconsistencies