### PR TITLE
Add comma groupings to timeit magic loop count

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -92,17 +92,15 @@ class TimeitResult(object):
                 pm = u'\xb1'
             except:
                 pass
-        return (
-            u"{mean} {pm} {std} per loop (mean {pm} std. dev. of {runs} run{run_plural}, {loops} loop{loop_plural} each)"
-                .format(
-                    pm = pm,
-                    runs = self.repeat,
-                    loops = self.loops,
-                    loop_plural = "" if self.loops == 1 else "s",
-                    run_plural = "" if self.repeat == 1 else "s",
-                    mean = _format_time(self.average, self._precision),
-                    std = _format_time(self.stdev, self._precision))
-                )
+        return "{mean} {pm} {std} per loop (mean {pm} std. dev. of {runs} run{run_plural}, {loops:,} loop{loop_plural} each)".format(
+            pm=pm,
+            runs=self.repeat,
+            loops=self.loops,
+            loop_plural="" if self.loops == 1 else "s",
+            run_plural="" if self.repeat == 1 else "s",
+            mean=_format_time(self.average, self._precision),
+            std=_format_time(self.stdev, self._precision),
+        )
 
     def _repr_pretty_(self, p , cycle):
         unic = self.__str__()


### PR DESCRIPTION
This is a pull request related to issue #13378.   I opted to use commas to group digits as the syntax `'{x:,}'.format(x=1000)` has been supported since at least 2.7.  That said, I'd think underscores might make more sense as CPython ignores underscores included in integers.

### Reiteration of the problem mentioned in #13378:
It's bugged me for years that the output of the wonderful `timeit` magic function is often made difficult to use for quick comparisons due to the long strings of zeros in the loop count that are often not aligned when comparing multiple results.
Here's an example:
![image](https://user-images.githubusercontent.com/3175485/145135507-66e675ee-caf4-4096-8952-3a0bce8670b7.png)
Reading this, first you might think, "Wow a 10x speedup!"  and then count some zeros and realize it's really a 100x speedup.