### PR TITLE
Document that `%run` can execute notebooks and ipy scripts.

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -525,13 +525,13 @@ class ExecutionMagics(Magics):
                ( -m mod | filename ) [args]
 
         The filename argument should be either a pure Python script (with
-        extension `.py`), or a file with custom IPython syntax (such as
-        magics). If the latter, the file can be either a script with `.ipy`
-        extension, or a Jupyter notebook with `.ipynb` extension. When running
+        extension ``.py``), or a file with custom IPython syntax (such as
+        magics). If the latter, the file can be either a script with ``.ipy``
+        extension, or a Jupyter notebook with ``.ipynb`` extension. When running
         a Jupyter notebook, the output from print statements and other
         displayed objects will appear in the terminal (even matplotlib figures
         will open, if a terminal-compliant backend is being used). Note that,
-        at the system command line, the `jupyter run` command offers similar
+        at the system command line, the ``jupyter run`` command offers similar
         functionality for executing notebooks (albeit currently with some
         differences in supported options).
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -530,7 +530,10 @@ class ExecutionMagics(Magics):
         extension, or a Jupyter notebook with `.ipynb` extension. When running
         a Jupyter notebook, the output from print statements and other
         displayed objects will appear in the terminal (even matplotlib figures
-        will open, if a terminal-compliant backend is being used).
+        will open, if a terminal-compliant backend is being used). Note that,
+        at the system command line, the `jupyter run` command offers similar
+        functionality for executing notebooks (albeit currently with some
+        differences in supported options).
 
         Parameters after the filename are passed as command-line arguments to
         the program (put in sys.argv). Then, control returns to IPython's

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -522,7 +522,15 @@ class ExecutionMagics(Magics):
         
           %run [-n -i -e -G]
                [( -t [-N<N>] | -d [-b<N>] | -p [profile options] )]
-               ( -m mod | file ) [args]
+               ( -m mod | filename ) [args]
+
+        The filename argument should be either a pure Python script (with
+        extension `.py`), or a file with custom IPython syntax (such as
+        magics). If the latter, the file can be either a script with `.ipy`
+        extension, or a Jupyter notebook with `.ipynb` extension. When running
+        a Jupyter notebook, the output from print statements and other
+        displayed objects will appear in the terminal (even matplotlib figures
+        will open, if a terminal-compliant backend is being used).
 
         Parameters after the filename are passed as command-line arguments to
         the program (put in sys.argv). Then, control returns to IPython's


### PR DESCRIPTION
This feature has been there for a long time but was not documented in the %run
docstring. This patch only adds documentation, without changing the
functionality.

cc @palewire - thanks for your work on jupyter/nbclient#165 and jupyter/nbclient#173, it motivated me to make my first IPython PR in ages! #13164 