### PR TITLE
TST: Remove unneeded requirement on pywin32

### DIFF
--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -70,15 +70,6 @@ def teardown_module():
 #-----------------------------------------------------------------------------
 # Test functions
 #-----------------------------------------------------------------------------
-def win32_without_pywin32():
-    if sys.platform == 'win32':
-        try:
-            import pywin32
-        except ImportError:
-            return True
-    return False
-
-
 class ProfileStartupTest(TestCase):
     def setUp(self):
         # create profile dir
@@ -102,12 +93,10 @@ class ProfileStartupTest(TestCase):
     def validate(self, output):
         tt.ipexec_validate(self.fname, output, '', options=self.options)
 
-    @dec.skipif(win32_without_pywin32(), "Test requires pywin32 on Windows")
     def test_startup_py(self):
         self.init('00-start.py', 'zzz=123\n', 'print(zzz)\n')
         self.validate('123')
 
-    @dec.skipif(win32_without_pywin32(), "Test requires pywin32 on Windows")
     def test_startup_ipy(self):
         self.init('00-start.ipy', '%xmode plain\n', '')
         self.validate('Exception reporting mode: Plain')

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -91,7 +91,7 @@ class ProfileStartupTest(TestCase):
             f.write(test)
 
     def validate(self, output):
-        tt.ipexec_validate(self.fname, output, '', options=self.options)
+        tt.ipexec_validate(self.fname, output, "", options=self.options)
 
     def test_startup_py(self):
         self.init('00-start.py', 'zzz=123\n', 'print(zzz)\n')

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -237,11 +237,6 @@ class TestMagicRunSimple(tt.TempFileMixin):
 
     def test_obj_del(self):
         """Test that object's __del__ methods are called on exit."""
-        if sys.platform == 'win32':
-            try:
-                import win32api
-            except ImportError as e:
-                raise unittest.SkipTest("Test requires pywin32") from e
         src = ("class A(object):\n"
                "    def __del__(self):\n"
                "        print('object A deleted')\n"

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -177,7 +177,7 @@ def ipexec(fname, options=None, commands=()):
 
     Parameters
     ----------
-    fname : str
+    fname : str, Path
       Name of file to be executed (should have .py or .ipy extension).
 
     options : optional, list
@@ -200,6 +200,9 @@ def ipexec(fname, options=None, commands=()):
     # Absolute path for filename
     full_fname = os.path.join(test_dir, fname)
     full_cmd = ipython_cmd + cmdargs + ['--', full_fname]
+    if sys.platform == "win32" and sys.version_info < (3, 8):
+        # subprocess.Popen does not support Path objects yet
+        full_cmd = list(map(str, full_cmd))
     env = os.environ.copy()
     # FIXME: ignore all warnings in ipexec while we have shims
     # should we keep suppressing warnings here, even after removing shims?
@@ -232,7 +235,7 @@ def ipexec_validate(fname, expected_out, expected_err='',
 
     Parameters
     ----------
-    fname : str
+    fname : str, Path
       Name of the file to be executed (should have .py or .ipy extension).
 
     expected_out : str

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ init:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python -m pip install --upgrade setuptools pip
-  - pip install nose coverage pytest pytest-cov pytest-trio pywin32 matplotlib pandas
+  - pip install nose coverage pytest pytest-cov pytest-trio matplotlib pandas
   - pip install -e .[test]
   - mkdir results
   - cd results


### PR DESCRIPTION
The only routine that requires `pywin32` is `win32_clipboard_get` which is not tested.