### PR TITLE
Use ThreadPoolExecutor for debugger cmdloop, solving infinite thread-creation and traceback loop

### DIFF
--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -1,11 +1,8 @@
 import asyncio
 import os
 import sys
-import threading
 
 from IPython.core.debugger import Pdb
-
-
 from IPython.core.completer import IPCompleter
 from .ptutils import IPythonPTCompleter
 from .shortcuts import create_ipython_shortcuts
@@ -17,6 +14,7 @@ from prompt_toolkit.shortcuts.prompt import PromptSession
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.formatted_text import PygmentsTokens
 from prompt_toolkit.history import InMemoryHistory, FileHistory
+from concurrent.futures import ThreadPoolExecutor
 
 from prompt_toolkit import __version__ as ptk_version
 PTK3 = ptk_version.startswith('3.')
@@ -29,6 +27,7 @@ class TerminalPdb(Pdb):
         Pdb.__init__(self, *args, **kwargs)
         self._ptcomp = None
         self.pt_init(pt_session_options)
+        self.thread_executor = ThreadPoolExecutor(1)
 
     def pt_init(self, pt_session_options=None):
         """Initialize the prompt session and the prompt loop
@@ -110,7 +109,7 @@ class TerminalPdb(Pdb):
             if intro is not None:
                 self.intro = intro
             if self.intro:
-                self.stdout.write(str(self.intro)+"\n")
+                print(self.intro, file=self.stdout)
             stop = None
             while not stop:
                 if self.cmdqueue:
@@ -120,24 +119,11 @@ class TerminalPdb(Pdb):
                     self._ptcomp.ipy_completer.global_namespace = self.curframe.f_globals
 
                     # Run the prompt in a different thread.
-                    line = ''
-                    keyboard_interrupt = False
+                    try:
+                        line = self.thread_executor.submit(self.pt_app.prompt).result()
+                    except EOFError:
+                        line = "EOF"
 
-                    def in_thread():
-                        nonlocal line, keyboard_interrupt
-                        try:
-                            line = self.pt_app.prompt()
-                        except EOFError:
-                            line = 'EOF'
-                        except KeyboardInterrupt:
-                            keyboard_interrupt = True
-
-                    th = threading.Thread(target=in_thread)
-                    th.start()
-                    th.join()
-
-                    if keyboard_interrupt:
-                        raise KeyboardInterrupt
                 line = self.precmd(line)
                 stop = self.onecmd(line)
                 stop = self.postcmd(stop, line)


### PR DESCRIPTION
In `TerminalPdb.cmdloop`, the prompt is run on a separate thread. This is done using `threading.Thread.start` + `threading.Thread.join` in a loop. When `self.pt_app.prompt` fails with an exception other than `EOFError` or `KeyboardInterrupt`, it causes an infinite loop that creates threads which fail immediately and print their traceback.

On my linux it is recreatable using the following script:
```python
from concurrent.futures import ProcessPoolExecutor
import ipdb

ipdb.set_trace()
ProcessPoolExecutor(1).submit(ipdb.set_trace).result()
```

Instead of using the low-level `threading.Thread`, I propose using `ThreadPoolExecutor`, which can handily retrieve return values from the thread, and reraise exceptions raised in it. It simplifies the existing code and prevents the infinite loop issue.

This also solves an issue with the debugger which I ran into using `madbg` - https://github.com/kmaork/madbg/issues/28, in which sending a `SIGINT` to the debugger while it is in the background also caused this infinite traceback loop (maybe an issue similar to https://github.com/ipython/ipython/issues/12267), so a backport would be awesome 😄 