### PR TITLE
Fix bunch of doctests

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -69,31 +69,33 @@ class Audio(DisplayObject):
     Generate a sound
 
     >>> import numpy as np
-    ... framerate = 44100
-    ... t = np.linspace(0,5,framerate*5)
-    ... data = np.sin(2*np.pi*220*t) + np.sin(2*np.pi*224*t)
-    ... Audio(data, rate=framerate)
+    >>> framerate = 44100
+    >>> t = np.linspace(0,5,framerate*5)
+    >>> data = np.sin(2*np.pi*220*t) + np.sin(2*np.pi*224*t)
+    >>> Audio(data, rate=framerate)
+    <IPython.lib.display.Audio object>
 
     Can also do stereo or more channels
 
     >>> dataleft = np.sin(2*np.pi*220*t)
-    ... dataright = np.sin(2*np.pi*224*t)
-    ... Audio([dataleft, dataright], rate=framerate)
+    >>> dataright = np.sin(2*np.pi*224*t)
+    >>> Audio([dataleft, dataright], rate=framerate)
+    <IPython.lib.display.Audio object>
 
     From URL:
 
-    >>> Audio("http://www.nch.com.au/acm/8k16bitpcm.wav")
-    >>> Audio(url="http://www.w3schools.com/html/horse.ogg")
+    >>> Audio("http://www.nch.com.au/acm/8k16bitpcm.wav")  # doctest: +SKIP
+    >>> Audio(url="http://www.w3schools.com/html/horse.ogg")  # doctest: +SKIP
 
     From a File:
 
-    >>> Audio('/path/to/sound.wav')
-    >>> Audio(filename='/path/to/sound.ogg')
+    >>> Audio('/path/to/sound.wav')  # doctest: +SKIP
+    >>> Audio(filename='/path/to/sound.ogg')  # doctest: +SKIP
 
     From Bytes:
 
-    >>> Audio(b'RAW_WAV_DATA..')
-    >>> Audio(data=b'RAW_WAV_DATA..')
+    >>> Audio(b'RAW_WAV_DATA..')  # doctest: +SKIP
+    >>> Audio(data=b'RAW_WAV_DATA..')  # doctest: +SKIP
 
     See Also
     --------

--- a/IPython/lib/lexers.py
+++ b/IPython/lib/lexers.py
@@ -221,10 +221,8 @@ class IPythonConsoleLexer(Lexer):
             In [2]: a
             Out[2]: 'foo'
 
-            In [3]: print a
+            In [3]: print(a)
             foo
-
-            In [4]: 1 / 0
 
 
     Support is also provided for IPython exceptions:
@@ -234,13 +232,9 @@ class IPythonConsoleLexer(Lexer):
         .. code-block:: ipythonconsole
 
             In [1]: raise Exception
-
-            ---------------------------------------------------------------------------
-            Exception                                 Traceback (most recent call last)
-            <ipython-input-1-fca2ab0ca76b> in <module>
-            ----> 1 raise Exception
-
-            Exception:
+            Traceback (most recent call last):
+            ...
+            Exception
 
     """
     name = 'IPython console session'

--- a/IPython/lib/security.py
+++ b/IPython/lib/security.py
@@ -48,7 +48,7 @@ def passwd(passphrase=None, algorithm='sha1'):
     Examples
     --------
     >>> passwd('mypassword')
-    'sha1:7cf3:b7d6da294ea9592a9480c8f52e63cd42cfb9dd12'
+    'sha1:7cf3:b7d6da294ea9592a9480c8f52e63cd42cfb9dd12'  # random
 
     """
     if passphrase is None:

--- a/IPython/testing/plugin/dtexample.py
+++ b/IPython/testing/plugin/dtexample.py
@@ -4,6 +4,9 @@ This file just contains doctests both using plain python and IPython prompts.
 All tests should be loaded by nose.
 """
 
+import os
+
+
 def pyfunc():
     """Some pure python tests...
 
@@ -38,18 +41,6 @@ def ipfunc():
     0 1 1 2 2 3 
 
 
-    Examples that access the operating system work:
-
-    In [1]: !echo hello
-    hello
-
-    In [2]: !echo hello > /tmp/foo_iptest
-
-    In [3]: !cat /tmp/foo_iptest
-    hello
-
-    In [4]: rm -f /tmp/foo_iptest
-
     It's OK to use '_' for the last result, but do NOT try to use IPython's
     numbered history of _NN outputs, since those won't exist under the
     doctest environment:
@@ -70,6 +61,25 @@ def ipfunc():
     Out[9]: 'ipfunc'
     """
     return 'ipfunc'
+
+
+def ipos():
+    """Examples that access the operating system work:
+
+    In [1]: !echo hello
+    hello
+
+    In [2]: !echo hello > /tmp/foo_iptest
+
+    In [3]: !cat /tmp/foo_iptest
+    hello
+
+    In [4]: rm -f /tmp/foo_iptest
+    """
+    pass
+
+
+ipos.__skip_doctest__ = os.name == "nt"
 
 
 def ranfunc():

--- a/IPython/testing/plugin/test_exampleip.txt
+++ b/IPython/testing/plugin/test_exampleip.txt
@@ -21,7 +21,7 @@ Another example::
 
 Just like in IPython docstrings, you can use all IPython syntax and features::
 
-    In [9]: !echo "hello"
+    In [9]: !echo hello
     hello
 
     In [10]: a='hi'

--- a/IPython/testing/tests/test_decorators.py
+++ b/IPython/testing/tests/test_decorators.py
@@ -11,6 +11,7 @@ import nose.tools as nt
 
 # Our own
 from IPython.testing import decorators as dec
+from IPython.testing.skipdoctest import skip_doctest
 
 #-----------------------------------------------------------------------------
 # Utilities
@@ -59,6 +60,7 @@ def test_deliberately_broken2():
 
 # Verify that we can correctly skip the doctest for a function at will, but
 # that the docstring itself is NOT destroyed by the decorator.
+@skip_doctest
 def doctest_bad(x,y=1,**k):
     """A function whose doctest we need to skip.
 
@@ -106,6 +108,7 @@ class FooClass(object):
     2
     """
 
+    @skip_doctest
     def __init__(self,x):
         """Make a FooClass.
 
@@ -117,6 +120,7 @@ class FooClass(object):
         print('Making a FooClass.')
         self.x = x
         
+    @skip_doctest
     def bar(self,y):
         """Example:
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -33,7 +33,7 @@ if sys.platform == 'win32':
         Examples
         --------
 
-        >>> get_long_path_name('c:\\docume~1')
+        >>> get_long_path_name('c:\\\\docume~1')
         'c:\\\\Documents and Settings'
 
         """


### PR DESCRIPTION
* Mark passwd doctest example as random output
* Make OS echo example Windows-compatible
* Fix escaping warning in _get_long_path_name doctest
* Fix IPythonConsoleLexer doctest
* Do not run POSIX-specific doctest on Windows
* Fix Audio doctest
* Partly revert "remove now-obsolete use of skip_doctest outside core". test_decorators.py is intended to test skip_doctest, the removing was wrong.
