### PR TITLE
Port `deepreload` to `importlib`

### DIFF
--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -28,7 +28,7 @@ re-implementation of hierarchical module import.
 
 import builtins as builtin_mod
 from contextlib import contextmanager
-import imp
+import importlib
 import sys
 
 from types import ModuleType
@@ -174,33 +174,17 @@ def import_submodule(mod, subname, fullname):
         print('Reloading', fullname)
         found_now[fullname] = 1
         oldm = sys.modules.get(fullname, None)
-
-        if mod is None:
-            path = None
-        elif hasattr(mod, '__path__'):
-            path = mod.__path__
-        else:
-            return None
-
         try:
-            # This appears to be necessary on Python 3, because imp.find_module()
-            # tries to import standard libraries (like io) itself, and we don't
-            # want them to be processed by our deep_import_hook.
-            with replace_import_hook(original_import):
-                fp, filename, stuff = imp.find_module(subname, path)
-        except ImportError:
-            return None
-
-        try:
-            m = imp.load_module(fullname, fp, filename, stuff)
+            if oldm is not None:
+                m = importlib.reload(oldm)
+            else:
+                m = importlib.import_module(subname, mod)
         except:
             # load_module probably removed name from modules because of
             # the error.  Put back the original module object.
             if oldm:
                 sys.modules[fullname] = oldm
             raise
-        finally:
-            if fp: fp.close()
 
         add_submodule(mod, m, fullname, subname)
 
@@ -285,43 +269,17 @@ def deep_reload_hook(m):
     except:
         modules_reloading[name] = m
 
-    dot = name.rfind('.')
-    if dot < 0:
-        subname = name
-        path = None
-    else:
-        try:
-            parent = sys.modules[name[:dot]]
-        except KeyError as e:
-            modules_reloading.clear()
-            raise ImportError("reload(): parent %.200s not in sys.modules" % name[:dot]) from e
-        subname = name[dot+1:]
-        path = getattr(parent, "__path__", None)
-
     try:
-        # This appears to be necessary on Python 3, because imp.find_module()
-        # tries to import standard libraries (like io) itself, and we don't
-        # want them to be processed by our deep_import_hook.
-        with replace_import_hook(original_import):
-            fp, filename, stuff  = imp.find_module(subname, path)
-    finally:
-        modules_reloading.clear()
-
-    try:
-        newm = imp.load_module(name, fp, filename, stuff)
+        newm = importlib.reload(m)
     except:
-         # load_module probably removed name from modules because of
-         # the error.  Put back the original module object.
         sys.modules[name] = m
         raise
     finally:
-        if fp: fp.close()
-
-    modules_reloading.clear()
+        modules_reloading.clear()
     return newm
 
 # Save the original hooks
-original_reload = imp.reload
+original_reload = importlib.reload
 
 # Replacement for reload()
 def reload(module, exclude=('sys', 'os.path', 'builtins', '__main__',

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -4,11 +4,14 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import pytest
+import types
+
 from pathlib import Path
 
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.tempdir import TemporaryDirectory
-from IPython.lib.deepreload import reload as dreload
+from IPython.lib.deepreload import reload as dreload, modules_reloading
 
 
 def test_deepreload():
@@ -17,9 +20,9 @@ def test_deepreload():
         with prepended_to_syspath(tmpdir):
             tmpdirpath = Path(tmpdir)
             with open(tmpdirpath / "A.py", "w") as f:
-                f.write("class Object(object):\n    pass\n")
+                f.write("class Object:\n    pass\nok = True\n")
             with open(tmpdirpath / "B.py", "w") as f:
-                f.write("import A\n")
+                f.write("import A\nassert A.ok, 'we are fine'\n")
             import A
             import B
 
@@ -28,7 +31,26 @@ def test_deepreload():
             dreload(B, exclude=["A"])
             assert isinstance(obj, A.Object) is True
 
+            # Test that an import failure will not blow-up us.
+            A.ok = False
+            with pytest.raises(AssertionError, match="we are fine"):
+                dreload(B, exclude=["A"])
+            assert len(modules_reloading) == 0
+            assert not A.ok
+
             # Test that A is reloaded.
             obj = A.Object()
+            A.ok = False
             dreload(B)
+            assert A.ok
             assert isinstance(obj, A.Object) is False
+
+
+def test_not_module():
+    pytest.raises(TypeError, dreload, "modulename")
+
+
+def test_not_in_sys_modules():
+    fake_module = types.ModuleType("fake_module")
+    with pytest.raises(ImportError, match="not in sys.modules"):
+        dreload(fake_module)


### PR DESCRIPTION
`imp` is deprecated since Python 3.3 and scheduled for removal in Python 3.12

The code is severely undertested, I added several, and also fixed a bug that `modules_reloading` was not cleaned-up on an import failure.