### PR TITLE
Import `reload` from `importlib` instead of deprecated `imp`

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -121,9 +121,8 @@ import traceback
 import types
 import weakref
 import gc
-from importlib import import_module
+from importlib import import_module, reload
 from importlib.util import source_from_cache
-from imp import reload
 
 # ------------------------------------------------------------------------------
 # Autoreload functionality


### PR DESCRIPTION
The `imp` module was deprecated in Python 3.4 in favor of `importlib`, and the function `imp.reload` is now just a wrapper for `importlib.reload`.

Apologies if this counts as unnecessary cleanup.