### PR TITLE
use full-alpha transparency on dvipng rendered LaTeX

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -161,9 +161,26 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
 
             resolution = round(150*scale)
             subprocess.check_call(
-                ["dvipng", "-T", "tight", "-D", str(resolution), "-z", "9",
-                 "-bg", "transparent", "-o", outfile, dvifile, "-fg", color],
-                 cwd=workdir, stdout=devnull, stderr=devnull)
+                [
+                    "dvipng",
+                    "-T",
+                    "tight",
+                    "-D",
+                    str(resolution),
+                    "-z",
+                    "9",
+                    "-bg",
+                    "Transparent",
+                    "-o",
+                    outfile,
+                    dvifile,
+                    "-fg",
+                    color,
+                ],
+                cwd=workdir,
+                stdout=devnull,
+                stderr=devnull,
+            )
 
         with outfile.open("rb") as f:
             return f.read()

--- a/IPython/utils/timing.py
+++ b/IPython/utils/timing.py
@@ -62,7 +62,6 @@ if resource is not None and hasattr(resource, "getrusage"):
         Similar to clock(), but return a tuple of user/system times."""
         return resource.getrusage(resource.RUSAGE_SELF)[:2]
 
-
 else:
     # There is no distinction of user/system time under windows, so we just use
     # time.perff_counter() for everything...


### PR DESCRIPTION
From `man dvipng` (version 1.17):

```
       -bg color_spec
           Choose background color for the images. This option will be ignored if there is a background color \special in the DVI. The color spec should be in TeX
           color \special syntax, e.g., 'rgb 1.0 0.0 0.0'. You can also specify 'Transparent' or 'transparent' which will give you a transparent background with the
           normal background as a fallback color. A capitalized 'Transparent' will give a full-alpha transparency, while an all-lowercase 'transparent' will give a
           simple fully transparent background with non-transparent antialiased pixels. The latter would be suitable for viewers who cannot cope with a true alpha
           channel.  GIF images do not support full alpha transparency, so in case of GIF output, both variants will use the latter behaviour.
```

Comparison on a QtConsole with solarized-dark theme (with https://github.com/jupyter/qtconsole/pull/512):

```python
In [1]: from control import rss

In [2]: randomstatespace = rss(3,2,1)

In [3]: randomstatespace._repr_latex_()
Out[3]: '\\[\n\\left(\n\\begin{array}{rllrllrll|rll}\n-1.&\\hspace{-1em}79&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}279&\\hspace{-1em}\\phantom{\\cdot}&-1.&\\hspace{-1em}77&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}223&\\hspace{-1em}\\phantom{\\cdot}\\\\\n-0.&\\hspace{-1em}652&\\hspace{-1em}\\phantom{\\cdot}&-1.&\\hspace{-1em}51&\\hspace{-1em}\\phantom{\\cdot}&-1.&\\hspace{-1em}36&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}128&\\hspace{-1em}\\phantom{\\cdot}\\\\\n0.&\\hspace{-1em}835&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}181&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}711&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}495&\\hspace{-1em}\\phantom{\\cdot}\\\\\n\\hline\n-0.&\\hspace{-1em}00268&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}855&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}0902&\\hspace{-1em}\\phantom{\\cdot}&-0.&\\hspace{-1em}852&\\hspace{-1em}\\phantom{\\cdot}\\\\\n-0.&\\hspace{-1em}762&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}0347&\\hspace{-1em}\\phantom{\\cdot}&0.&\\hspace{-1em}472&\\hspace{-1em}\\phantom{\\cdot}&1.&\\hspace{-1em}34&\\hspace{-1em}\\phantom{\\cdot}\\\\\n\\end{array}\\right)\n\\]'
```

| before | after |
| --- | --- |
![image](https://user-images.githubusercontent.com/4623504/144717246-be2ab2b2-0f92-4ab9-83ba-3ed8d153e542.png) | ![image](https://user-images.githubusercontent.com/4623504/144717259-a5b8695f-852f-49be-ac36-b2ce6418c6fa.png) |

