### PR TITLE
Fix highlighting of ast nodes in traceback.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -826,8 +826,8 @@ class VerboseTB(TBTools):
         after = context // 2
         before = context - after
         if self.has_colors:
-            style = get_style_by_name('default')
-            style = stack_data.style_with_executing_node(style, 'bg:#00005f')
+            style = get_style_by_name("default")
+            style = stack_data.style_with_executing_node(style, "bg:ansiyellow")
             formatter = Terminal256Formatter(style=style)
         else:
             formatter = None


### PR DESCRIPTION
Using ansi mean it will follow terminal colorscheme