### PR TITLE
Enable `check_make_token_by_line_never_ends_empty` test

### DIFF
--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -143,7 +143,8 @@ def null_cleanup_transformer(lines):
     """
     return []
 
-def check_make_token_by_line_never_ends_empty():
+
+def test_check_make_token_by_line_never_ends_empty():
     """
     Check that not sequence of single or double characters ends up leading to en empty list of tokens
     """


### PR DESCRIPTION
It was added in 28a8ea639a7a37bfb03ee87d397ea5e69dcc537e but missed `test_` prefix in the name.

Note: There is a type mismatch in calls to `make_tokens_by_line` but that does not lead to an error.