### PR TITLE
All Lineno to traceback

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -419,9 +419,9 @@ class TestCompleter(unittest.TestCase):
             with provisionalcompleter():
                 ip.Completer.use_jedi = jedi_status
                 matches = c.all_completions("TestCl")
-                assert matches == ['TestClass'], jedi_status
+                assert matches == ["TestClass"], (jedi_status, matches)
                 matches = c.all_completions("TestClass.")
-                assert len(matches) > 2, jedi_status
+                assert len(matches) > 2, (jedi_status, matches)
                 matches = c.all_completions("TestClass.a")
                 assert matches == ['TestClass.a', 'TestClass.a1'], jedi_status
 

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -413,7 +413,7 @@ def test_decorator_skip():
     child.close()
 
 
-@pytest.mark.skip(platform.python_implementation() == "PyPy", reason="issues on PyPy")
+@pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="issues on PyPy")
 @skip_win32
 def test_decorator_skip_disabled():
     """test that decorator frame skipping can be disabled"""
@@ -441,7 +441,7 @@ def test_decorator_skip_disabled():
     child.close()
 
 
-@pytest.mark.skip(platform.python_implementation() == "PyPy", reason="issues on PyPy")
+@pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="issues on PyPy")
 @skip_win32
 def test_decorator_skip_with_breakpoint():
     """test that decorator frame skipping can be disabled"""

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -45,11 +45,11 @@ def doctest_tb_plain():
 
     In [19]: run simpleerr.py
     Traceback (most recent call last):
-      ...line ..., in <module>
+      File ...:... in <module>
         bar(mode)
-      ...line ..., in bar
+      File ...:... in bar
         div0()
-      ...line ..., in div0
+      File ...:... in div0
         x/y
     ZeroDivisionError: ...
     """
@@ -132,13 +132,13 @@ def doctest_tb_sysexit():
 
     In [20]: %tb
     Traceback (most recent call last):
-      File ..., in execfile
+      File ...:... in execfile
         exec(compiler(f.read(), fname, "exec"), glob, loc)
-      File ..., in <module>
+      File ...:... in <module>
         bar(mode)
-      File ..., in bar
+      File ...:... in bar
         sysexit(stat, mode)
-      File ..., in sysexit
+      File ...:... in sysexit
         raise SystemExit(stat, f"Mode = {mode}")
     SystemExit: (2, 'Mode = exit')
 

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -188,10 +188,6 @@ se_file_2 = """7/
 """
 
 class SyntaxErrorTest(unittest.TestCase):
-    def test_syntaxerror_without_lineno(self):
-        with tt.AssertNotPrints("TypeError"):
-            with tt.AssertPrints("line unknown"):
-                ip.run_cell("raise SyntaxError()")
 
     def test_syntaxerror_no_stacktrace_at_compile_time(self):
         syntax_error_at_compile_time = """

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -628,13 +628,21 @@ class VerboseTB(TBTools):
             return '    %s[... skipping similar frames: %s]%s\n' % (
                 Colors.excName, frame_info.description, ColorsNormal)
 
-        indent = ' ' * INDENT_SIZE
-        em_normal = '%s\n%s%s' % (Colors.valEm, indent, ColorsNormal)
-        tpl_call = 'line %s, in %s%%s%s%%s%s' % (frame_info.lineno, Colors.vName, Colors.valEm,
-                                        ColorsNormal)
-        tpl_call_fail = 'line %s, in %s%%s%s(***failed resolving arguments***)%s' % \
-                        (frame_info.lineno, Colors.vName, Colors.valEm, ColorsNormal)
-        tpl_name_val = '%%s %s= %%s%s' % (Colors.valEm, ColorsNormal)
+        indent = " " * INDENT_SIZE
+        em_normal = "%s\n%s%s" % (Colors.valEm, indent, ColorsNormal)
+        tpl_call = "line %s, in %s%%s%s%%s%s" % (
+            frame_info.lineno,
+            Colors.vName,
+            Colors.valEm,
+            ColorsNormal,
+        )
+        tpl_call_fail = "line %s, in %s%%s%s(***failed resolving arguments***)%s" % (
+            frame_info.lineno,
+            Colors.vName,
+            Colors.valEm,
+            ColorsNormal,
+        )
+        tpl_name_val = "%%s %s= %%s%s" % (Colors.valEm, ColorsNormal)
 
         link = _format_filename(frame_info.filename, Colors.filenameEm, ColorsNormal)
         args, varargs, varkw, locals_ = inspect.getargvalues(frame_info.frame)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -630,7 +630,7 @@ class VerboseTB(TBTools):
 
         indent = ' ' * INDENT_SIZE
         em_normal = '%s\n%s%s' % (Colors.valEm, indent, ColorsNormal)
-        tpl_call = 'in %s%%s%s%%s%s' % (Colors.vName, Colors.valEm,
+        tpl_call = 'in %s%%s%s%%s%s in Line %%s' % (Colors.vName, Colors.valEm,
                                         ColorsNormal)
         tpl_call_fail = 'in %s%%s%s(***failed resolving arguments***)%s' % \
                         (Colors.vName, Colors.valEm, ColorsNormal)
@@ -641,14 +641,14 @@ class VerboseTB(TBTools):
 
         func = frame_info.executing.code_qualname()
         if func == '<module>':
-            call = tpl_call % (func, '')
+            call = tpl_call % (func, '', frame_info.lineno)
         else:
             # Decide whether to include variable details or not
             var_repr = eqrepr if self.include_vars else nullrepr
             try:
                 call = tpl_call % (func, inspect.formatargvalues(args,
                                                                  varargs, varkw,
-                                                                 locals_, formatvalue=var_repr))
+                                                                 locals_, formatvalue=var_repr), frame_info.lineno)
             except KeyError:
                 # This happens in situations like errors inside generator
                 # expressions, where local variables are listed in the

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -630,10 +630,10 @@ class VerboseTB(TBTools):
 
         indent = ' ' * INDENT_SIZE
         em_normal = '%s\n%s%s' % (Colors.valEm, indent, ColorsNormal)
-        tpl_call = 'in %s%%s%s%%s%s' % (Colors.vName, Colors.valEm,
+        tpl_call = 'line %s, in %s%%s%s%%s%s' % (frame_info.lineno, Colors.vName, Colors.valEm,
                                         ColorsNormal)
-        tpl_call_fail = 'in %s%%s%s(***failed resolving arguments***)%s' % \
-                        (Colors.vName, Colors.valEm, ColorsNormal)
+        tpl_call_fail = 'line %s, in %s%%s%s(***failed resolving arguments***)%s' % \
+                        (frame_info.lineno, Colors.vName, Colors.valEm, ColorsNormal)
         tpl_name_val = '%%s %s= %%s%s' % (Colors.valEm, ColorsNormal)
 
         link = _format_filename(frame_info.filename, Colors.filenameEm, ColorsNormal)

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -190,13 +190,13 @@ def onlyif_cmds_exist(*commands):
     """
     Decorator to skip test when at least one of `commands` is not found.
     """
+    assert (
+        os.environ.get("IPTEST_WORKING_DIR", None) is None
+    ), "iptest deprecated since IPython 8.0"
     for cmd in commands:
         reason = f"This test runs only if command '{cmd}' is installed"
         if not shutil.which(cmd):
-            if os.environ.get("IPTEST_WORKING_DIR", None) is not None:
-                return skip(reason)
-            else:
-                import pytest
+            import pytest
 
-                return pytest.mark.skip(reason=reason)
+            return pytest.mark.skip(reason=reason)
     return null_deco

--- a/IPython/testing/plugin/pytest_ipdoctest.py
+++ b/IPython/testing/plugin/pytest_ipdoctest.py
@@ -503,7 +503,7 @@ def _check_all_skipped(test: "doctest.DocTest") -> None:
 
     all_skipped = all(x.options.get(doctest.SKIP, False) for x in test.examples)
     if all_skipped:
-        pytest.skip("all tests skipped by +SKIP option")
+        pytest.skip("all docstests skipped by +SKIP option")
 
 
 def _is_mocked(obj: object) -> bool:


### PR DESCRIPTION
Will close #13237 #13221

Add line number next to the file in the traceback

Fix some "skip" error messages and docstrings for test.

We use filename:lineno as this syntax is understood by many tools to
directly open the relevant file at given line.

We also fix a couple corresponding and other issues in the test suite.
