### PR TITLE
Stop support for 3.7 on the master branch.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         deps: [test_extra]
         # Test all on ubuntu, test ends on macos
         include:
           - os: macos-latest
-            python-version: "3.7"
+            python-version: "3.8"
             deps: test_extra
           - os: macos-latest
             python-version: "3.10"

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 IPython: tools for interactive and parallel computing in Python.
 
@@ -27,13 +26,15 @@ import sys
 #-----------------------------------------------------------------------------
 
 # Don't forget to also update setup.py when this changes!
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 8):
     raise ImportError(
 """
-IPython 7.10+ supports Python 3.6 and above.
+IPython 8+ supports Python 3.8 and above, following NEP 29.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
 Python 3.3 and 3.4 were supported up to IPython 6.x.
 Python 3.5 was supported with IPython 7.0 to 7.9.
+Python 3.6 was supported with IPython up to 7.16.
+Python 3.7 was still supported with the 7.x branch.
 
 See IPython `README.rst` file for more information:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
     COLUMNS: 120  # Appveyor web viwer window width is 130 chars
 
   matrix:
-
    - PYTHON: "C:\\Python38"
      PYTHON_VERSION: "3.8.x"
      PYTHON_ARCH: "32"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from pathlib import Path
 #
 # This check is also made in IPython/__init__, don't forget to update both when
 # changing Python version requirements.
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
     try:
         import pip
@@ -41,11 +41,12 @@ if sys.version_info < (3, 7):
 
 
     error = """
-IPython 7.17+ supports Python 3.7 and above, following NEP 29.
+IPython 8+ supports Python 3.8 and above, following NEP 29.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
 Python 3.3 and 3.4 were supported up to IPython 6.x.
 Python 3.5 was supported with IPython 7.0 to 7.9.
 Python 3.6 was supported with IPython up to 7.16.
+Python 3.7 was still supported with the 7.x branch.
 
 See IPython `README.rst` file for more information:
 
@@ -244,15 +245,15 @@ for key, deps in extras_require.items():
         everything.update(deps)
 extras_require['all'] = list(sorted(everything))
 
-if 'setuptools' in sys.modules:
-    setuptools_extra_args['python_requires'] = '>=3.7'
-    setuptools_extra_args['zip_safe'] = False
-    setuptools_extra_args['entry_points'] = {
-        'console_scripts': find_entry_points(),
-        'pygments.lexers': [
-            'ipythonconsole = IPython.lib.lexers:IPythonConsoleLexer',
-            'ipython = IPython.lib.lexers:IPythonLexer',
-            'ipython3 = IPython.lib.lexers:IPython3Lexer',
+if "setuptools" in sys.modules:
+    setuptools_extra_args["python_requires"] = ">=3.8"
+    setuptools_extra_args["zip_safe"] = False
+    setuptools_extra_args["entry_points"] = {
+        "console_scripts": find_entry_points(),
+        "pygments.lexers": [
+            "ipythonconsole = IPython.lib.lexers:IPythonConsoleLexer",
+            "ipython = IPython.lib.lexers:IPythonLexer",
+            "ipython3 = IPython.lib.lexers:IPython3Lexer",
         ],
     }
     setup_args['extras_require'] = extras_require


### PR DESCRIPTION
According to NEP 29, Python 3.7 support can be stopped this december.

https://numpy.org/neps/nep-0029-deprecation_policy.html

Here we start dropping support for 3.7 as we'll release 8.0 likely early
2022