### PR TITLE
Pathlib in IPython/paths.py

### DIFF
--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -84,7 +84,7 @@ def test_get_ipython_dir_3():
         ), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
-        nt.assert_equal(ipdir, str(Path(tmphome.name) / ".ipython"))
+        nt.assert_equal(ipdir, str((Path(tmphome.name) / ".ipython").resolve()))
         if sys.platform != "darwin":
             nt.assert_equal(len(w), 1)
             nt.assert_in("Moving", str(w[0]))

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -44,27 +44,27 @@ def teardown_module():
     shutil.rmtree(TMP_TEST_DIR)
 
 def patch_get_home_dir(dirpath):
-    return patch.object(paths, 'get_home_dir', return_value=dirpath)
+    return patch.object(paths, "get_home_dir", return_value=dirpath)
 
 
 def test_get_ipython_dir_1():
     """test_get_ipython_dir_1, Testcase to see if we can call get_ipython_dir without Exceptions."""
     env_ipdir = str(Path("someplace") / ".ipython")
-    with patch.object(paths, '_writable_dir', return_value=True), \
-            modified_env({'IPYTHONDIR': env_ipdir}):
+    with patch.object(paths, "_writable_dir", return_value=True), \
+            modified_env({"IPYTHONDIR": env_ipdir}):
         ipdir = paths.get_ipython_dir()
 
     nt.assert_equal(ipdir, str(Path(env_ipdir).resolve()))
 
 def test_get_ipython_dir_2():
     """test_get_ipython_dir_2, Testcase to see if we can call get_ipython_dir without Exceptions."""
-    with patch_get_home_dir('someplace'), \
-            patch.object(paths, 'get_xdg_dir', return_value=None), \
-            patch.object(paths, '_writable_dir', return_value=True), \
-            patch('os.name', "posix"), \
-            modified_env({'IPYTHON_DIR': None,
-                          'IPYTHONDIR': None,
-                          'XDG_CONFIG_HOME': None
+    with patch_get_home_dir("someplace"), \
+            patch.object(paths, "get_xdg_dir", return_value=None), \
+            patch.object(paths, "_writable_dir", return_value=True), \
+            patch("os.name", "posix"), \
+            modified_env({"IPYTHON_DIR": None,
+                          "IPYTHONDIR": None,
+                          "XDG_CONFIG_HOME": None
                          }):
         ipdir = paths.get_ipython_dir()
 
@@ -76,25 +76,25 @@ def test_get_ipython_dir_3():
     tmphome = TemporaryDirectory()
     try:
         with patch_get_home_dir(tmphome.name), \
-                patch('os.name', 'posix'), \
+                patch("os.name", "posix"), \
                 modified_env({
-                    'IPYTHON_DIR': None,
-                    'IPYTHONDIR': None,
-                    'XDG_CONFIG_HOME': XDG_TEST_DIR,
+                    "IPYTHON_DIR": None,
+                    "IPYTHONDIR": None,
+                    "XDG_CONFIG_HOME": XDG_TEST_DIR,
                 }), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
         nt.assert_equal(ipdir, str(Path(tmphome.name) / ".ipython"))
-        if sys.platform != 'darwin':
+        if sys.platform != "darwin":
             nt.assert_equal(len(w), 1)
-            nt.assert_in('Moving', str(w[0]))
+            nt.assert_in("Moving", str(w[0]))
     finally:
         tmphome.cleanup()
 
 def test_get_ipython_dir_4():
     """test_get_ipython_dir_4, warn if XDG and home both exist."""
     with patch_get_home_dir(HOME_TEST_DIR), \
-            patch('os.name', 'posix'):
+            patch("os.name", "posix"):
         try:
             os.mkdir(Path(XDG_TEST_DIR) / "ipython")
         except OSError as e:
@@ -103,21 +103,21 @@ def test_get_ipython_dir_4():
 
 
         with modified_env({
-            'IPYTHON_DIR': None,
-            'IPYTHONDIR': None,
-            'XDG_CONFIG_HOME': XDG_TEST_DIR,
+            "IPYTHON_DIR": None,
+            "IPYTHONDIR": None,
+            "XDG_CONFIG_HOME": XDG_TEST_DIR,
         }), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
         nt.assert_equal(ipdir, str(Path(HOME_TEST_DIR) / ".ipython"))
-        if sys.platform != 'darwin':
+        if sys.platform != "darwin":
             nt.assert_equal(len(w), 1)
-            nt.assert_in('Ignoring', str(w[0]))
+            nt.assert_in("Ignoring", str(w[0]))
 
 def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
     with patch_get_home_dir(HOME_TEST_DIR), \
-            patch('os.name', 'posix'):
+            patch("os.name", "posix"):
         try:
             os.rmdir(Path(XDG_TEST_DIR) / "ipython")
         except OSError as e:
@@ -125,9 +125,9 @@ def test_get_ipython_dir_5():
                 raise
 
         with modified_env({
-            'IPYTHON_DIR': None,
-            'IPYTHONDIR': None,
-            'XDG_CONFIG_HOME': XDG_TEST_DIR,
+            "IPYTHON_DIR": None,
+            "IPYTHONDIR": None,
+            "XDG_CONFIG_HOME": XDG_TEST_DIR,
         }):
             ipdir = paths.get_ipython_dir()
 
@@ -140,12 +140,12 @@ def test_get_ipython_dir_6():
     shutil.rmtree(Path(HOME_TEST_DIR) / ".ipython")
     print(paths._writable_dir)
     with patch_get_home_dir(HOME_TEST_DIR), \
-            patch.object(paths, 'get_xdg_dir', return_value=xdg), \
-            patch('os.name', 'posix'), \
+            patch.object(paths, "get_xdg_dir", return_value=xdg), \
+            patch("os.name", "posix"), \
             modified_env({
-                'IPYTHON_DIR': None,
-                'IPYTHONDIR': None,
-                'XDG_CONFIG_HOME': None,
+                "IPYTHON_DIR": None,
+                "IPYTHONDIR": None,
+                "XDG_CONFIG_HOME": None,
             }), warnings.catch_warnings(record=True) as w:
         ipdir = paths.get_ipython_dir()
 
@@ -169,22 +169,22 @@ def test_get_ipython_dir_8():
         # test only when HOME directory actually writable
         return
 
-    with patch.object(paths, '_writable_dir', lambda path: bool(path)), \
-            patch.object(paths, 'get_xdg_dir', return_value=None), \
+    with patch.object(paths, "_writable_dir", lambda path: bool(path)), \
+            patch.object(paths, "get_xdg_dir", return_value=None), \
             modified_env({
-                'IPYTHON_DIR': None,
-                'IPYTHONDIR': None,
-                'HOME': '/',
+                "IPYTHON_DIR": None,
+                "IPYTHONDIR": None,
+                "HOME": "/",
             }):
-        nt.assert_equal(paths.get_ipython_dir(), '/.ipython')
+        nt.assert_equal(paths.get_ipython_dir(), "/.ipython")
 
 
 def test_get_ipython_cache_dir():
-    with modified_env({'HOME': HOME_TEST_DIR}):
-        if os.name == 'posix' and sys.platform != 'darwin':
+    with modified_env({"HOME": HOME_TEST_DIR}):
+        if os.name == "posix" and sys.platform != "darwin":
             # test default
             os.makedirs(Path(HOME_TEST_DIR) / ".cache")
-            with modified_env({'XDG_CACHE_HOME': None}):
+            with modified_env({"XDG_CACHE_HOME": None}):
                 ipdir = paths.get_ipython_cache_dir()
             nt.assert_equal(str(Path(HOME_TEST_DIR) / ".cache" / "ipython"), ipdir)
             assert_isdir(ipdir)
@@ -204,5 +204,5 @@ def test_get_ipython_package_dir():
 
 
 def test_get_ipython_module_path():
-    ipapp_path = paths.get_ipython_module_path('IPython.terminal.ipapp')
+    ipapp_path = paths.get_ipython_module_path("IPython.terminal.ipapp")
     assert_isfile(ipapp_path)

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -50,22 +50,22 @@ def patch_get_home_dir(dirpath):
 def test_get_ipython_dir_1():
     """test_get_ipython_dir_1, Testcase to see if we can call get_ipython_dir without Exceptions."""
     env_ipdir = str(Path("someplace") / ".ipython")
-    with patch.object(paths, "_writable_dir", return_value=True), \
-            modified_env({"IPYTHONDIR": env_ipdir}):
+    with patch.object(paths, "_writable_dir", return_value=True), modified_env(
+        {"IPYTHONDIR": env_ipdir}
+    ):
         ipdir = paths.get_ipython_dir()
 
     nt.assert_equal(ipdir, str(Path(env_ipdir).resolve()))
 
 def test_get_ipython_dir_2():
     """test_get_ipython_dir_2, Testcase to see if we can call get_ipython_dir without Exceptions."""
-    with patch_get_home_dir("someplace"), \
-            patch.object(paths, "get_xdg_dir", return_value=None), \
-            patch.object(paths, "_writable_dir", return_value=True), \
-            patch("os.name", "posix"), \
-            modified_env({"IPYTHON_DIR": None,
-                          "IPYTHONDIR": None,
-                          "XDG_CONFIG_HOME": None
-                         }):
+    with patch_get_home_dir("someplace"), patch.object(
+        paths, "get_xdg_dir", return_value=None
+    ), patch.object(paths, "_writable_dir", return_value=True), patch(
+        "os.name", "posix"
+    ), modified_env(
+        {"IPYTHON_DIR": None, "IPYTHONDIR": None, "XDG_CONFIG_HOME": None}
+    ):
         ipdir = paths.get_ipython_dir()
 
     nt.assert_equal(ipdir, str((Path("someplace") / ".ipython").resolve()))
@@ -75,13 +75,13 @@ def test_get_ipython_dir_3():
     """test_get_ipython_dir_3, move XDG if defined, and .ipython doesn't exist."""
     tmphome = TemporaryDirectory()
     try:
-        with patch_get_home_dir(tmphome.name), \
-                patch("os.name", "posix"), \
-                modified_env({
-                    "IPYTHON_DIR": None,
-                    "IPYTHONDIR": None,
-                    "XDG_CONFIG_HOME": XDG_TEST_DIR,
-                }), warnings.catch_warnings(record=True) as w:
+        with patch_get_home_dir(tmphome.name), patch("os.name", "posix"), modified_env(
+            {
+                "IPYTHON_DIR": None,
+                "IPYTHONDIR": None,
+                "XDG_CONFIG_HOME": XDG_TEST_DIR,
+            }
+        ), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
         nt.assert_equal(ipdir, str(Path(tmphome.name) / ".ipython"))
@@ -93,20 +93,20 @@ def test_get_ipython_dir_3():
 
 def test_get_ipython_dir_4():
     """test_get_ipython_dir_4, warn if XDG and home both exist."""
-    with patch_get_home_dir(HOME_TEST_DIR), \
-            patch("os.name", "posix"):
+    with patch_get_home_dir(HOME_TEST_DIR), patch("os.name", "posix"):
         try:
             os.mkdir(Path(XDG_TEST_DIR) / "ipython")
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
 
-
-        with modified_env({
-            "IPYTHON_DIR": None,
-            "IPYTHONDIR": None,
-            "XDG_CONFIG_HOME": XDG_TEST_DIR,
-        }), warnings.catch_warnings(record=True) as w:
+        with modified_env(
+            {
+                "IPYTHON_DIR": None,
+                "IPYTHONDIR": None,
+                "XDG_CONFIG_HOME": XDG_TEST_DIR,
+            }
+        ), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
         nt.assert_equal(ipdir, str(Path(HOME_TEST_DIR) / ".ipython"))
@@ -116,19 +116,20 @@ def test_get_ipython_dir_4():
 
 def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
-    with patch_get_home_dir(HOME_TEST_DIR), \
-            patch("os.name", "posix"):
+    with patch_get_home_dir(HOME_TEST_DIR), patch("os.name", "posix"):
         try:
             os.rmdir(Path(XDG_TEST_DIR) / "ipython")
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
 
-        with modified_env({
-            "IPYTHON_DIR": None,
-            "IPYTHONDIR": None,
-            "XDG_CONFIG_HOME": XDG_TEST_DIR,
-        }):
+        with modified_env(
+            {
+                "IPYTHON_DIR": None,
+                "IPYTHONDIR": None,
+                "XDG_CONFIG_HOME": XDG_TEST_DIR,
+            }
+        ):
             ipdir = paths.get_ipython_dir()
 
         nt.assert_equal(ipdir, IP_TEST_DIR)
@@ -139,14 +140,17 @@ def test_get_ipython_dir_6():
     os.mkdir(xdg)
     shutil.rmtree(Path(HOME_TEST_DIR) / ".ipython")
     print(paths._writable_dir)
-    with patch_get_home_dir(HOME_TEST_DIR), \
-            patch.object(paths, "get_xdg_dir", return_value=xdg), \
-            patch("os.name", "posix"), \
-            modified_env({
-                "IPYTHON_DIR": None,
-                "IPYTHONDIR": None,
-                "XDG_CONFIG_HOME": None,
-            }), warnings.catch_warnings(record=True) as w:
+    with patch_get_home_dir(HOME_TEST_DIR), patch.object(
+        paths, "get_xdg_dir", return_value=xdg
+    ), patch("os.name", "posix"), modified_env(
+        {
+            "IPYTHON_DIR": None,
+            "IPYTHONDIR": None,
+            "XDG_CONFIG_HOME": None,
+        }
+    ), warnings.catch_warnings(
+        record=True
+    ) as w:
         ipdir = paths.get_ipython_dir()
 
     nt.assert_equal(ipdir, str(Path(HOME_TEST_DIR) / ".ipython"))
@@ -169,13 +173,15 @@ def test_get_ipython_dir_8():
         # test only when HOME directory actually writable
         return
 
-    with patch.object(paths, "_writable_dir", lambda path: bool(path)), \
-            patch.object(paths, "get_xdg_dir", return_value=None), \
-            modified_env({
-                "IPYTHON_DIR": None,
-                "IPYTHONDIR": None,
-                "HOME": "/",
-            }):
+    with patch.object(paths, "_writable_dir", lambda path: bool(path)), patch.object(
+        paths, "get_xdg_dir", return_value=None
+    ), modified_env(
+        {
+            "IPYTHON_DIR": None,
+            "IPYTHONDIR": None,
+            "HOME": "/",
+        }
+    ):
         nt.assert_equal(paths.get_ipython_dir(), "/.ipython")
 
 

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -54,16 +54,13 @@ def test_get_ipython_dir_1():
         {"IPYTHONDIR": env_ipdir}
     ):
         ipdir = paths.get_ipython_dir()
-
-    nt.assert_equal(ipdir, str(Path(env_ipdir).resolve()))
+        nt.assert_equal(ipdir, str(Path(env_ipdir).resolve()))
 
 def test_get_ipython_dir_2():
     """test_get_ipython_dir_2, Testcase to see if we can call get_ipython_dir without Exceptions."""
     with patch_get_home_dir("someplace"), patch.object(
         paths, "get_xdg_dir", return_value=None
-    ), patch.object(paths, "_writable_dir", return_value=True), patch(
-        "os.name", "posix"
-    ), modified_env(
+    ), patch.object(paths, "_writable_dir", return_value=True), modified_env(
         {"IPYTHON_DIR": None, "IPYTHONDIR": None, "XDG_CONFIG_HOME": None}
     ):
         ipdir = paths.get_ipython_dir()
@@ -71,11 +68,12 @@ def test_get_ipython_dir_2():
     nt.assert_equal(ipdir, str((Path("someplace") / ".ipython").resolve()))
 
 
+@skip_win32
 def test_get_ipython_dir_3():
     """test_get_ipython_dir_3, move XDG if defined, and .ipython doesn't exist."""
     tmphome = TemporaryDirectory()
     try:
-        with patch_get_home_dir(tmphome.name), patch("os.name", "posix"), modified_env(
+        with patch_get_home_dir(tmphome.name), modified_env(
             {
                 "IPYTHON_DIR": None,
                 "IPYTHONDIR": None,
@@ -91,9 +89,11 @@ def test_get_ipython_dir_3():
     finally:
         tmphome.cleanup()
 
+
+@skip_win32
 def test_get_ipython_dir_4():
     """test_get_ipython_dir_4, warn if XDG and home both exist."""
-    with patch_get_home_dir(HOME_TEST_DIR), patch("os.name", "posix"):
+    with patch_get_home_dir(HOME_TEST_DIR):
         try:
             os.mkdir(Path(XDG_TEST_DIR) / "ipython")
         except OSError as e:
@@ -116,7 +116,7 @@ def test_get_ipython_dir_4():
 
 def test_get_ipython_dir_5():
     """test_get_ipython_dir_5, use .ipython if exists and XDG defined, but doesn't exist."""
-    with patch_get_home_dir(HOME_TEST_DIR), patch("os.name", "posix"):
+    with patch_get_home_dir(HOME_TEST_DIR):
         try:
             os.rmdir(Path(XDG_TEST_DIR) / "ipython")
         except OSError as e:
@@ -142,7 +142,7 @@ def test_get_ipython_dir_6():
     print(paths._writable_dir)
     with patch_get_home_dir(HOME_TEST_DIR), patch.object(
         paths, "get_xdg_dir", return_value=xdg
-    ), patch("os.name", "posix"), modified_env(
+    ), modified_env(
         {
             "IPYTHON_DIR": None,
             "IPYTHONDIR": None,
@@ -156,6 +156,7 @@ def test_get_ipython_dir_6():
     nt.assert_equal(ipdir, str(Path(HOME_TEST_DIR) / ".ipython"))
     nt.assert_equal(len(w), 0)
 
+@skip_win32
 def test_get_ipython_dir_7():
     """test_get_ipython_dir_7, test home directory expansion on IPYTHONDIR"""
     home_dir = Path("~").resolve()

--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -2,6 +2,7 @@ import tempfile, os
 
 from traitlets.config.loader import Config
 import nose.tools as nt
+from pathlib import Path
 
 
 def setup_module():
@@ -44,7 +45,10 @@ def test_store_restore():
     nt.assert_equal(ip.user_ns['foobaz'], '80')
 
     ip.magic("store -r")  # restores _dh too
-    nt.assert_in(tmpd, ip.user_ns["_dh"])
+
+    # Check against resolved paths, different strings can lead to same path
+    _user_ns = list(map(lambda x: str(Path(x).resolve()), ip.user_ns["_dh"]))
+    nt.assert_in(str(Path(tmpd).resolve()), _user_ns)
 
     os.rmdir(tmpd)
 

--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -43,8 +43,8 @@ def test_store_restore():
     nt.assert_equal(ip.user_ns['foobar'], 79)
     nt.assert_equal(ip.user_ns['foobaz'], '80')
 
-    ip.magic('store -r') # restores _dh too
-    nt.assert_in(os.path.realpath(tmpd), ip.user_ns['_dh'])
+    ip.magic("store -r")  # restores _dh too
+    nt.assert_in(tmpd, ip.user_ns["_dh"])
 
     os.rmdir(tmpd)
 

--- a/IPython/paths.py
+++ b/IPython/paths.py
@@ -28,15 +28,15 @@ def get_ipython_dir() -> str:
     env = os.environ
 
 
-    ipdir_def = '.ipython'
+    ipdir_def = ".ipython"
 
     home_dir = get_home_dir()
     xdg_dir = get_xdg_dir()
 
-    if 'IPYTHON_DIR' in env:
-        warn('The environment variable IPYTHON_DIR is deprecated since IPython 3.0. '
-                'Please use IPYTHONDIR instead.', DeprecationWarning)
-    ipdir = env.get('IPYTHONDIR', env.get('IPYTHON_DIR', None))
+    if "IPYTHON_DIR" in env:
+        warn("The environment variable IPYTHON_DIR is deprecated since IPython 3.0. "
+                "Please use IPYTHONDIR instead.", DeprecationWarning)
+    ipdir = env.get("IPYTHONDIR", env.get("IPYTHON_DIR", None))
     if ipdir is None:
         # not set explicitly, use ~/.ipython
         ipdir = Path(home_dir) / ipdir_def
@@ -48,13 +48,13 @@ def get_ipython_dir() -> str:
             if _writable_dir(xdg_ipdir):
                 cu = lambda x: compress_user(str(x))
                 if ipdir.exists():
-                    warn(('Ignoring {0} in favour of {1}. Remove {0} to '
-                        'get rid of this message').format(cu(xdg_ipdir), cu(ipdir)))
+                    warn(("Ignoring {0} in favour of {1}. Remove {0} to "
+                        "get rid of this message").format(cu(xdg_ipdir), cu(ipdir)))
                 elif xdg_ipdir.is_symlink():
-                    warn(('{0} is deprecated. Move link to {1} to '
-                        'get rid of this message').format(cu(xdg_ipdir), cu(ipdir)))
+                    warn(("{0} is deprecated. Move link to {1} to "
+                        "get rid of this message").format(cu(xdg_ipdir), cu(ipdir)))
                 else:
-                    warn('Moving {0} to {1}'.format(cu(xdg_ipdir), cu(ipdir)))
+                    warn("Moving {0} to {1}".format(cu(xdg_ipdir), cu(ipdir)))
                     shutil.move(xdg_ipdir, ipdir)
     else:
         ipdir = Path(ipdir)
@@ -69,7 +69,7 @@ def get_ipython_dir() -> str:
     elif not ipdir.exists():
         parent = ipdir.parent
         if not _writable_dir(parent):
-            # ipdir does not exist and parent isn't writable
+            # ipdir does not exist and parent isn"t writable
             warn("IPython parent '{0}' is not a writable location,"
                     " using a temp directory.".format(parent))
             ipdir = tempfile.mkdtemp()
@@ -112,12 +112,12 @@ def get_ipython_module_path(module_str):
     if module_str == "IPython":
         return str(Path(get_ipython_package_dir()) / "__init__.py")
     mod = import_item(module_str)
-    the_path = mod.__file__.replace('.pyc', '.py')
-    the_path = the_path.replace('.pyo', '.py')
+    the_path = mod.__file__.replace(".pyc", ".py")
+    the_path = the_path.replace(".pyo", ".py")
     return the_path
 
 
-def locate_profile(profile='default'):
+def locate_profile(profile="default"):
     """Find the path to the folder associated with a given profile.
 
     I.e. find $IPYTHONDIR/profile_whatever.

--- a/IPython/paths.py
+++ b/IPython/paths.py
@@ -70,7 +70,10 @@ def get_ipython_dir() -> str:
     else:
         ipdir = Path(ipdir)
 
+
     ipdir = ipdir.resolve(strict=False)
+    if not ipdir.is_absolute():
+        ipdir = (Path.cwd() / ipdir).resolve(strict=False)
 
     if ipdir.exists() and not _writable_dir(ipdir):
         # ipdir exists, but is not writable

--- a/IPython/paths.py
+++ b/IPython/paths.py
@@ -34,8 +34,11 @@ def get_ipython_dir() -> str:
     xdg_dir = get_xdg_dir()
 
     if "IPYTHON_DIR" in env:
-        warn("The environment variable IPYTHON_DIR is deprecated since IPython 3.0. "
-                "Please use IPYTHONDIR instead.", DeprecationWarning)
+        warn(
+            "The environment variable IPYTHON_DIR is deprecated since IPython 3.0. "
+            "Please use IPYTHONDIR instead.",
+            DeprecationWarning,
+        )
     ipdir = env.get("IPYTHONDIR", env.get("IPYTHON_DIR", None))
     if ipdir is None:
         # not set explicitly, use ~/.ipython
@@ -48,11 +51,19 @@ def get_ipython_dir() -> str:
             if _writable_dir(xdg_ipdir):
                 cu = lambda x: compress_user(str(x))
                 if ipdir.exists():
-                    warn(("Ignoring {0} in favour of {1}. Remove {0} to "
-                        "get rid of this message").format(cu(xdg_ipdir), cu(ipdir)))
+                    warn(
+                        (
+                            "Ignoring {0} in favour of {1}. Remove {0} to "
+                            "get rid of this message"
+                        ).format(cu(xdg_ipdir), cu(ipdir))
+                    )
                 elif xdg_ipdir.is_symlink():
-                    warn(("{0} is deprecated. Move link to {1} to "
-                        "get rid of this message").format(cu(xdg_ipdir), cu(ipdir)))
+                    warn(
+                        (
+                            "{0} is deprecated. Move link to {1} to "
+                            "get rid of this message"
+                        ).format(cu(xdg_ipdir), cu(ipdir))
+                    )
                 else:
                     warn("Moving {0} to {1}".format(cu(xdg_ipdir), cu(ipdir)))
                     shutil.move(xdg_ipdir, ipdir)

--- a/IPython/utils/tests/test_tempdir.py
+++ b/IPython/utils/tests/test_tempdir.py
@@ -24,6 +24,6 @@ def test_temporary_working_directory():
     with TemporaryWorkingDirectory() as directory:
         directory_path = Path(directory)
         assert directory_path.exists()
-        assert Path.cwd() == directory_path.resolve()
+        assert Path.cwd().resolve() == directory_path.resolve()
     assert not directory_path.exists()
-    assert Path.cwd() != directory_path.resolve()
+    assert Path.cwd().resolve() != directory_path.resolve()


### PR DESCRIPTION
I have removed usage of os.path in IPython/paths.py.

I have updated tests accordingly (primarily to not use os.path).

However, there is a change, former code utilized os.path.realpath, which is not equivalent to pathlib.Path.resolve(). The former converts path to absolute. I have addressed this matter in tests, but I am not sure that it won't affect the library in general. 