### PR TITLE
Fix DeprecationWarning: There is no current event loop

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -505,7 +505,7 @@ class TerminalInteractiveShell(InteractiveShell):
         # while/true inside which will freeze the prompt.
 
         try:
-            old_loop = asyncio.get_event_loop()
+            old_loop = asyncio.get_running_loop()
         except RuntimeError:
             # This happens when the user used `asyncio.run()`.
             old_loop = None


### PR DESCRIPTION
Fix:

```
/Users/redacted/.asdf/installs/python/3.10.0/lib/python3.10/site-packages/IPython/terminal/interactiveshell.py:464: DeprecationWarning: There is no current event loop
  old_loop = asyncio.get_event_loop()
```

Per https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop this method is deprecated and get_running_loop is preferred over this method moving forward. As IPython requires 3.7+ now, this can be updated