### PR TITLE
Skip test_pylabtools when no matplotlib installed

### DIFF
--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -8,14 +8,15 @@
 from binascii import a2b_base64
 from io import BytesIO
 
-import matplotlib
+import pytest
+
+matplotlib = pytest.importorskip("matplotlib")
 matplotlib.use('Agg')
 from matplotlib.figure import Figure
 
 from matplotlib import pyplot as plt
 from matplotlib_inline import backend_inline
 import numpy as np
-import pytest
 
 from IPython.core.getipython import get_ipython
 from IPython.core.interactiveshell import InteractiveShell


### PR DESCRIPTION
Currently Pytest will bail out the whole suit because of ImportError.