### PR TITLE
Disable codecov for current patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 coverage:
   status:
+    patch: off
     project:
       default:
         target: auto


### PR DESCRIPTION
It is too sensitive and fails when the number of lines in a file decreases.