### PR TITLE
Move most of Windows test runners to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         deps: [test_extra]
         # Test all on ubuntu, test ends on macos
@@ -49,11 +49,12 @@ jobs:
         python -m pip install --upgrade -e .[${{ matrix.deps }}]
         python -m pip install --upgrade check-manifest pytest-cov
     - name: Check manifest
+      if: runner.os != 'Windows'  # setup.py does not support sdist on Windows
       run: check-manifest
     - name: pytest
       env:
         COLUMNS: 120
       run: |
-        pytest --color=yes -v --cov --cov-report=xml
+        pytest --color=yes -ra -v --cov --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/IPython/extensions/tests/test_storemagic.py
+++ b/IPython/extensions/tests/test_storemagic.py
@@ -1,4 +1,5 @@
 import tempfile, os
+from pathlib import Path
 
 from traitlets.config.loader import Config
 
@@ -43,7 +44,7 @@ def test_store_restore():
     assert ip.user_ns["foobaz"] == "80"
 
     ip.magic("store -r")  # restores _dh too
-    assert os.path.realpath(tmpd) in ip.user_ns["_dh"]
+    assert any(Path(tmpd).samefile(p) for p in ip.user_ns["_dh"])
 
     os.rmdir(tmpd)
 

--- a/IPython/utils/tests/test_tempdir.py
+++ b/IPython/utils/tests/test_tempdir.py
@@ -22,8 +22,8 @@ def test_named_file_in_temporary_directory():
 
 def test_temporary_working_directory():
     with TemporaryWorkingDirectory() as directory:
-        directory_path = Path(directory)
+        directory_path = Path(directory).resolve()
         assert directory_path.exists()
-        assert Path.cwd() == directory_path.resolve()
+        assert Path.cwd().resolve() == directory_path
     assert not directory_path.exists()
-    assert Path.cwd() != directory_path.resolve()
+    assert Path.cwd().resolve() != directory_path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,21 +9,9 @@ environment:
 
   matrix:
 
-   - PYTHON: "C:\\Python310-x64"
-     PYTHON_VERSION: "3.10.x"
-     PYTHON_ARCH: "64"
-
-   - PYTHON: "C:\\Python37-x64"
-     PYTHON_VERSION: "3.7.x"
-     PYTHON_ARCH: "64"
-
    - PYTHON: "C:\\Python38"
      PYTHON_VERSION: "3.8.x"
      PYTHON_ARCH: "32"
-
-   - PYTHON: "C:\\Python38-x64"
-     PYTHON_VERSION: "3.8.x"
-     PYTHON_ARCH: "64"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"


### PR DESCRIPTION
Leave only 32-bit jobs on Appveyor, I don't know how to configure actions/setup-python to install 32-bit CPython.