### PR TITLE
Deprecate `IPython.utils.version`

### DIFF
--- a/IPython/external/qt_for_kernel.py
+++ b/IPython/external/qt_for_kernel.py
@@ -31,7 +31,6 @@ else:
 import os
 import sys
 
-from IPython.utils.version import check_version
 from IPython.external.qt_loaders import (
     load_qt,
     loaded_api,
@@ -101,8 +100,8 @@ def get_options():
 
     mpl = sys.modules.get('matplotlib', None)
 
-    if mpl is not None and not check_version(mpl.__version__, '1.0.2'):
-        #1.0.1 only supports PyQt4 v1
+    if mpl is not None and tuple(mpl.__version__.split(".")) < ("1", "0", "2"):
+        # 1.0.1 only supports PyQt4 v1
         return [QT_API_PYQT_DEFAULT]
 
     qt_api = os.environ.get('QT_API', None)

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -13,8 +13,6 @@ import types
 from functools import partial, lru_cache
 import operator
 
-from IPython.utils.version import check_version
-
 # ### Available APIs.
 # Qt6
 QT_API_PYQT6 = "pyqt6"
@@ -149,7 +147,8 @@ def has_binding(api):
     if api == QT_API_PYSIDE:
         # We can also safely check PySide version
         import PySide
-        return check_version(PySide.__version__, '1.0.3')
+
+        return PySide.__version_info__ >= (1, 0, 3)
 
     return True
 
@@ -211,7 +210,7 @@ def import_pyqt4(version=2):
 
     from PyQt4 import QtGui, QtCore, QtSvg
 
-    if not check_version(QtCore.PYQT_VERSION_STR, '4.7'):
+    if QtCore.PYQT_VERSION < 0x040700:
         raise ImportError("IPython requires PyQt4 >= 4.7, found %s" %
                           QtCore.PYQT_VERSION_STR)
 

--- a/IPython/utils/version.py
+++ b/IPython/utils/version.py
@@ -12,15 +12,10 @@ It is a bit ridiculous that we need these.
 #  the file COPYING, distributed as part of this software.
 #-----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
-# Imports
-#-----------------------------------------------------------------------------
+from warnings import warn
 
-from distutils.version import LooseVersion
+warn("The `IPython.utils.version` module has been deprecated since IPython 8.0.")
 
-#-----------------------------------------------------------------------------
-# Code
-#-----------------------------------------------------------------------------
 
 def check_version(v, check):
     """check version string v >= check
@@ -29,6 +24,15 @@ def check_version(v, check):
     it is assumed that the dependency is satisfied.
     Users on dev branches are responsible for keeping their own packages up to date.
     """
+    warn(
+        "`check_version` function is deprecated as of IPython 8.0"
+        "and will be removed in future versions.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    from distutils.version import LooseVersion
+
     try:
         return LooseVersion(v) >= LooseVersion(check)
     except TypeError:

--- a/pytest.ini
+++ b/pytest.ini
@@ -43,5 +43,6 @@ addopts = --durations=10
     --ignore=IPython/utils/log.py
     --ignore=IPython/utils/signatures.py
     --ignore=IPython/utils/traitlets.py
+    --ignore=IPython/utils/version.py
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 ipdoctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS


### PR DESCRIPTION
The `distutils.version.LooseVersion` is deprecated and there is no replacement in the standard library.