### PR TITLE
Deprecate `utils.sysinfo.num_cpus`

### DIFF
--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -118,49 +118,25 @@ def sys_info():
     """
     return pprint.pformat(get_sys_info())
 
-def _num_cpus_unix():
-    """Return the number of active CPUs on a Unix system."""
-    return os.sysconf("SC_NPROCESSORS_ONLN")
-
-
-def _num_cpus_darwin():
-    """Return the number of active CPUs on a Darwin system."""
-    p = subprocess.Popen(['sysctl','-n','hw.ncpu'],stdout=subprocess.PIPE)
-    return p.stdout.read()
-
-
-def _num_cpus_windows():
-    """Return the number of active CPUs on a Windows system."""
-    return os.environ.get("NUMBER_OF_PROCESSORS")
-
 
 def num_cpus():
-   """Return the effective number of CPUs in the system as an integer.
+    """DEPRECATED
 
-   This cross-platform function makes an attempt at finding the total number of
-   available CPUs in the system, as returned by various underlying system and
-   python calls.
+    Return the effective number of CPUs in the system as an integer.
 
-   If it can't find a sensible answer, it returns 1 (though an error *may* make
-   it return a large positive number that's actually incorrect).
-   """
+    This cross-platform function makes an attempt at finding the total number of
+    available CPUs in the system, as returned by various underlying system and
+    python calls.
 
-   # Many thanks to the Parallel Python project (http://www.parallelpython.com)
-   # for the names of the keys we needed to look up for this function.  This
-   # code was inspired by their equivalent function.
+    If it can't find a sensible answer, it returns 1 (though an error *may* make
+    it return a large positive number that's actually incorrect).
+    """
+    import warnings
 
-   ncpufuncs = {'Linux':_num_cpus_unix,
-                'Darwin':_num_cpus_darwin,
-                'Windows':_num_cpus_windows
-                }
+    warnings.warn(
+        "`num_cpus` is deprecated since IPython 8.0. Use `os.cpu_count` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-   ncpufunc = ncpufuncs.get(platform.system(),
-                            # default to unix version (Solaris, AIX, etc)
-                            _num_cpus_unix)
-
-   try:
-       ncpus = max(1,int(ncpufunc()))
-   except:
-       ncpus = 1
-   return ncpus
-
+    return os.cpu_count() or 1

--- a/IPython/utils/tests/test_sysinfo.py
+++ b/IPython/utils/tests/test_sysinfo.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+import pytest
 
 from IPython.utils import sysinfo
 
@@ -14,3 +15,8 @@ def test_json_getsysinfo():
     test that it is easily jsonable and don't return bytes somewhere.
     """
     json.dumps(sysinfo.get_sys_info())
+
+
+def test_num_cpus():
+    with pytest.deprecated_call():
+        sysinfo.num_cpus()


### PR DESCRIPTION
`os.cpu_count()` exists since Python 3.4