### PR TITLE
Expand ~ in filename arguments for %notebook, %save and %history magics

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -4,6 +4,7 @@
 import argparse
 from logging import error
 import io
+import os
 from pprint import pformat
 import sys
 from warnings import warn
@@ -572,6 +573,7 @@ Currently the magic system has the following functions:""",
         For example, to export the history to "foo.ipynb" do "%notebook foo.ipynb".
         """
         args = magic_arguments.parse_argstring(self.notebook, s)
+        outfname = os.path.expanduser(args.filename)
 
         from nbformat import write, v4
 
@@ -585,7 +587,7 @@ Currently the magic system has the following functions:""",
                 source=source
             ))
         nb = v4.new_notebook(cells=cells)
-        with io.open(args.filename, 'w', encoding='utf-8') as f:
+        with io.open(outfname, "w", encoding="utf-8") as f:
             write(nb, f, version=4)
 
 @magics_class

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -222,6 +222,7 @@ class CodeMagics(Magics):
         fname, codefrom = args[0], " ".join(args[1:])
         if not fname.endswith(('.py','.ipy')):
             fname += ext
+        fname = os.path.expanduser(fname)
         file_exists = os.path.isfile(fname)
         if file_exists and not force and not append:
             try:

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -151,6 +151,7 @@ class HistoryMagics(Magics):
             # We don't want to close stdout at the end!
             close_at_end = False
         else:
+            outfname = os.path.expanduser(outfname)
             if os.path.exists(outfname):
                 try:
                     ans = io.ask_yes_no("File %r exists. Overwrite?" % outfname)


### PR DESCRIPTION
I searched the documentation page for built-in magics for places where the terms "path" and "file" are mentioned and tested them to see if they would be able to expand users properly, the problem was `io.open` -- other file opening methods didn't have this problem. 

Closes #13065 