### PR TITLE
get_running_loop is only valid in coroutines

### DIFF
--- a/IPython/core/async_helpers.py
+++ b/IPython/core/async_helpers.py
@@ -12,17 +12,28 @@ Python semantics.
 
 
 import ast
+import asyncio
 import inspect
 
 
 class _AsyncIORunner:
+    def __init__(self):
+        self._loop = None
+
+    @property
+    def loop(self):
+        """Always returns a non-closed event loop"""
+        if self._loop is None or self._loop.is_closed():
+            policy = asyncio.get_event_loop_policy()
+            self._loop = policy.new_event_loop()
+            policy.set_event_loop(self._loop)
+        return self._loop
+
     def __call__(self, coro):
         """
         Handler for asyncio autoawait
         """
-        import asyncio
-
-        return asyncio.get_event_loop_policy().get_event_loop().run_until_complete(coro)
+        return self.loop.run_until_complete(coro)
 
     def __str__(self):
         return "asyncio"

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -1058,6 +1058,22 @@ def test_run_cell_async():
     assert result.result == 5
 
 
+def test_run_cell_await():
+    ip.run_cell("import asyncio")
+    result = ip.run_cell("await asyncio.sleep(0.01); 10")
+    assert ip.user_ns["_"] == 10
+
+
+def test_run_cell_asyncio_run():
+    ip.run_cell("import asyncio")
+    result = ip.run_cell("await asyncio.sleep(0.01); 1")
+    assert ip.user_ns["_"] == 1
+    result = ip.run_cell("asyncio.run(asyncio.sleep(0.01)); 2")
+    assert ip.user_ns["_"] == 2
+    result = ip.run_cell("await asyncio.sleep(0.01); 3")
+    assert ip.user_ns["_"] == 3
+
+
 def test_should_run_async():
     assert not ip.should_run_async("a = 5")
     assert ip.should_run_async("await x")

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -970,7 +970,11 @@ def test_script_config():
 
 @pytest.fixture
 def event_loop():
-    yield asyncio.get_event_loop_policy().get_event_loop()
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
+    policy.set_event_loop(loop)
+    yield loop
+    loop.close()
 
 
 @dec.skip_win32


### PR DESCRIPTION
This fixes the problems introduced in #13269 by following the pattern in #13289. Using `get_running_loop` is only a valid way to get the event loop from inside a coroutine, which is not what's happening here.

I don't really understand why `asyncio.get_event_loop` is deprecated and `policy.get_event_loop` is not, but that is the case, at least for now.

await doesn't work in 7.30 because of this, so this should perhaps be in 7.30.1