### PR TITLE
f_locals might not have get method

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -415,9 +415,10 @@ class Pdb(OldPdb):
         if self._predicates["tbhide"]:
             if frame in (self.curframe, getattr(self, "initial_frame", None)):
                 return False
-            else:
-                return self._get_frame_locals(frame).get("__tracebackhide__", False)
-
+            frame_locals = self._get_frame_locals(frame)
+            if "__tracebackhide__" not in frame_locals:
+                return False
+            return frame_locals["__tracebackhide__"]
         return False
 
     def hidden_frames(self, stack):


### PR DESCRIPTION
See https://github.com/spyder-ide/spyder/issues/16780

pytorch uses a `EvalEnv` object as a locals namespace. This obgect doesn't have a `get` method. See https://github.com/pytorch/pytorch/blob/6831d8e379392da1340a28fdb3e7e1382176d1d4/torch/jit/annotations.py#L150