### PR TITLE
Fix unintentional skipping of module level doctests

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -142,7 +142,7 @@ from traitlets.config.configurable import Configurable
 import __main__
 
 # skip module docstests
-skip_doctest = True
+__skip_doctest__ = True
 
 try:
     import jedi

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -116,6 +116,8 @@ from IPython.utils import coloransi, py3compat
 from IPython.core.excolors import exception_colors
 from IPython.testing.skipdoctest import skip_doctest
 
+# skip module docstests
+__skip_doctest__ = True
 
 prompt = 'ipdb> '
 

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -97,7 +97,7 @@ Some of the known remaining caveats are:
 - C extension modules cannot be reloaded, and so cannot be autoreloaded.
 """
 
-skip_doctest = True
+__skip_doctest__ = True
 
 # -----------------------------------------------------------------------------
 #  Copyright (C) 2000 Thomas Heller

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -125,7 +125,7 @@ class DocTestFinder(doctest.DocTestFinder):
         add them to `tests`.
         """
         print('_find for:', obj, name, module)  # dbg
-        if hasattr(obj,"skip_doctest"):
+        if bool(getattr(obj, "__skip_doctest__", False)):
             #print 'SKIPPING DOCTEST FOR:',obj  # dbg
             obj = DocTestSkip(obj)
         

--- a/IPython/testing/skipdoctest.py
+++ b/IPython/testing/skipdoctest.py
@@ -15,5 +15,5 @@ def skip_doctest(f):
     This decorator allows you to mark a function whose docstring you wish to
     omit from testing, while preserving the docstring for introspection, help,
     etc."""
-    f.skip_doctest = True
+    f.__skip_doctest__ = True
     return f


### PR DESCRIPTION
Importing `skip_doctest` decorator unintentionally marks for skipping a module level doctest. It happens because doctests discovery only checks whether a variable with name `skip_doctest` is presented without checking the type.

I have renamed the 'magic' variable name to `__skip_doctest__` to resolve the name clash, and also made the check actually depend on the variable content.

The module level doctest in `core/debugger.py` was previously unintentionally skipped and now is disabled because it contains syntax/name errors.