### PR TITLE
Backport PR #13349: get_running_loop is only valid in coroutines

### DIFF
--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -1037,6 +1037,22 @@ def test_run_cell_async():
     assert result.result == 5
 
 
+def test_run_cell_await():
+    ip.run_cell("import asyncio")
+    result = ip.run_cell("await asyncio.sleep(0.01); 10")
+    assert ip.user_ns["_"] == 10
+
+
+def test_run_cell_asyncio_run():
+    ip.run_cell("import asyncio")
+    result = ip.run_cell("await asyncio.sleep(0.01); 1")
+    assert ip.user_ns["_"] == 1
+    result = ip.run_cell("asyncio.run(asyncio.sleep(0.01)); 2")
+    assert ip.user_ns["_"] == 2
+    result = ip.run_cell("await asyncio.sleep(0.01); 3")
+    assert ip.user_ns["_"] == 3
+
+
 def test_should_run_async():
     assert not ip.should_run_async("a = 5")
     assert ip.should_run_async("await x")

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -460,13 +460,15 @@ class TerminalInteractiveShell(InteractiveShell):
         # If we don't do this, people could spawn coroutine with a
         # while/true inside which will freeze the prompt.
 
+        policy = asyncio.get_event_loop_policy()
         try:
-            old_loop = asyncio.get_running_loop()
+            old_loop = policy.get_event_loop()
         except RuntimeError:
-            # This happens when the user used `asyncio.run()`.
+            # This happens when the the event loop is closed,
+            # e.g. by calling `asyncio.run()`.
             old_loop = None
 
-        asyncio.set_event_loop(self.pt_loop)
+        policy.set_event_loop(self.pt_loop)
         try:
             with patch_stdout(raw=True):
                 text = self.pt_app.prompt(
@@ -474,7 +476,8 @@ class TerminalInteractiveShell(InteractiveShell):
                     **self._extra_prompt_options())
         finally:
             # Restore the original event loop.
-            asyncio.set_event_loop(old_loop)
+            if old_loop is not None:
+                policy.set_event_loop(old_loop)
 
         return text
 


### PR DESCRIPTION
This only pickes up the first commit of the PR