### PR TITLE
Switch out off deprecated `asyncio.get_event_loop` call

### DIFF
--- a/IPython/core/async_helpers.py
+++ b/IPython/core/async_helpers.py
@@ -25,7 +25,7 @@ class _AsyncIORunner:
         """
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(coro)
+        return asyncio.get_event_loop_policy().get_event_loop().run_until_complete(coro)
 
     def __str__(self):
         return 'asyncio'

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -81,7 +81,7 @@ def safe_watcher():
         yield
         return
 
-    loop = asyncio.get_event_loop()
+    loop = policy.get_event_loop()
     try:
         watcher = asyncio.SafeChildWatcher()
         watcher.attach_loop(loop)
@@ -238,7 +238,7 @@ class ScriptMagics(Magics):
 
         if sys.platform.startswith("win"):
             asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_event_loop_policy().get_event_loop()
         argv = arg_split(line, posix=not sys.platform.startswith("win"))
         args, cmd = self.shebang.parser.parse_known_args(argv)
         try:

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -1039,7 +1039,7 @@ def test_custom_exc_count():
 
 
 def test_run_cell_async():
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_event_loop_policy().get_event_loop()
     ip.run_cell("import asyncio")
     coro = ip.run_cell_async("await asyncio.sleep(0.01)\n5")
     assert asyncio.iscoroutine(coro)

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -967,17 +967,22 @@ def test_script_config():
     assert "whoda" in sm.magics["cell"]
 
 
+@pytest.fixture
+def event_loop():
+    yield asyncio.get_event_loop_policy().get_event_loop()
+
+
 @dec.skip_iptest_but_not_pytest
 @dec.skip_win32
 @pytest.mark.skipif(
     sys.platform == "win32", reason="This test does not run under Windows"
 )
-def test_script_out():
-    assert asyncio.get_event_loop().is_running() is False
+def test_script_out(event_loop):
+    assert event_loop.is_running() is False
 
     ip = get_ipython()
     ip.run_cell_magic("script", "--out output sh", "echo 'hi'")
-    assert asyncio.get_event_loop().is_running() is False
+    assert event_loop.is_running() is False
     assert ip.user_ns["output"] == "hi\n"
 
 
@@ -986,11 +991,11 @@ def test_script_out():
 @pytest.mark.skipif(
     sys.platform == "win32", reason="This test does not run under Windows"
 )
-def test_script_err():
+def test_script_err(event_loop):
     ip = get_ipython()
-    assert asyncio.get_event_loop().is_running() is False
+    assert event_loop.is_running() is False
     ip.run_cell_magic("script", "--err error sh", "echo 'hello' >&2")
-    assert asyncio.get_event_loop().is_running() is False
+    assert event_loop.is_running() is False
     assert ip.user_ns["error"] == "hello\n"
 
 
@@ -1014,12 +1019,12 @@ def test_script_out_err():
 @pytest.mark.skipif(
     sys.platform == "win32", reason="This test does not run under Windows"
 )
-async def test_script_bg_out():
+async def test_script_bg_out(event_loop):
     ip = get_ipython()
     ip.run_cell_magic("script", "--bg --out output sh", "echo 'hi'")
     assert (await ip.user_ns["output"].read()) == b"hi\n"
     ip.user_ns["output"].close()
-    asyncio.get_event_loop().stop()
+    event_loop.stop()
 
 
 @dec.skip_iptest_but_not_pytest

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -648,7 +648,7 @@ class TerminalInteractiveShell(InteractiveShell):
                 # When we integrate the asyncio event loop, run the UI in the
                 # same event loop as the rest of the code. don't use an actual
                 # input hook. (Asyncio is not made for nesting event loops.)
-                self.pt_loop = asyncio.get_event_loop()
+                self.pt_loop = asyncio.get_event_loop_policy().get_event_loop()
 
             elif self._inputhook:
                 # If an inputhook was set, create a new asyncio event loop with

--- a/IPython/terminal/pt_inputhooks/asyncio.py
+++ b/IPython/terminal/pt_inputhooks/asyncio.py
@@ -35,7 +35,7 @@ PTK3 = ptk_version.startswith('3.')
 
 # Keep reference to the original asyncio loop, because getting the event loop
 # within the input hook would return the other loop.
-loop = asyncio.get_event_loop()
+loop = asyncio.get_event_loop_policy().get_event_loop()
 
 
 def inputhook(context):


### PR DESCRIPTION
This seems to be the safest way to deal with the deprecation warning.
