### PR TITLE
Second attempt at removal of rprint/rprinte

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -233,11 +233,6 @@ def raw_print_err(*args, **kw):
           file=sys.__stderr__)
     sys.__stderr__.flush()
 
-# used by IPykernel <- 4.9. Removed during IPython 7-dev period and re-added 
-# Keep for a version or two then should remove
-rprint = raw_print
-rprinte = raw_print_err
-
 @undoc
 def unicode_std_stream(stream='stdout'):
     """DEPRECATED, moved to nbconvert.utils.io"""


### PR DESCRIPTION
Those were removed once, but trigged issues, let's try again see if
there are any dependencies still relying on them.