### PR TITLE
Don't add ipython unconditionally to sys.path

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -185,14 +185,16 @@ class BaseIPythonApplication(Application):
                 get_ipython_package_dir(), u'config', u'profile', change['new']
         )
 
-    add_ipython_dir_to_sys_path = Bool(False,
+    add_ipython_dir_to_sys_path = Bool(
+        False,
         """Should the IPython profile directory be added to sys path ?
 
         This option was non-existing before IPython 8.0, and ipython_dir was added to
         sys path to allow import of extensions present there. This was historical
         baggage from when pip did not exist. This now default to false,
         but can be set to true for legacy reasons.
-        """).tag(config=True)
+        """,
+    ).tag(config=True)
 
     ipython_dir = Unicode(
         help="""
@@ -307,11 +309,13 @@ class BaseIPythonApplication(Application):
             str_path = os.path.abspath(new)
             sys.path.append(str_path)
             ensure_dir_exists(new)
-            readme = os.path.join(new, 'README')
-            readme_src = os.path.join(get_ipython_package_dir(), u'config', u'profile', 'README')
+            readme = os.path.join(new, "README")
+            readme_src = os.path.join(
+                get_ipython_package_dir(), "config", "profile", "README"
+            )
             if not os.path.exists(readme) and os.path.exists(readme_src):
                 shutil.copy(readme_src, readme)
-            for d in ('extensions', 'nbextensions'):
+            for d in ("extensions", "nbextensions"):
                 path = os.path.join(new, d)
                 try:
                     ensure_dir_exists(path)

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -185,6 +185,15 @@ class BaseIPythonApplication(Application):
                 get_ipython_package_dir(), u'config', u'profile', change['new']
         )
 
+    add_ipython_dir_to_sys_path = Bool(False,
+        """Should the IPython profile directory be added to sys path ?
+
+        This option was non-existing before IPython 8.0, and ipython_dir was added to
+        sys path to allow import of extensions present there. This was historical
+        baggage from when pip did not exist. This now default to false,
+        but can bet to true for legacy reasons
+        """).tag(config=True)
+
     ipython_dir = Unicode(
         help="""
         The name of the IPython directory. This directory is used for logging
@@ -294,21 +303,22 @@ class BaseIPythonApplication(Application):
             str_old = os.path.abspath(old)
             if str_old in sys.path:
                 sys.path.remove(str_old)
-        str_path = os.path.abspath(new)
-        sys.path.append(str_path)
-        ensure_dir_exists(new)
-        readme = os.path.join(new, 'README')
-        readme_src = os.path.join(get_ipython_package_dir(), u'config', u'profile', 'README')
-        if not os.path.exists(readme) and os.path.exists(readme_src):
-            shutil.copy(readme_src, readme)
-        for d in ('extensions', 'nbextensions'):
-            path = os.path.join(new, d)
-            try:
-                ensure_dir_exists(path)
-            except OSError as e:
-                # this will not be EEXIST
-                self.log.error("couldn't create path %s: %s", path, e)
-        self.log.debug("IPYTHONDIR set to: %s" % new)
+        if self.add_ipython_dir_to_sys_path:
+            str_path = os.path.abspath(new)
+            #sys.path.append(str_path)
+            ensure_dir_exists(new)
+            readme = os.path.join(new, 'README')
+            readme_src = os.path.join(get_ipython_package_dir(), u'config', u'profile', 'README')
+            if not os.path.exists(readme) and os.path.exists(readme_src):
+                shutil.copy(readme_src, readme)
+            for d in ('extensions', 'nbextensions'):
+                path = os.path.join(new, d)
+                try:
+                    ensure_dir_exists(path)
+                except OSError as e:
+                    # this will not be EEXIST
+                    self.log.error("couldn't create path %s: %s", path, e)
+            self.log.debug("IPYTHONDIR set to: %s" % new)
 
     def load_config_file(self, suppress_errors=IPYTHON_SUPPRESS_CONFIG_ERRORS):
         """Load the config file.

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -191,7 +191,7 @@ class BaseIPythonApplication(Application):
         This option was non-existing before IPython 8.0, and ipython_dir was added to
         sys path to allow import of extensions present there. This was historical
         baggage from when pip did not exist. This now default to false,
-        but can bet to true for legacy reasons
+        but can be set to true for legacy reasons.
         """).tag(config=True)
 
     ipython_dir = Unicode(
@@ -305,7 +305,7 @@ class BaseIPythonApplication(Application):
                 sys.path.remove(str_old)
         if self.add_ipython_dir_to_sys_path:
             str_path = os.path.abspath(new)
-            #sys.path.append(str_path)
+            sys.path.append(str_path)
             ensure_dir_exists(new)
             readme = os.path.join(new, 'README')
             readme_src = os.path.join(get_ipython_package_dir(), u'config', u'profile', 'README')


### PR DESCRIPTION
Load ext will already do it with a context manager.

This should remove false positive when import modules, whithout breaking
functionalities.

Maybe closes #13294 (making this part of 8.0 release make sens).