### PR TITLE
Fix codecov.yml syntax

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,10 @@ coverage:
       default: false
       library:
         target: auto
-        paths: '!.*/tests/.*'
+        paths: ['!.*/tests/.*']
       tests:
         target: auto
-        paths: '.*/tests/.*'
+        paths: ['.*/tests/.*']
 codecov:
   require_ci_to_pass: false
 


### PR DESCRIPTION
It expects `paths` to be a list (though a string had been working previously) but for some reason Codecov will silently ignore mistakes and won't tell you that the file has incorrect syntax.