### PR TITLE
Fix quick reference documentation for 'exec'

### DIFF
--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -305,7 +305,7 @@ History:
 
 _i, _ii, _iii    : Previous, next previous, next next previous input
 _i4, _ih[2:5]    : Input history line 4, lines 2-4
-exec _i81        : Execute input history line #81 again
+exec(_i81)       : Execute input history line #81 again
 %rep 81          : Edit input history line #81
 _, __, ___       : previous, next previous, next next previous output
 _dh              : Directory history


### PR DESCRIPTION
`exec` was a statement in Python 2.7, but it's a function in Python 3+.

Following the old quickref line triggers a `SyntaxError` on Python 3:

```
In [2]: exec _i1
  File "<ipython-input-12-f8fcb58cbaa6>", line 1
    exec _i1
         ^
SyntaxError: Missing parentheses in call to 'exec'
```

But it is fixed with the parentheses:

```
In [3]: exec(_i1)
```