### PR TITLE
Add line number to error messages

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -628,13 +628,21 @@ class VerboseTB(TBTools):
             return '    %s[... skipping similar frames: %s]%s\n' % (
                 Colors.excName, frame_info.description, ColorsNormal)
 
-        indent = ' ' * INDENT_SIZE
-        em_normal = '%s\n%s%s' % (Colors.valEm, indent, ColorsNormal)
-        tpl_call = 'line %s, in %s%%s%s%%s%s' % (frame_info.lineno, Colors.vName, Colors.valEm,
-                                        ColorsNormal)
-        tpl_call_fail = 'line %s, in %s%%s%s(***failed resolving arguments***)%s' % \
-                        (frame_info.lineno, Colors.vName, Colors.valEm, ColorsNormal)
-        tpl_name_val = '%%s %s= %%s%s' % (Colors.valEm, ColorsNormal)
+        indent = " " * INDENT_SIZE
+        em_normal = "%s\n%s%s" % (Colors.valEm, indent, ColorsNormal)
+        tpl_call = "line %s, in %s%%s%s%%s%s" % (
+            frame_info.lineno,
+            Colors.vName,
+            Colors.valEm,
+            ColorsNormal,
+        )
+        tpl_call_fail = "line %s, in %s%%s%s(***failed resolving arguments***)%s" % (
+            frame_info.lineno,
+            Colors.vName,
+            Colors.valEm,
+            ColorsNormal,
+        )
+        tpl_name_val = "%%s %s= %%s%s" % (Colors.valEm, ColorsNormal)
 
         link = _format_filename(frame_info.filename, Colors.filenameEm, ColorsNormal)
         args, varargs, varkw, locals_ = inspect.getargvalues(frame_info.frame)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -630,10 +630,10 @@ class VerboseTB(TBTools):
 
         indent = ' ' * INDENT_SIZE
         em_normal = '%s\n%s%s' % (Colors.valEm, indent, ColorsNormal)
-        tpl_call = 'in %s%%s%s%%s%s' % (Colors.vName, Colors.valEm,
+        tpl_call = 'line %s, in %s%%s%s%%s%s' % (frame_info.lineno, Colors.vName, Colors.valEm,
                                         ColorsNormal)
-        tpl_call_fail = 'in %s%%s%s(***failed resolving arguments***)%s' % \
-                        (Colors.vName, Colors.valEm, ColorsNormal)
+        tpl_call_fail = 'line %s, in %s%%s%s(***failed resolving arguments***)%s' % \
+                        (frame_info.lineno, Colors.vName, Colors.valEm, ColorsNormal)
         tpl_name_val = '%%s %s= %%s%s' % (Colors.valEm, ColorsNormal)
 
         link = _format_filename(frame_info.filename, Colors.filenameEm, ColorsNormal)


### PR DESCRIPTION
As suggested in #13169, it adds line number to error messages, in order to make them more friendly.

![image](https://user-images.githubusercontent.com/20190646/139513782-ea8d42ab-9c73-4452-b607-5c54ca50a125.png)

That was the file used in the test
![image](https://user-images.githubusercontent.com/20190646/139513827-0aa4bed3-682f-40ee-a8ea-4f0e6e3fbc34.png)
