### PR TITLE
Do not use mutables as default arguments

### DIFF
--- a/docs/sphinxext/github.py
+++ b/docs/sphinxext/github.py
@@ -51,7 +51,7 @@ def make_link_node(rawtext, app, type, slug, options):
                            **options)
     return node
 
-def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def ghissue_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a GitHub issue.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -66,6 +66,8 @@ def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param options: Directive options for customization.
     :param content: The directive content for customization.
     """
+    if options is None:
+        options = {}
 
     try:
         issue_num = int(text)
@@ -92,7 +94,7 @@ def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = make_link_node(rawtext, app, category, str(issue_num), options)
     return [node], []
 
-def ghuser_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def ghuser_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a GitHub user.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -107,13 +109,16 @@ def ghuser_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param options: Directive options for customization.
     :param content: The directive content for customization.
     """
+    if options is None:
+        options = {}
+
     app = inliner.document.settings.env.app
     #info('user link %r' % text)
     ref = 'https://www.github.com/' + text
     node = nodes.reference(rawtext, text, refuri=ref, **options)
     return [node], []
 
-def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+def ghcommit_role(name, rawtext, text, lineno, inliner, options=None, content=None):
     """Link to a GitHub commit.
 
     Returns 2 part tuple containing list of nodes to insert into the
@@ -128,6 +133,9 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param options: Directive options for customization.
     :param content: The directive content for customization.
     """
+    if options is None:
+        options = {}
+
     app = inliner.document.settings.env.app
     #info('user link %r' % text)
     try:


### PR DESCRIPTION
Articles that discuss why mutable default arguments should be avoided:
* [Python Mutable Defaults Are The Source of All Evil](https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/)
* [Using a mutable default value as an argument](https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html)
* [Python Pitfall: Mutable Default Arguments](https://towardsdatascience.com/python-pitfall-mutable-default-arguments-9385e8265422)
* ...

Noticed in https://github.com/matplotlib/matplotlib/pull/21402 while fixing the matplotlib file `docs/sphinxext/github.py` which had been copied over from IPython (https://github.com/matplotlib/matplotlib/commit/820985ad65be943568512dc20ae3eca4a3a0f273).
