### PR TITLE
removed a name shadowing pitfall

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -95,8 +95,8 @@ def find_packages():
     """
     excludes = ['deathrow', 'quarantine']
     packages = []
-    for dir,subdirs,files in os.walk('IPython'):
-        package = dir.replace(os.path.sep, '.')
+    for directory, subdirs,files in os.walk('IPython'):
+        package = directory.replace(os.path.sep, '.')
         if any(package.startswith('IPython.'+exc) for exc in excludes):
             # package is to be excluded (e.g. deathrow)
             continue


### PR DESCRIPTION
**The problem**
there was a part of the code creating a variable called 'dir', but this is the name of a built-in method and by creating this variable, the code was shadowing the method name. If for some reason this method gets called inside the context of the name shadowing event, it would throw a hard to debug bug.
That because **dir(argument)** wouldnt be a method call, but a variable being called as a method.

**The solution**
renamed the variable to **directory** 