### PR TITLE
Improvement of core.magic_arguments example

### DIFF
--- a/IPython/core/magic_arguments.py
+++ b/IPython/core/magic_arguments.py
@@ -37,7 +37,6 @@ arguments::
           -o OPTION, --option OPTION
                                 An optional argument.
 
-
 Here is an elaborated example that uses default parameters in `argument` and calls the `args` in the cell magic::
 
     from IPython.core.magic import register_cell_magic
@@ -69,7 +68,6 @@ In a jupyter notebook, this cell magic can be executed like this::
     %%my_cell_magic -o Hello
     print("bar")
     i = 42
-
 
 Inheritance diagram:
 

--- a/IPython/core/magic_arguments.py
+++ b/IPython/core/magic_arguments.py
@@ -37,6 +37,40 @@ arguments::
           -o OPTION, --option OPTION
                                 An optional argument.
 
+
+Here is an elaborated example that uses default parameters in `argument` and calls the `args` in the cell magic::
+
+    from IPython.core.magic import register_cell_magic
+    from IPython.core.magic_arguments import (argument, magic_arguments,
+                                            parse_argstring)
+
+
+    @magic_arguments()
+    @argument(
+        "--option",
+        "-o",
+        help=("Add an option here"),
+    )
+    @argument(
+        "--style",
+        "-s",
+        default="foo",
+        help=("Add some style arguments"),
+    )
+    @register_cell_magic
+    def my_cell_magic(line, cell):
+        args = parse_argstring(my_cell_magic, line)
+        print(f"{args.option=}")
+        print(f"{args.style=}")
+        print(f"{cell=}")
+
+In a jupyter notebook, this cell magic can be executed like this::
+
+    %%my_cell_magic -o Hello
+    print("bar")
+    i = 42
+
+
 Inheritance diagram:
 
 .. inheritance-diagram:: IPython.core.magic_arguments


### PR DESCRIPTION
Adds an elaborated example that uses default parameters in `argument` and calls the `args` in cell magic function.
Closes  #13431
I wonder, is it possible to add also the use case into the documentation, like this:
![image](https://user-images.githubusercontent.com/44469195/148444242-1cfb7df4-9699-4810-8c67-e9705eecfd53.png)
