### PR TITLE
Use sphinxify (if available) in object_inspect_mime path

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1813,8 +1813,9 @@ class InteractiveShell(SingletonConfigurable):
         with self.builtin_trap:
             info = self._object_find(oname)
             if info.found:
+                docformat = sphinxify if self.sphinxify_docstring else None
                 return self.inspector._get_info(info.obj, oname, info=info,
-                            detail_level=detail_level
+                            detail_level=detail_level, formatter=docformat
                 )
             else:
                 raise KeyError(oname)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1814,8 +1814,12 @@ class InteractiveShell(SingletonConfigurable):
             info = self._object_find(oname)
             if info.found:
                 docformat = sphinxify if self.sphinxify_docstring else None
-                return self.inspector._get_info(info.obj, oname, info=info,
-                            detail_level=detail_level, formatter=docformat
+                return self.inspector._get_info(
+                    info.obj,
+                    oname,
+                    info=info,
+                    detail_level=detail_level,
+                    formatter=docformat,
                 )
             else:
                 raise KeyError(oname)


### PR DESCRIPTION
Background: if we use `%pinfo` line magic (or equivalently `?`; and similarly for `pinfo2` and `??`), we will call `interactiveshell`'s `_inspect` method which automatically uses the docrepr module (if available and activated) to beautifully format docstrings.

However, if we use the lower-level `object_inspect_mime` public method in `interactiveshell`, docrepr is not used.

(Sidenote: practically speaking, this function is called from JupyterLab's Context Help, which creates an "inspect_request" message, which in turns calls `object_inspect_mime`.)

This commit enables `object_inspect_mime` to use the same functionality as `_inspect`: see https://github.com/ipython/ipython/blob/66843b1ea573772309a6b29a69b2afd4641ae0d1/IPython/core/interactiveshell.py#L1763-L1769