### PR TITLE
Remove more deprecated utilities.

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -561,10 +561,6 @@ Currently the magic system has the following functions:""",
 
     @magic_arguments.magic_arguments()
     @magic_arguments.argument(
-        '-e', '--export', action='store_true', default=False,
-        help=argparse.SUPPRESS
-    )
-    @magic_arguments.argument(
         'filename', type=str,
         help='Notebook name or filename'
     )
@@ -574,9 +570,6 @@ Currently the magic system has the following functions:""",
 
         This function can export the current IPython history to a notebook file.
         For example, to export the history to "foo.ipynb" do "%notebook foo.ipynb".
-
-        The -e or --export flag is deprecated in IPython 5.2, and will be
-        removed in the future.
         """
         args = magic_arguments.parse_argstring(self.notebook, s)
 

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -750,7 +750,7 @@ def test_notebook_export_json():
         _ip.history_manager.store_inputs(i, cmd)
     with TemporaryDirectory() as td:
         outfile = os.path.join(td, "nb.ipynb")
-        _ip.magic("notebook -e %s" % outfile)
+        _ip.magic("notebook %s" % outfile)
 
 
 class TestEnv(TestCase):

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -208,26 +208,6 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             StoreMagics,
         ]
 
-    deprecated_subcommands = dict(
-        qtconsole=('qtconsole.qtconsoleapp.JupyterQtConsoleApp',
-            """DEPRECATED, Will be removed in IPython 6.0 : Launch the Jupyter Qt Console."""
-        ),
-        notebook=('notebook.notebookapp.NotebookApp',
-            """DEPRECATED, Will be removed in IPython 6.0 : Launch the Jupyter HTML Notebook Server."""
-        ),
-        console=('jupyter_console.app.ZMQTerminalIPythonApp',
-            """DEPRECATED, Will be removed in IPython 6.0 : Launch the Jupyter terminal-based Console."""
-        ),
-        nbconvert=('nbconvert.nbconvertapp.NbConvertApp',
-            "DEPRECATED, Will be removed in IPython 6.0 : Convert notebooks to/from other formats."
-        ),
-        trust=('nbformat.sign.TrustNotebookApp',
-            "DEPRECATED, Will be removed in IPython 6.0 : Sign notebooks to trust their potentially unsafe contents at load."
-        ),
-        kernelspec=('jupyter_client.kernelspecapp.KernelSpecApp',
-            "DEPRECATED, Will be removed in IPython 6.0 : Manage Jupyter kernel specifications."
-        ),
-    )
     subcommands = dict(
         profile = ("IPython.core.profileapp.ProfileApp",
             "Create and manage IPython profiles."
@@ -242,11 +222,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             "Manage the IPython history database."
         ),
     )
-    deprecated_subcommands['install-nbextension'] = (
-        "notebook.nbextensions.InstallNBExtensionApp",
-        "DEPRECATED, Will be removed in IPython 6.0 : Install Jupyter notebook extension files"
-    )
-    subcommands.update(deprecated_subcommands)
+
 
     # *do* autocreate requested profile, but don't create the config file.
     auto_create=Bool(True)


### PR DESCRIPTION
Most subcommands have been in jupyter for many years,
and the -e export flags has been doing nothing for a long time as well.