### PR TITLE
Address pathlib issues in `init_virtualenv`

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -953,7 +953,7 @@ class InteractiveShell(SingletonConfigurable):
             "please install IPython inside the virtualenv."
         )
         import site
-        sys.path.insert(0, virtual_env)
+        sys.path.insert(0, str(virtual_env))
         site.addsitedir(virtual_env)
 
     #-------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses an issue in `init_virtualenv` related to inserting a `pathlib.Path` object into `sys.path`: 

Always insert a `str` into `sys.path` to avoid the inability to load packages from the virtualenv due to the existence of `pathlib.Path` object in `sys.path`. Fixes #13165 