### PR TITLE
Revive doctest_tb_sysexit

### DIFF
--- a/IPython/core/tests/simpleerr.py
+++ b/IPython/core/tests/simpleerr.py
@@ -8,7 +8,7 @@ def div0():
     x/y
 
 def sysexit(stat, mode):
-    raise SystemExit(stat, 'Mode = %s' % mode)
+    raise SystemExit(stat, f'Mode = {mode}')
 
 def bar(mode):
     "bar"

--- a/IPython/core/tests/simpleerr.py
+++ b/IPython/core/tests/simpleerr.py
@@ -8,7 +8,8 @@ def div0():
     x/y
 
 def sysexit(stat, mode):
-    raise SystemExit(stat, f'Mode = {mode}')
+    raise SystemExit(stat, f"Mode = {mode}")
+
 
 def bar(mode):
     "bar"

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -43,15 +43,15 @@ def doctest_tb_plain():
 In [18]: xmode plain
 Exception reporting mode: Plain
 
-In [19]: run simpleerr.py
-Traceback (most recent call last):
-  ...line 32, in <module>
-    bar(mode)
-  ...line 16, in bar
-    div0()
-  ...line 8, in div0
-    x/y
-ZeroDivisionError: ...
+        In [19]: run simpleerr.py
+        Traceback (most recent call last):
+          ...line ..., in <module>
+            bar(mode)
+          ...line ..., in bar
+            div0()
+          ...line ..., in div0
+            x/y
+        ZeroDivisionError: ...
     """
 
 
@@ -60,29 +60,28 @@ def doctest_tb_context():
 In [3]: xmode context
 Exception reporting mode: Context
 
-In [4]: run simpleerr.py
----------------------------------------------------------------------------
-ZeroDivisionError                         Traceback (most recent call last)
-<BLANKLINE>
-... in <module>
-     29     except IndexError:
-     30         mode = 'div'
----> 32     bar(mode)
-<BLANKLINE>
-... in bar(mode)
-     14     "bar"
-     15     if mode=='div':
----> 16         div0()
-     17     elif mode=='exit':
-     18         try:
-<BLANKLINE>
-... in div0()
-      6     x = 1
-      7     y = 0
-----> 8     x/y
-<BLANKLINE>
-ZeroDivisionError: ...
-"""
+        In [4]: run simpleerr.py
+        ---------------------------------------------------------------------------
+        ZeroDivisionError                         Traceback (most recent call last)
+        <BLANKLINE>
+        ... in <module>
+             30     except IndexError:
+             31         mode = 'div'
+        ---> 33     bar(mode)
+        <BLANKLINE>
+        ... in bar(mode)
+             15     "bar"
+             16     if mode=='div':
+        ---> 17         div0()
+             18     elif mode=='exit':
+             19         try:
+        <BLANKLINE>
+        ... in div0()
+              6     x = 1
+              7     y = 0
+        ----> 8     x/y
+        <BLANKLINE>
+        ZeroDivisionError: ..."""
 
 
 def doctest_tb_verbose():
@@ -95,17 +94,17 @@ def doctest_tb_verbose():
     ZeroDivisionError                         Traceback (most recent call last)
     <BLANKLINE>
     ... in <module>
-         29     except IndexError:
-         30         mode = 'div'
-    ---> 32     bar(mode)
+         30     except IndexError:
+         31         mode = 'div'
+    ---> 33     bar(mode)
             mode = 'div'
     <BLANKLINE>
     ... in bar(mode='div')
-         14     "bar"
-         15     if mode=='div':
-    ---> 16         div0()
-         17     elif mode=='exit':
-         18         try:
+         15     "bar"
+         16     if mode=='div':
+    ---> 17         div0()
+         18     elif mode=='exit':
+         19         try:
     <BLANKLINE>
     ... in div0()
           6     x = 1
@@ -133,12 +132,14 @@ def doctest_tb_sysexit():
 
     In [20]: %tb
     Traceback (most recent call last):
-      File ... in <module>
+      File ..., in execfile
+        exec(compiler(f.read(), fname, 'exec'), glob, loc)
+      File ..., in <module>
         bar(mode)
-      File ... line 22, in bar
+      File ..., in bar
         sysexit(stat, mode)
-      File ... line 11, in sysexit
-        raise SystemExit(stat, f'Mode = {mode}')
+      File ..., in sysexit
+        raise SystemExit(stat, f"Mode = {mode}")
     SystemExit: (2, 'Mode = exit')
 
     In [21]: %xmode context
@@ -147,23 +148,38 @@ def doctest_tb_sysexit():
     In [22]: %tb
     ---------------------------------------------------------------------------
     SystemExit                                Traceback (most recent call last)
-    <BLANKLINE>
+    File ..., in execfile(fname, glob, loc, compiler)
+         70 with open(fname, 'rb') as f:
+         71     compiler = compiler or compile
+    ---> 72     exec(compiler(f.read(), fname, 'exec'), glob, loc)
     ...<module>
-         29     except IndexError:
-         30         mode = 'div'
-    ---> 32     bar(mode)
+         30     except IndexError:
+         31         mode = 'div'
+    ---> 33     bar(mode)
     <BLANKLINE>
     ...bar(mode)
-         20         except:
-         21             stat = 1
-    ---> 22         sysexit(stat, mode)
-         23     else:
-         24         raise ValueError('Unknown mode')
+         21         except:
+         22             stat = 1
+    ---> 23         sysexit(stat, mode)
+         24     else:
+         25         raise ValueError('Unknown mode')
     <BLANKLINE>
     ...sysexit(stat, mode)
          10 def sysexit(stat, mode):
-    ---> 11     raise SystemExit(stat, f'Mode = {mode}')
+    ---> 11     raise SystemExit(stat, f"Mode = {mode}")
     <BLANKLINE>
+    SystemExit: (2, 'Mode = exit')
+    """
+
+
+def doctest_tb_sysexit_verbose():
+    """
+    In [18]: %run simpleerr.py exit
+    An exception has occurred, use %tb to see the full traceback.
+    SystemExit: (1, 'Mode = exit')
+
+    In [19]: %run simpleerr.py exit 2
+    An exception has occurred, use %tb to see the full traceback.
     SystemExit: (2, 'Mode = exit')
 
     In [23]: %xmode verbose
@@ -174,23 +190,23 @@ def doctest_tb_sysexit():
     SystemExit                                Traceback (most recent call last)
     <BLANKLINE>
     ... in <module>
-         29     except IndexError:
-         30         mode = 'div'
-    ---> 32     bar(mode)
+         30     except IndexError:
+         31         mode = 'div'
+    ---> 33     bar(mode)
             mode = 'exit'
     <BLANKLINE>
     ... in bar(mode='exit')
-         20         except:
-         21             stat = 1
-    ---> 22         sysexit(stat, mode)
+         ...     except:
+         ...         stat = 1
+    ---> ...     sysexit(stat, mode)
             mode = 'exit'
             stat = 2
-         23     else:
-         24         raise ValueError('Unknown mode')
+         ...     else:
+         ...         raise ValueError('Unknown mode')
     <BLANKLINE>
     ... in sysexit(stat=2, mode='exit')
          10 def sysexit(stat, mode):
-    ---> 11     raise SystemExit(stat, f'Mode = {mode}')
+    ---> 11     raise SystemExit(stat, f"Mode = {mode}")
             stat = 2
     <BLANKLINE>
     SystemExit: (2, 'Mode = exit')

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -40,48 +40,48 @@ def test_reset():
 
 def doctest_tb_plain():
     """
-In [18]: xmode plain
-Exception reporting mode: Plain
+    In [18]: xmode plain
+    Exception reporting mode: Plain
 
-        In [19]: run simpleerr.py
-        Traceback (most recent call last):
-          ...line ..., in <module>
-            bar(mode)
-          ...line ..., in bar
-            div0()
-          ...line ..., in div0
-            x/y
-        ZeroDivisionError: ...
+    In [19]: run simpleerr.py
+    Traceback (most recent call last):
+      ...line ..., in <module>
+        bar(mode)
+      ...line ..., in bar
+        div0()
+      ...line ..., in div0
+        x/y
+    ZeroDivisionError: ...
     """
 
 
 def doctest_tb_context():
     """
-In [3]: xmode context
-Exception reporting mode: Context
+    In [3]: xmode context
+    Exception reporting mode: Context
 
-        In [4]: run simpleerr.py
-        ---------------------------------------------------------------------------
-        ZeroDivisionError                         Traceback (most recent call last)
-        <BLANKLINE>
-        ... in <module>
-             30     except IndexError:
-             31         mode = 'div'
-        ---> 33     bar(mode)
-        <BLANKLINE>
-        ... in bar(mode)
-             15     "bar"
-             16     if mode=='div':
-        ---> 17         div0()
-             18     elif mode=='exit':
-             19         try:
-        <BLANKLINE>
-        ... in div0()
-              6     x = 1
-              7     y = 0
-        ----> 8     x/y
-        <BLANKLINE>
-        ZeroDivisionError: ..."""
+    In [4]: run simpleerr.py
+    ---------------------------------------------------------------------------
+    ZeroDivisionError                         Traceback (most recent call last)
+    <BLANKLINE>
+    ... in <module>
+         30     except IndexError:
+         31         mode = 'div'
+    ---> 33     bar(mode)
+    <BLANKLINE>
+    ... in bar(mode)
+         15     "bar"
+         16     if mode=='div':
+    ---> 17         div0()
+         18     elif mode=='exit':
+         19         try:
+    <BLANKLINE>
+    ... in div0()
+          6     x = 1
+          7     y = 0
+    ----> 8     x/y
+    <BLANKLINE>
+    ZeroDivisionError: ..."""
 
 
 def doctest_tb_verbose():

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -118,91 +118,83 @@ def doctest_tb_verbose():
     """
 
 
-# TODO : Marc 2021 – this seem to fail due
-# to upstream changes in CI for whatever reason.
-# Commenting for now, to revive someday (maybe?)
-# nose won't work in 3.10 anyway and we'll have to disable iptest.
-# thus this likely need to bemigrated to pytest.
+def doctest_tb_sysexit():
+    """
+    In [17]: %xmode plain
+    Exception reporting mode: Plain
 
+    In [18]: %run simpleerr.py exit
+    An exception has occurred, use %tb to see the full traceback.
+    SystemExit: (1, 'Mode = exit')
 
-# def doctest_tb_sysexit():
-#     """
-# In [17]: %xmode plain
-# Exception reporting mode: Plain
-#
-# In [18]: %run simpleerr.py exit
-# An exception has occurred, use %tb to see the full traceback.
-# SystemExit: (1, 'Mode = exit')
-#
-# In [19]: %run simpleerr.py exit 2
-# An exception has occurred, use %tb to see the full traceback.
-# SystemExit: (2, 'Mode = exit')
-#
-# In [20]: %tb
-# Traceback (most recent call last):
-#   File ... in <module>
-#     bar(mode)
-#   File ... line 22, in bar
-#     sysexit(stat, mode)
-#   File ... line 11, in sysexit
-#     raise SystemExit(stat, 'Mode = %s' % mode)
-# SystemExit: (2, 'Mode = exit')
-#
-# In [21]: %xmode context
-# Exception reporting mode: Context
-#
-# In [22]: %tb
-# ---------------------------------------------------------------------------
-# SystemExit                                Traceback (most recent call last)
-# <BLANKLINE>
-# ...<module>
-#      29     except IndexError:
-#      30         mode = 'div'
-# ---> 32     bar(mode)
-# <BLANKLINE>
-# ...bar(mode)
-#      20         except:
-#      21             stat = 1
-# ---> 22         sysexit(stat, mode)
-#      23     else:
-#      24         raise ValueError('Unknown mode')
-# <BLANKLINE>
-# ...sysexit(stat, mode)
-#      10 def sysexit(stat, mode):
-# ---> 11     raise SystemExit(stat, 'Mode = %s' % mode)
-# <BLANKLINE>
-# SystemExit: (2, 'Mode = exit')
-#
-# In [23]: %xmode verbose
-# Exception reporting mode: Verbose
-#
-# In [24]: %tb
-# ---------------------------------------------------------------------------
-# SystemExit                                Traceback (most recent call last)
-# <BLANKLINE>
-# ... in <module>
-#      29     except IndexError:
-#      30         mode = 'div'
-# ---> 32     bar(mode)
-#         mode = 'exit'
-# <BLANKLINE>
-# ... in bar(mode='exit')
-#      20         except:
-#      21             stat = 1
-# ---> 22         sysexit(stat, mode)
-#         mode = 'exit'
-#         stat = 2
-#      23     else:
-#      24         raise ValueError('Unknown mode')
-# <BLANKLINE>
-# ... in sysexit(stat=2, mode='exit')
-#      10 def sysexit(stat, mode):
-# ---> 11     raise SystemExit(stat, 'Mode = %s' % mode)
-#         stat = 2
-#         mode = 'exit'
-# <BLANKLINE>
-# SystemExit: (2, 'Mode = exit')
-#     """
+    In [19]: %run simpleerr.py exit 2
+    An exception has occurred, use %tb to see the full traceback.
+    SystemExit: (2, 'Mode = exit')
+
+    In [20]: %tb
+    Traceback (most recent call last):
+      File ... in <module>
+        bar(mode)
+      File ... line 22, in bar
+        sysexit(stat, mode)
+      File ... line 11, in sysexit
+        raise SystemExit(stat, f'Mode = {mode}')
+    SystemExit: (2, 'Mode = exit')
+
+    In [21]: %xmode context
+    Exception reporting mode: Context
+
+    In [22]: %tb
+    ---------------------------------------------------------------------------
+    SystemExit                                Traceback (most recent call last)
+    <BLANKLINE>
+    ...<module>
+         29     except IndexError:
+         30         mode = 'div'
+    ---> 32     bar(mode)
+    <BLANKLINE>
+    ...bar(mode)
+         20         except:
+         21             stat = 1
+    ---> 22         sysexit(stat, mode)
+         23     else:
+         24         raise ValueError('Unknown mode')
+    <BLANKLINE>
+    ...sysexit(stat, mode)
+         10 def sysexit(stat, mode):
+    ---> 11     raise SystemExit(stat, f'Mode = {mode}')
+    <BLANKLINE>
+    SystemExit: (2, 'Mode = exit')
+
+    In [23]: %xmode verbose
+    Exception reporting mode: Verbose
+
+    In [24]: %tb
+    ---------------------------------------------------------------------------
+    SystemExit                                Traceback (most recent call last)
+    <BLANKLINE>
+    ... in <module>
+         29     except IndexError:
+         30         mode = 'div'
+    ---> 32     bar(mode)
+            mode = 'exit'
+    <BLANKLINE>
+    ... in bar(mode='exit')
+         20         except:
+         21             stat = 1
+    ---> 22         sysexit(stat, mode)
+            mode = 'exit'
+            stat = 2
+         23     else:
+         24         raise ValueError('Unknown mode')
+    <BLANKLINE>
+    ... in sysexit(stat=2, mode='exit')
+         10 def sysexit(stat, mode):
+    ---> 11     raise SystemExit(stat, f'Mode = {mode}')
+            stat = 2
+    <BLANKLINE>
+    SystemExit: (2, 'Mode = exit')
+    """
 
 
 def test_run_cell():


### PR DESCRIPTION
Output changed with `pure-eval>=0.2.0` which learned to parse binary operators and to show its arguments. Test changed to not use the binary operator '%' to pass on any version.