### PR TITLE
Disable coverage collection on PyPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,6 @@ jobs:
       env:
         COLUMNS: 120
       run: |
-        pytest --color=yes -raXxs --cov --cov-report=xml
+        pytest --color=yes -raXxs ${{ startsWith(matrix.python-version, 'pypy') && ' ' || '--cov --cov-report=xml' }}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2


### PR DESCRIPTION
Coverage collection overhead on PyPy is 330-420% (20-110% on CPython)