### PR TITLE
Fixed and added Line Number into error messages

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -630,7 +630,7 @@ class VerboseTB(TBTools):
 
         indent = ' ' * INDENT_SIZE
         em_normal = '%s\n%s%s' % (Colors.valEm, indent, ColorsNormal)
-        tpl_call = 'in %s%%s%s%%s%s' % (Colors.vName, Colors.valEm,
+        tpl_call = 'in %s%%s%s%%s%s in Line %%s' % (Colors.vName, Colors.valEm,
                                         ColorsNormal)
         tpl_call_fail = 'in %s%%s%s(***failed resolving arguments***)%s' % \
                         (Colors.vName, Colors.valEm, ColorsNormal)
@@ -641,14 +641,14 @@ class VerboseTB(TBTools):
 
         func = frame_info.executing.code_qualname()
         if func == '<module>':
-            call = tpl_call % (func, '')
+            call = tpl_call % (func, '', frame_info.lineno)
         else:
             # Decide whether to include variable details or not
             var_repr = eqrepr if self.include_vars else nullrepr
             try:
                 call = tpl_call % (func, inspect.formatargvalues(args,
                                                                  varargs, varkw,
-                                                                 locals_, formatvalue=var_repr))
+                                                                 locals_, formatvalue=var_repr), frame_info.lineno)
             except KeyError:
                 # This happens in situations like errors inside generator
                 # expressions, where local variables are listed in the


### PR DESCRIPTION
I fixed it as requested. Attached is how it looks like now. Not sure if this is what you have in mind @Carreau ! Do let me know if you need me to work on it a bit more! I think I roughly get how the code there works.

Here is `test.py` which is from #7998
<img width="527" alt="Screenshot 2021-10-27 at 00 24 11" src="https://user-images.githubusercontent.com/49758830/138921136-05992701-b28e-4670-9d45-e76ebce4c110.png">

Here is the output on my terminal:
<img width="631" alt="Screenshot 2021-10-27 at 00 24 37" src="https://user-images.githubusercontent.com/49758830/138921374-ff61d8aa-9ec7-4784-b741-a8bc8d490c56.png">

