### PR TITLE
Allow more control over what sections of the "info" messages are desired via a sections blocklist

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1804,7 +1804,7 @@ class InteractiveShell(SingletonConfigurable):
         """Get object info as formatted text"""
         return self.object_inspect_mime(oname, detail_level)['text/plain']
 
-    def object_inspect_mime(self, oname, detail_level=0):
+    def object_inspect_mime(self, oname, detail_level=0, omit_sections={}):
         """Get object info as a mimebundle of formatted representations.
 
         A mimebundle is a dictionary, keyed by mime-type.
@@ -1820,6 +1820,7 @@ class InteractiveShell(SingletonConfigurable):
                     info=info,
                     detail_level=detail_level,
                     formatter=docformat,
+                    omit_sections=omit_sections,
                 )
             else:
                 raise KeyError(oname)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1804,7 +1804,7 @@ class InteractiveShell(SingletonConfigurable):
         """Get object info as formatted text"""
         return self.object_inspect_mime(oname, detail_level)['text/plain']
 
-    def object_inspect_mime(self, oname, detail_level=0, omit_sections={}):
+    def object_inspect_mime(self, oname, detail_level=0, omit_sections=()):
         """Get object info as a mimebundle of formatted representations.
 
         A mimebundle is a dictionary, keyed by mime-type.

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -567,7 +567,7 @@ class Inspector(Colorable):
         return bundle
 
     def _get_info(
-        self, obj, oname="", formatter=None, info=None, detail_level=0, omit_sections={}
+        self, obj, oname="", formatter=None, info=None, detail_level=0, omit_sections=()
     ):
         """Retrieve an info dict and format it.
 
@@ -583,8 +583,8 @@ class Inspector(Colorable):
             already computed information
         detail_level: integer
             Granularity of detail level, if set to 1, give more information.
-        omit_sections: set[str]
-            Titles or keys to omit from output
+        omit_sections: container[str]
+            Titles or keys to omit from output (can be set, tuple, etc., anything supporting `in`)
         """
 
         info = self._info(obj, oname=oname, info=info, detail_level=detail_level)
@@ -669,7 +669,7 @@ class Inspector(Colorable):
         info=None,
         detail_level=0,
         enable_html_pager=True,
-        omit_sections={},
+        omit_sections=(),
     ):
         """Show detailed information about an object.
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -566,7 +566,9 @@ class Inspector(Colorable):
         bundle['text/plain'] = text
         return bundle
 
-    def _get_info(self, obj, oname='', formatter=None, info=None, detail_level=0, omit_sections={}):
+    def _get_info(
+        self, obj, oname="", formatter=None, info=None, detail_level=0, omit_sections={}
+    ):
         """Retrieve an info dict and format it.
 
         Parameters
@@ -659,7 +661,16 @@ class Inspector(Colorable):
 
         return self.format_mime(_mime)
 
-    def pinfo(self, obj, oname='', formatter=None, info=None, detail_level=0, enable_html_pager=True, omit_sections={}):
+    def pinfo(
+        self,
+        obj,
+        oname="",
+        formatter=None,
+        info=None,
+        detail_level=0,
+        enable_html_pager=True,
+        omit_sections={},
+    ):
         """Show detailed information about an object.
 
         Optional arguments:
@@ -683,7 +694,9 @@ class Inspector(Colorable):
 
         - omit_sections: set of section keys and titles to omit
         """
-        info = self._get_info(obj, oname, formatter, info, detail_level, omit_sections=omit_sections)
+        info = self._get_info(
+            obj, oname, formatter, info, detail_level, omit_sections=omit_sections
+        )
         if not enable_html_pager:
             del info['text/html']
         page.page(info)

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -566,7 +566,7 @@ class Inspector(Colorable):
         bundle['text/plain'] = text
         return bundle
 
-    def _get_info(self, obj, oname='', formatter=None, info=None, detail_level=0):
+    def _get_info(self, obj, oname='', formatter=None, info=None, detail_level=0, omit_sections={}):
         """Retrieve an info dict and format it.
 
         Parameters
@@ -581,6 +581,8 @@ class Inspector(Colorable):
             already computed information
         detail_level: integer
             Granularity of detail level, if set to 1, give more information.
+        omit_sections: set[str]
+            Titles or keys to omit from output
         """
 
         info = self._info(obj, oname=oname, info=info, detail_level=detail_level)
@@ -591,6 +593,8 @@ class Inspector(Colorable):
         }
 
         def append_field(bundle, title:str, key:str, formatter=None):
+            if title in omit_sections or key in omit_sections:
+                return
             field = info[key]
             if field is not None:
                 formatted_field = self._mime_format(field, formatter)
@@ -655,7 +659,7 @@ class Inspector(Colorable):
 
         return self.format_mime(_mime)
 
-    def pinfo(self, obj, oname='', formatter=None, info=None, detail_level=0, enable_html_pager=True):
+    def pinfo(self, obj, oname='', formatter=None, info=None, detail_level=0, enable_html_pager=True, omit_sections={}):
         """Show detailed information about an object.
 
         Optional arguments:
@@ -676,8 +680,10 @@ class Inspector(Colorable):
           precomputed already.
 
         - detail_level: if set to 1, more information is given.
+
+        - omit_sections: set of section keys and titles to omit
         """
-        info = self._get_info(obj, oname, formatter, info, detail_level)
+        info = self._get_info(obj, oname, formatter, info, detail_level, omit_sections=omit_sections)
         if not enable_html_pager:
             del info['text/html']
         page.page(info)


### PR DESCRIPTION
Currently, IPython responds to (1) `pinfo` messages or to (2) ipykernel's "inspect" messages (which invoke IPython's `object_inspect_mime` function) by building a document containing a number of sections, for example, for `numpy.sin` we get 
- Call signature
- Type
- String form
- File
- Docstring
- Class docstring

<details>
<summary>(Code snippet to generate HTML, for example)</summary>

```py
from IPython.core.oinspect import Inspector
import numpy as np

a = Inspector()._get_info(np.sin)
with open('foo.html', 'w') as fid:
    fid.write(a['text/html'])
```

</details>

In order to support building richer documentation browsers, it would be helpful to customize which sections are desired in the output. For example, we might be interested in displaying *just* the docstring to beginners using Jupyter notebooks.

Of course IPython's clients are free to analyze the text/HTML and remove the sections they don't want, but it would be nice to specify which sections a client wants because it can
- reduce runtime (generating HTML documentation with [Docrepr](https://github.com/spyder-ide/docrepr) involves calling Sphinx),
- reduce bandwidth to transmit documentation that won't be displayed, and
- generally fits with our desire to let frontends for exactly the information they want of backends.

This PR makes a small change to the core private method, `Inspector._get_info`, allowing it to skip sections that callers don't want based on a new keyword argument. This method is invoked by both "info" and "inspect" messages, and so I've threaded the new argument up to some public methods.

With this in place, clients can customize which sections they *don't* want to see. A couple of open questions remain:

- are we interested in *further* customization of the output? This PR only adds a list of sections to *omit*. The inverse of that would be explicitly a list of sections you *want*. I chose to add just the former to gauge interest, I am happy to add the latter.
- Are there other users of Inspector's private `_get_info` that I'm missing?