### PR TITLE
Remove pre-3.8 codepath in interactiveshell.py

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -690,7 +690,6 @@ class InteractiveShell(SingletonConfigurable):
         self.init_pdb()
         self.init_extension_manager()
         self.init_payload()
-        self.init_deprecation_warnings()
         self.hooks.late_startup_hook()
         self.events.trigger('shell_initialized', self)
         atexit.register(self.atexit_operations)
@@ -815,16 +814,6 @@ class InteractiveShell(SingletonConfigurable):
             self.magic('logstart %s' % self.logfile)
         elif self.logstart:
             self.magic('logstart')
-
-    def init_deprecation_warnings(self):
-        """
-        register default filter for deprecation warning.
-
-        This will allow deprecation warning of function used interactively to show
-        warning to users, and still hide deprecation warning from libraries import.
-        """
-        if sys.version_info < (3,7):
-            warnings.filterwarnings("default", category=DeprecationWarning, module=self.user_ns.get("__name__"))
 
 
     def init_builtins(self):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -123,7 +123,7 @@ _single_targets_nodes = (ast.AugAssign, ast.AnnAssign)
 
 # we still need to run things using the asyncio eventloop, but there is no
 # async integration
-from .async_helpers import (_asyncio_runner, _pseudo_sync_runner)
+from .async_helpers import _asyncio_runner, _pseudo_sync_runner
 from .async_helpers import _curio_runner, _trio_runner, _should_be_async
 
 #-----------------------------------------------------------------------------
@@ -3224,27 +3224,32 @@ class InteractiveShell(SingletonConfigurable):
             raise ValueError("Interactivity was %r" % interactivity)
 
         try:
+
             def compare(code):
-                is_async = (inspect.CO_COROUTINE & code.co_flags == inspect.CO_COROUTINE)
+                is_async = inspect.CO_COROUTINE & code.co_flags == inspect.CO_COROUTINE
                 return is_async
 
             # refactor that to just change the mod constructor.
             to_run = []
             for node in to_run_exec:
-                to_run.append((node, 'exec'))
+                to_run.append((node, "exec"))
 
             for node in to_run_interactive:
-                to_run.append((node, 'single'))
+                to_run.append((node, "single"))
 
-            for node,mode in to_run:
-                if mode == 'exec':
+            for node, mode in to_run:
+                if mode == "exec":
                     mod = Module([node], [])
-                elif mode == 'single':
+                elif mode == "single":
                     mod = ast.Interactive([node])
-                with compiler.extra_flags(getattr(ast, 'PyCF_ALLOW_TOP_LEVEL_AWAIT', 0x0) if self.autoawait else 0x0):
+                with compiler.extra_flags(
+                    getattr(ast, "PyCF_ALLOW_TOP_LEVEL_AWAIT", 0x0)
+                    if self.autoawait
+                    else 0x0
+                ):
                     code = compiler(mod, cell_name, mode)
                     asy = compare(code)
-                if (await self.run_code(code, result,  async_=asy)):
+                if await self.run_code(code, result, async_=asy):
                     return True
 
             # Flush softspace
@@ -3302,7 +3307,7 @@ class InteractiveShell(SingletonConfigurable):
         try:
             try:
                 self.hooks.pre_run_code_hook()
-                if async_ :
+                if async_:
                     await eval(code_obj, self.user_global_ns, self.user_ns)
                 else:
                     exec(code_obj, self.user_global_ns, self.user_ns)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -112,13 +112,7 @@ class ProvisionalWarning(DeprecationWarning):
     """
     pass
 
-if sys.version_info > (3,8):
-    from ast import Module
-else :
-    # mock the new API, ignore second argument
-    # see https://github.com/ipython/ipython/issues/11590
-    from ast import Module as OriginalModule
-    Module = lambda nodelist, type_ignores: OriginalModule(nodelist)
+from ast import Module
 
 _assign_nodes = (ast.AugAssign, ast.AnnAssign, ast.Assign)
 _single_targets_nodes = (ast.AugAssign, ast.AnnAssign)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -83,7 +83,7 @@ from logging import error
 import IPython.core.hooks
 
 from typing import List as ListType, Tuple, Optional, Callable
-from ast import AST, stmt
+from ast import stmt
 
 
 # NoOpContext is deprecated, but ipykernel imports it from here.
@@ -121,104 +121,11 @@ _single_targets_nodes = (ast.AugAssign, ast.AnnAssign)
 # Await Helpers
 #-----------------------------------------------------------------------------
 
-def removed_co_newlocals(function:types.FunctionType) -> types.FunctionType:
-    """Return a function that do not create a new local scope.
-
-    Given a function, create a clone of this function where the co_newlocal flag
-    has been removed, making this function code actually run in the sourounding
-    scope.
-
-    We need this in order to run asynchronous code in user level namespace.
-    """
-    from types import CodeType, FunctionType
-    CO_NEWLOCALS = 0x0002
-    code = function.__code__
-    new_co_flags = code.co_flags & ~CO_NEWLOCALS
-    if sys.version_info > (3, 8, 0, 'alpha', 3):
-        new_code = code.replace(co_flags=new_co_flags)
-    else:
-        new_code = CodeType(
-            code.co_argcount,
-            code.co_kwonlyargcount,
-            code.co_nlocals,
-            code.co_stacksize,
-            new_co_flags,
-            code.co_code,
-            code.co_consts,
-            code.co_names,
-            code.co_varnames,
-            code.co_filename,
-            code.co_name,
-            code.co_firstlineno,
-            code.co_lnotab,
-            code.co_freevars,
-            code.co_cellvars
-        )
-    return FunctionType(new_code, globals(), function.__name__, function.__defaults__)
-
-
 # we still need to run things using the asyncio eventloop, but there is no
 # async integration
-from .async_helpers import (_asyncio_runner,  _asyncify, _pseudo_sync_runner)
+from .async_helpers import (_asyncio_runner, _pseudo_sync_runner)
 from .async_helpers import _curio_runner, _trio_runner, _should_be_async
 
-
-def _ast_asyncify(cell:str, wrapper_name:str) -> ast.Module:
-    """
-    Parse a cell with top-level await and modify the AST to be able to run it later.
-
-    Parameters
-    ----------
-    cell: str
-        The code cell to asyncronify
-    wrapper_name: str
-        The name of the function to be used to wrap the passed `cell`. It is
-        advised to **not** use a python identifier in order to not pollute the
-        global namespace in which the function will be ran.
-
-    Returns
-    -------
-    ModuleType:
-        A module object AST containing **one** function named `wrapper_name`.
-
-        The given code is wrapped in a async-def function, parsed into an AST, and
-        the resulting function definition AST is modified to return the last
-        expression.
-
-        The last expression or await node is moved into a return statement at the
-        end of the function, and removed from its original location. If the last
-        node is not Expr or Await nothing is done.
-
-        The function `__code__` will need to be later modified  (by
-        ``removed_co_newlocals``) in a subsequent step to not create new `locals()`
-        meaning that the local and global scope are the same, ie as if the body of
-        the function was at module level.
-
-        Lastly a call to `locals()` is made just before the last expression of the
-        function, or just after the last assignment or statement to make sure the
-        global dict is updated as python function work with a local fast cache which
-        is updated only on `local()` calls.
-    """
-
-    from ast import Expr, Await, Return, stmt, FunctionDef, Try, AsyncFunctionDef
-    if sys.version_info >= (3,8):
-        return ast.parse(cell)
-    tree = ast.parse(_asyncify(cell))
-
-    function_def = tree.body[0]
-    if sys.version_info > (3, 8):
-        assert isinstance(function_def, FunctionDef), function_def
-    else:
-        assert isinstance(function_def, (FunctionDef, AsyncFunctionDef)), function_def
-
-    function_def.name = wrapper_name
-    try_block = function_def.body[0]
-    assert isinstance(try_block, Try)
-    lastexpr = try_block.body[-1]
-    if isinstance(lastexpr, (Expr, Await)):
-        try_block.body[-1] = Return(lastexpr.value)
-    ast.fix_missing_locations(tree)
-    return tree
 #-----------------------------------------------------------------------------
 # Globals
 #-----------------------------------------------------------------------------
@@ -3136,28 +3043,7 @@ class InteractiveShell(SingletonConfigurable):
             with self.display_trap:
                 # Compile to bytecode
                 try:
-                    if sys.version_info < (3,8) and self.autoawait:
-                        if _should_be_async(cell):
-                            # the code AST below will not be user code: we wrap it
-                            # in an `async def`. This will likely make some AST
-                            # transformer below miss some transform opportunity and
-                            # introduce a small coupling to run_code (in which we
-                            # bake some assumptions of what _ast_asyncify returns.
-                            # they are ways around (like grafting part of the ast
-                            # later:
-                            #    - Here, return code_ast.body[0].body[1:-1], as well
-                            #    as last expression in  return statement which is
-                            #    the user code part.
-                            #    - Let it go through the AST transformers, and graft
-                            #    - it back after the AST transform
-                            # But that seem unreasonable, at least while we
-                            # do not need it.
-                            code_ast = _ast_asyncify(cell, 'async-def-wrapper')
-                            _run_async = True
-                        else:
-                            code_ast = compiler.ast_parse(cell, filename=cell_name)
-                    else:
-                        code_ast = compiler.ast_parse(cell, filename=cell_name)
+                    code_ast = compiler.ast_parse(cell, filename=cell_name)
                 except self.custom_exceptions as e:
                     etype, value, tb = sys.exc_info()
                     self.CustomTB(etype, value, tb)
@@ -3183,8 +3069,6 @@ class InteractiveShell(SingletonConfigurable):
 
                 # Execute the user code
                 interactivity = "none" if silent else self.ast_node_interactivity
-                if _run_async:
-                    interactivity = 'async'
 
                 has_raised = await self.run_ast_nodes(code_ast.body, cell_name,
                        interactivity=interactivity, compiler=compiler, result=result)
@@ -3293,11 +3177,6 @@ class InteractiveShell(SingletonConfigurable):
           or the last assignment. Other values for this parameter will raise a
           ValueError.
 
-          Experimental value: 'async' Will try to run top level interactive
-          async/await code in default runner, this will not respect the
-          interactivity setting and will only run the last node if it is an
-          expression.
-
         compiler : callable
           A function with the same interface as the built-in compile(), to turn
           the AST nodes into code objects. Default is the built-in compile().
@@ -3341,52 +3220,32 @@ class InteractiveShell(SingletonConfigurable):
             to_run_exec, to_run_interactive = nodelist[:-1], nodelist[-1:]
         elif interactivity == 'all':
             to_run_exec, to_run_interactive = [], nodelist
-        elif interactivity == 'async':
-            to_run_exec, to_run_interactive = [], nodelist
-            _async = True
         else:
             raise ValueError("Interactivity was %r" % interactivity)
 
         try:
-            if _async and sys.version_info > (3,8):
-                raise ValueError("This branch should never happen on Python 3.8 and above, "
-                                 "please try to upgrade IPython and open a bug report with your case.")
-            if _async:
-                # If interactivity is async the semantics of run_code are
-                # completely different Skip usual machinery.
-                mod = Module(nodelist, [])
-                async_wrapper_code = compiler(mod, cell_name, 'exec')
-                exec(async_wrapper_code, self.user_global_ns, self.user_ns)
-                async_code = removed_co_newlocals(self.user_ns.pop('async-def-wrapper')).__code__
-                if (await self.run_code(async_code, result, async_=True)):
+            def compare(code):
+                is_async = (inspect.CO_COROUTINE & code.co_flags == inspect.CO_COROUTINE)
+                return is_async
+
+            # refactor that to just change the mod constructor.
+            to_run = []
+            for node in to_run_exec:
+                to_run.append((node, 'exec'))
+
+            for node in to_run_interactive:
+                to_run.append((node, 'single'))
+
+            for node,mode in to_run:
+                if mode == 'exec':
+                    mod = Module([node], [])
+                elif mode == 'single':
+                    mod = ast.Interactive([node])
+                with compiler.extra_flags(getattr(ast, 'PyCF_ALLOW_TOP_LEVEL_AWAIT', 0x0) if self.autoawait else 0x0):
+                    code = compiler(mod, cell_name, mode)
+                    asy = compare(code)
+                if (await self.run_code(code, result,  async_=asy)):
                     return True
-            else:
-                if sys.version_info > (3, 8):
-                    def compare(code):
-                        is_async = (inspect.CO_COROUTINE & code.co_flags == inspect.CO_COROUTINE)
-                        return is_async
-                else:
-                    def compare(code):
-                        return _async
-
-                # refactor that to just change the mod constructor.
-                to_run = []
-                for node in to_run_exec:
-                    to_run.append((node, 'exec'))
-
-                for node in to_run_interactive:
-                    to_run.append((node, 'single'))
-
-                for node,mode in to_run:
-                    if mode == 'exec':
-                        mod = Module([node], [])
-                    elif mode == 'single':
-                        mod = ast.Interactive([node])
-                    with compiler.extra_flags(getattr(ast, 'PyCF_ALLOW_TOP_LEVEL_AWAIT', 0x0) if self.autoawait else 0x0):
-                        code = compiler(mod, cell_name, mode)
-                        asy = compare(code)
-                    if (await self.run_code(code, result,  async_=asy)):
-                        return True
 
             # Flush softspace
             if softspace(sys.stdout, 0):
@@ -3408,21 +3267,6 @@ class InteractiveShell(SingletonConfigurable):
             return True
 
         return False
-
-    def _async_exec(self, code_obj: types.CodeType, user_ns: dict):
-        """
-        Evaluate an asynchronous code object using a code runner
-
-        Fake asynchronous execution of code_object in a namespace via a proxy namespace.
-
-        Returns coroutine object, which can be executed via async loop runner
-
-        WARNING: The semantics of `async_exec` are quite different from `exec`,
-        in particular you can only pass a single namespace. It also return a
-        handle to the value of the last things returned by code_object.
-        """
-
-        return eval(code_obj, user_ns)
 
     async def run_code(self, code_obj, result=None, *, async_=False):
         """Execute a code object.
@@ -3458,11 +3302,7 @@ class InteractiveShell(SingletonConfigurable):
         try:
             try:
                 self.hooks.pre_run_code_hook()
-                if async_ and sys.version_info < (3,8):
-                    last_expr = (await self._async_exec(code_obj, self.user_ns))
-                    code = compile('last_expr', 'fake', "single")
-                    exec(code, {'last_expr': last_expr})
-                elif async_ :
+                if async_ :
                     await eval(code_obj, self.user_global_ns, self.user_ns)
                 else:
                     exec(code_obj, self.user_global_ns, self.user_ns)


### PR DESCRIPTION
Related to #13316.
The last commit is pretty big. The main change is the removal of ast_asyncify() and the rest is the removal of affected code.
I checked it against the coverage changes seen in https://app.codecov.io/gh/ipython/ipython/compare/13315/changes for this file.