### PR TITLE
test_path: revive match tests

### DIFF
--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -390,7 +390,7 @@ class TestShellGlob(unittest.TestCase):
                 ([r'a\*', 'a*'], ['a*'] + self.filenames_start_with_a),
                 ([r'a\[012]'], ['a[012]']),
                 ]:
-            yield (self.check_match, patterns, matches)
+            self.check_match(patterns, matches)
 
     @skip_if_not_win32
     def test_match_windows(self):
@@ -401,7 +401,7 @@ class TestShellGlob(unittest.TestCase):
                 ([r'a\*', 'a*'], [r'a\*'] + self.filenames_start_with_a),
                 ([r'a\[012]'], [r'a\[012]']),
                 ]:
-            yield (self.check_match, patterns, matches)
+            self.check_match(patterns, matches)
 
 
 # TODO : pytest.mark.parametrise once nose is gone.


### PR DESCRIPTION
These tests had not been running on Nose and I did not spot that previously.