### PR TITLE
Use codecov Github action v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
       run: |
         pytest
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2


### PR DESCRIPTION
The v1 action is deprecated due to security concerns, and will stop working in a few months:

https://github.com/marketplace/actions/codecov
https://about.codecov.io/blog/introducing-codecovs-new-uploader/