### PR TITLE
Run Pytest tests on Appveyor

### DIFF
--- a/IPython/external/decorators/_decorators.py
+++ b/IPython/external/decorators/_decorators.py
@@ -133,9 +133,16 @@ def knownfailureif(fail_condition, msg=None):
         # import time overhead at actual test-time.
         import nose
 
+        try:
+            from pytest import xfail
+        except ImportError:
+
+            def xfail():
+                raise KnownFailureTest(msg)
+
         def knownfailer(*args, **kwargs):
             if fail_condition:
-                raise KnownFailureTest(msg)
+                xfail(msg)
             else:
                 return f(*args, **kwargs)
         return nose.tools.make_decorator(f)(knownfailer)

--- a/IPython/external/decorators/_numpy_testing_noseclasses.py
+++ b/IPython/external/decorators/_numpy_testing_noseclasses.py
@@ -7,9 +7,15 @@ import os
 
 from nose.plugins.errorclass import ErrorClass, ErrorClassPlugin
 
-class KnownFailureTest(Exception):
-    '''Raise this exception to mark a test as a known failing test.'''
-    pass
+
+try:
+    import pytest
+
+    KnownFailureTest = pytest.xfail.Exception
+except ImportError:
+
+    class KnownFailureTest(Exception):
+        """Raise this exception to mark a test as a known failing test."""
 
 
 class KnownFailure(ErrorClassPlugin):

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -376,7 +376,7 @@ def onlyif_cmds_exist(*commands):
     Decorator to skip test when at least one of `commands` is not found.
     """
     for cmd in commands:
-        reason = "This test runs only if command '{cmd}' is installed"
+        reason = f"This test runs only if command '{cmd}' is installed"
         if not shutil.which(cmd):
             if os.environ.get("IPTEST_WORKING_DIR", None) is not None:
                 return skip(reason)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,5 @@ install:
 test_script:
   - iptest --coverage xml
 on_finish:
-  - pip install codecov
-  - codecov -e PYTHON_VERSION PYTHON_ARCH
+  - curl -Os https://uploader.codecov.io/latest/windows/codecov.exe
+  - codecov -e PYTHON_VERSION,PYTHON_ARCH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,13 +22,13 @@ init:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "%CMD_IN_ENV%  python -m pip install --upgrade setuptools pip"
-  - "%CMD_IN_ENV%  pip install nose coverage pytest"
-  - "%CMD_IN_ENV%  pip install .[test]"
-  - "%CMD_IN_ENV%  mkdir results"
-  - "%CMD_IN_ENV%  cd results"
+  - python -m pip install --upgrade setuptools pip
+  - pip install nose coverage pytest
+  - pip install .[test]
+  - mkdir results
+  - cd results
 test_script:
-  - "%CMD_IN_ENV%  iptest --coverage xml"
+  - iptest --coverage xml
 on_finish:
   - pip install codecov
   - codecov -e PYTHON_VERSION PYTHON_ARCH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,14 @@ init:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python -m pip install --upgrade setuptools pip
-  - pip install nose coverage pytest
+  - pip install nose coverage pytest pytest-cov pytest-trio pywin32 matplotlib
   - pip install .[test]
   - mkdir results
   - cd results
 test_script:
   - iptest --coverage xml
+  - cd ..
+  - pytest -ra --cov --cov-report=xml
 on_finish:
   - curl -Os https://uploader.codecov.io/latest/windows/codecov.exe
   - codecov -e PYTHON_VERSION,PYTHON_ARCH


### PR DESCRIPTION
* Make knownfailureif Pytest-compatible
* Fix onlyif_cmds_exist skip message
* CI: Remove noop %CMD_IN_ENV% usage
* CI: Switch to the new codecov uploader: Apparently the python one is deprecated already
* CI: Run Pytest tests on Appveyor
