### PR TITLE
Add Xfail test on 3.9.8

### DIFF
--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -12,6 +12,7 @@ from IPython.core import inputsplitter as isp
 from IPython.core.inputtransformer import InputTransformer
 from IPython.core.tests.test_inputtransformer import syntax, syntax_ml
 from IPython.testing import tools as tt
+from IPython.testing.decorators import skipif
 
 #-----------------------------------------------------------------------------
 # Semi-complete examples (also used as tests)
@@ -321,6 +322,7 @@ class InputSplitterTestCase(unittest.TestCase):
         self.isp.push(u'\xc3\xa9')
         self.isp.push(u"u'\xc3\xa9'")
 
+    @skipif(sys.version_info[:3] == (3, 9, 8))
     def test_line_continuation(self):
         """ Test issue #2108."""
         isp = self.isp

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -5,11 +5,14 @@ more complex. See test_inputtransformer2_line for tests for line-based
 transformations.
 """
 import string
+import sys
+from textwrap import dedent
+
+import pytest
 
 from IPython.core import inputtransformer2 as ipt2
-from IPython.core.inputtransformer2 import make_tokens_by_line, _find_assign_op
-
-from textwrap import dedent
+from IPython.core.inputtransformer2 import _find_assign_op, make_tokens_by_line
+from IPython.testing.decorators import skip_iptest_but_not_pytest
 
 MULTILINE_MAGIC = ("""\
 a = f()
@@ -256,20 +259,45 @@ def test_find_assign_op_dedent():
     )
 
 
+examples = [
+    pytest.param("a = 1", "complete", None),
+    pytest.param("for a in range(5):", "incomplete", 4),
+    pytest.param("for a in range(5):\n    if a > 0:", "incomplete", 8),
+    pytest.param("raise = 2", "invalid", None),
+    pytest.param("a = [1,\n2,", "incomplete", 0),
+    pytest.param("(\n))", "incomplete", 0),
+    pytest.param("\\\r\n", "incomplete", 0),
+    pytest.param("a = '''\n   hi", "incomplete", 3),
+    pytest.param("def a():\n x=1\n global x", "invalid", None),
+    pytest.param(
+        "a \\ ",
+        "invalid",
+        None,
+        marks=pytest.mark.xfail(
+            reason="Bug in python 3.9.8 – bpo 45738",
+            condition=sys.version_info[:3] == (3, 9, 8),
+            raises=SystemError,
+            strict=True,
+        ),
+    ),  # Nothing allowed after backslash,
+    pytest.param("1\\\n+2", "complete", None),
+]
+
+
+@skip_iptest_but_not_pytest
+@pytest.mark.parametrize("code, expected, number", examples)
+def test_check_complete_param(code, expected, number):
+    cc = ipt2.TransformerManager().check_complete
+    assert cc(code) == (expected, number)
+
+
+@skip_iptest_but_not_pytest
+@pytest.mark.xfail(
+    reason="Bug in python 3.9.8 – bpo 45738",
+    condition=sys.version_info[:3] == (3, 9, 8),
+)
 def test_check_complete():
     cc = ipt2.TransformerManager().check_complete
-    assert cc("a = 1") == ("complete", None)
-    assert cc("for a in range(5):") == ("incomplete", 4)
-    assert cc("for a in range(5):\n    if a > 0:") == ("incomplete", 8)
-    assert cc("raise = 2") == ("invalid", None)
-    assert cc("a = [1,\n2,") == ("incomplete", 0)
-    assert cc("(\n))") == ("incomplete", 0)
-    assert cc("\\\r\n") == ("incomplete", 0)
-    assert cc("a = '''\n   hi") == ("incomplete", 3)
-    assert cc("def a():\n x=1\n global x") == ("invalid", None)
-    assert cc("a \\ ") == ("invalid", None)  # Nothing allowed after backslash
-    assert cc("1\\\n+2") == ("complete", None)
-    assert cc("exit") == ("complete", None)
 
     example = dedent("""
         if True:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,7 @@ coverage:
       library:
         target: auto
         paths: ['!.*/tests/.*']
+        threshold: 0.1%
       tests:
         target: auto
         paths: ['.*/tests/.*']


### PR DESCRIPTION
See https://bugs.python.org/issue45738 once fixed (or later if not fixed),
we can also catch system error only on the relevant Python versions and
that _should_ be ok, but I want to avoid doing it for now.