### PR TITLE
add optional support for xdg_config|cache_dir

### DIFF
--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -68,7 +68,7 @@ def test_get_ipython_dir_2():
     assert ipdir == os.path.join("someplace", ".ipython")
 
 def test_get_ipython_dir_3():
-    """test_get_ipython_dir_3, move XDG if defined, and .ipython doesn't exist."""
+    """test_get_ipython_dir_3, use XDG if defined and exists, and .ipython doesn't exist."""
     tmphome = TemporaryDirectory()
     try:
         with patch_get_home_dir(tmphome.name), \
@@ -80,10 +80,8 @@ def test_get_ipython_dir_3():
                 }), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
-        assert ipdir == os.path.join(tmphome.name, ".ipython")
-        if sys.platform != 'darwin':
-            assert len(w) == 1
-            assert "Moving" in str(w[0])
+        assert ipdir == os.path.join(tmphome.name, XDG_TEST_DIR, "ipython")
+        assert len(w) == 0
     finally:
         tmphome.cleanup()
 
@@ -105,10 +103,8 @@ def test_get_ipython_dir_4():
         }), warnings.catch_warnings(record=True) as w:
             ipdir = paths.get_ipython_dir()
 
-        assert ipdir == os.path.join(HOME_TEST_DIR, ".ipython")
-        if sys.platform != 'darwin':
-            assert len(w) == 1
-            assert "Ignoring" in str(w[0])
+        assert len(w) == 1
+        assert "Ignoring" in str(w[0])
 
 
 def test_get_ipython_dir_5():
@@ -179,7 +175,7 @@ def test_get_ipython_dir_8():
 
 def test_get_ipython_cache_dir():
     with modified_env({'HOME': HOME_TEST_DIR}):
-        if os.name == 'posix' and sys.platform != 'darwin':
+        if os.name == "posix":
             # test default
             os.makedirs(os.path.join(HOME_TEST_DIR, ".cache"))
             with modified_env({'XDG_CACHE_HOME': None}):

--- a/IPython/paths.py
+++ b/IPython/paths.py
@@ -54,8 +54,7 @@ def get_ipython_dir() -> str:
                     warn(('{0} is deprecated. Move link to {1} to '
                         'get rid of this message').format(cu(xdg_ipdir), cu(ipdir)))
                 else:
-                    warn('Moving {0} to {1}'.format(cu(xdg_ipdir), cu(ipdir)))
-                    shutil.move(xdg_ipdir, ipdir)
+                    ipdir = xdg_ipdir
 
     ipdir = os.path.normpath(os.path.expanduser(ipdir))
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -223,7 +223,7 @@ def get_xdg_dir():
 
     env = os.environ
 
-    if os.name == 'posix' and sys.platform != 'darwin':
+    if os.name == "posix":
         # Linux, Unix, AIX, etc.
         # use ~/.config if empty OR not set
         xdg = env.get("XDG_CONFIG_HOME", None) or os.path.join(get_home_dir(), '.config')
@@ -242,7 +242,7 @@ def get_xdg_cache_dir():
 
     env = os.environ
 
-    if os.name == 'posix' and sys.platform != 'darwin':
+    if os.name == "posix":
         # Linux, Unix, AIX, etc.
         # use ~/.cache if empty OR not set
         xdg = env.get("XDG_CACHE_HOME", None) or os.path.join(get_home_dir(), '.cache')

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -228,11 +228,11 @@ def test_get_xdg_dir_2():
 
 @with_environment
 def test_get_xdg_dir_3():
-    """test_get_xdg_dir_3, check xdg_dir not used on OS X"""
+    """test_get_xdg_dir_3, check xdg_dir not used on non-posix systems"""
     reload(path)
     path.get_home_dir = lambda : HOME_TEST_DIR
-    os.name = "posix"
-    sys.platform = "darwin"
+    os.name = "nt"
+    sys.platform = "win32"
     env.pop('IPYTHON_DIR', None)
     env.pop('IPYTHONDIR', None)
     env.pop('XDG_CONFIG_HOME', None)


### PR DESCRIPTION
This PR adds support for xdg_config_dir and xdg_cache_dir on all posix systems. All behavior should be identical except  when ipython files exist in xdg_config_dir and not in `$HOME`, they won't be ignored or moved.