### PR TITLE
Split coverage into distinct library and tests stats

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,12 @@ coverage:
   status:
     patch: off
     project:
-      default:
+      default: false
+      library:
         target: auto
+        paths: '!.*/tests/.*'
+      tests:
+        target: auto
+        paths: '.*/tests/.*'
 codecov:
   require_ci_to_pass: false


### PR DESCRIPTION
Some projects exclude tests coverage completely because counting it with other code artificially increases total code coverage, but tests coverage monitoring is a good thing because it catches mistakenly not running tests. The split should eliminate situations with 'coverage decreases' status reports when tests code shrinks while the library code and its coverage remains the same.