### PR TITLE
Fix: Add custom repr to pretty print collections.UserList

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -926,7 +926,7 @@ def _userlist_pprint(obj, p, cycle):
     if cycle:
         p.pretty(cls_ctor(RawText("...")))
     else:
-        p.pretty(cls_ctor(list(obj)))
+        p.pretty(cls_ctor(obj.data))
 
 
 for_type_by_name('collections', 'defaultdict', _defaultdict_pprint)

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -920,10 +920,20 @@ def _counter_pprint(obj, p, cycle):
     else:
         p.pretty(cls_ctor())
 
+
+def _userlist_pprint(obj, p, cycle):
+    cls_ctor = CallExpression.factory(obj.__class__.__name__)
+    if cycle:
+        p.pretty(cls_ctor(RawText("...")))
+    else:
+        p.pretty(cls_ctor(list(obj)))
+
+
 for_type_by_name('collections', 'defaultdict', _defaultdict_pprint)
 for_type_by_name('collections', 'OrderedDict', _ordereddict_pprint)
 for_type_by_name('collections', 'deque', _deque_pprint)
 for_type_by_name('collections', 'Counter', _counter_pprint)
+for_type_by_name("collections", "UserList", _userlist_pprint)
 
 if __name__ == '__main__':
     from random import randrange

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-from collections import Counter, defaultdict, deque, OrderedDict
+from collections import Counter, defaultdict, deque, OrderedDict, UserList
 import os
 import pytest
 import types
@@ -292,6 +292,42 @@ def test_basic_class():
 
     assert output == "%s.MyObj" % __name__
     assert type_pprint_wrapper.called is True
+
+
+def test_collections_userlist():
+    # Create userlist with cycle
+    a = UserList()
+    a.append(a)
+
+    cases = [
+        (UserList(), "UserList([])"),
+        (
+            UserList(i for i in range(1000, 1020)),
+            "UserList([1000,\n"
+            "          1001,\n"
+            "          1002,\n"
+            "          1003,\n"
+            "          1004,\n"
+            "          1005,\n"
+            "          1006,\n"
+            "          1007,\n"
+            "          1008,\n"
+            "          1009,\n"
+            "          1010,\n"
+            "          1011,\n"
+            "          1012,\n"
+            "          1013,\n"
+            "          1014,\n"
+            "          1015,\n"
+            "          1016,\n"
+            "          1017,\n"
+            "          1018,\n"
+            "          1019])",
+        ),
+        (a, "UserList([UserList(...)])"),
+    ]
+    for obj, expected in cases:
+        assert pretty.pretty(obj) == expected
 
 
 # TODO : pytest.mark.parametrise once nose is gone.


### PR DESCRIPTION
Implemented `_userlist_pprint` to enable pretty printing of `collections.UserList`.
Followed convention of previously implemented pprints of other container types of the collections module.
solved against issue #13283 

Eg Usage:
```
In [3]: collections.UserList(range(5))
Out[3]: UserList([0, 1, 2, 3, 4])

In [4]: collections.UserList(range(50))
Out[4]: 
UserList([0,
          1,
          2,
          3,
          4,
         ...
          46,
          47,
          48,
          49])
```