### PR TITLE
Remove not working pip caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip
     - name: Install latex
       if: runner.os == 'Linux' && matrix.deps == 'test_extra'
       run: sudo apt-get -yq -o Acquire::Retries=3 --no-install-suggests --no-install-recommends install texlive dvipng


### PR DESCRIPTION
It [requires `requirements.txt`](https://github.com/actions/setup-python#caching-packages-dependencies) which does not exist, it also forces workers in forks to fail with `Error: getCacheEntry failed: Cache service responded with 500` message.