### PR TITLE
Fix TODOs by moving to pytest.mark.parameterize (now that nose is gone).

### DIFF
--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -406,13 +406,15 @@ class TestShellGlob(unittest.TestCase):
             self.check_match(patterns, matches)
 
 
-# TODO : pytest.mark.parametrise once nose is gone.
-def test_unescape_glob():
-    assert path.unescape_glob(r"\*\[\!\]\?") == "*[!]?"
-    assert path.unescape_glob(r"\\*") == r"\*"
-    assert path.unescape_glob(r"\\\*") == r"\*"
-    assert path.unescape_glob(r"\\a") == r"\a"
-    assert path.unescape_glob(r"\a") == r"\a"
+@pytest.mark.parametrize('globstr, unescaped_globstr', [
+    (r"\*\[\!\]\?", "*[!]?"),
+    (r"\\*", r"\*"),
+    (r"\\\*", r"\*"),
+    (r"\\a", r"\a"),
+    (r"\a", r"\a")
+])
+def test_unescape_glob(globstr, unescaped_globstr):
+    assert path.unescape_glob(globstr) == unescaped_globstr
 
 
 @onlyif_unicode_paths

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -407,14 +407,14 @@ class TestShellGlob(unittest.TestCase):
 
 
 @pytest.mark.parametrize(
-    'globstr, unescaped_globstr', 
+    "globstr, unescaped_globstr",
     [
         (r"\*\[\!\]\?", "*[!]?"),
         (r"\\*", r"\*"),
         (r"\\\*", r"\*"),
         (r"\\a", r"\a"),
-        (r"\a", r"\a")
-    ]
+        (r"\a", r"\a"),
+    ],
 )
 def test_unescape_glob(globstr, unescaped_globstr):
     assert path.unescape_glob(globstr) == unescaped_globstr

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -406,13 +406,16 @@ class TestShellGlob(unittest.TestCase):
             self.check_match(patterns, matches)
 
 
-@pytest.mark.parametrize('globstr, unescaped_globstr', [
-    (r"\*\[\!\]\?", "*[!]?"),
-    (r"\\*", r"\*"),
-    (r"\\\*", r"\*"),
-    (r"\\a", r"\a"),
-    (r"\a", r"\a")
-])
+@pytest.mark.parametrize(
+    'globstr, unescaped_globstr', 
+    [
+        (r"\*\[\!\]\?", "*[!]?"),
+        (r"\\*", r"\*"),
+        (r"\\\*", r"\*"),
+        (r"\\a", r"\a"),
+        (r"\a", r"\a")
+    ]
+)
 def test_unescape_glob(globstr, unescaped_globstr):
     assert path.unescape_glob(globstr) == unescaped_globstr
 

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -56,35 +56,33 @@ def test_find_cmd_fail():
     pytest.raises(FindCmdError, find_cmd, "asdfasdf")
 
 
-# TODO: move to pytest.mark.parametrize once nose gone
 @dec.skip_win32
-def test_arg_split():
+@pytest.mark.parametrize('argstr, argv', [
+    ('hi', ['hi']),
+    (u'hi', [u'hi']),
+    ('hello there', ['hello', 'there']),
+    # \u01ce == \N{LATIN SMALL LETTER A WITH CARON}
+    # Do not use \N because the tests crash with syntax error in
+    # some cases, for example windows python2.6.
+    (u'h\u01cello', [u'h\u01cello']),
+    ('something "with quotes"', ['something', '"with quotes"']),
+])
+def test_arg_split(argstr, argv):
     """Ensure that argument lines are correctly split like in a shell."""
-    tests = [['hi', ['hi']],
-             [u'hi', [u'hi']],
-             ['hello there', ['hello', 'there']],
-             # \u01ce == \N{LATIN SMALL LETTER A WITH CARON}
-             # Do not use \N because the tests crash with syntax error in
-             # some cases, for example windows python2.6.
-             [u'h\u01cello', [u'h\u01cello']],
-             ['something "with quotes"', ['something', '"with quotes"']],
-             ]
-    for argstr, argv in tests:
-        assert arg_split(argstr) == argv
+    assert arg_split(argstr) == argv
 
 
-# TODO: move to pytest.mark.parametrize once nose gone
 @dec.skip_if_not_win32
-def test_arg_split_win32():
+@pytest.mark.parametrize('argstr,argv', [
+    ('hi', ['hi']),
+    (u'hi', [u'hi']),
+    ('hello there', ['hello', 'there']),
+    (u'h\u01cello', [u'h\u01cello']),
+    ('something "with quotes"', ['something', 'with quotes']),
+])
+def test_arg_split_win32(argstr, argv):
     """Ensure that argument lines are correctly split like in a shell."""
-    tests = [['hi', ['hi']],
-             [u'hi', [u'hi']],
-             ['hello there', ['hello', 'there']],
-             [u'h\u01cello', [u'h\u01cello']],
-             ['something "with quotes"', ['something', 'with quotes']],
-             ]
-    for argstr, argv in tests:
-        assert arg_split(argstr) == argv
+    assert arg_split(argstr) == argv
 
 
 class SubProcessTestCase(tt.TempFileMixin):

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -58,17 +58,17 @@ def test_find_cmd_fail():
 
 @dec.skip_win32
 @pytest.mark.parametrize(
-    'argstr, argv', 
+    "argstr, argv",
     [
-        ('hi', ['hi']),
-        (u'hi', [u'hi']),
-        ('hello there', ['hello', 'there']),
+        ("hi", ["hi"]),
+        (u"hi", [u"hi"]),
+        ("hello there", ["hello", "there"]),
         # \u01ce == \N{LATIN SMALL LETTER A WITH CARON}
         # Do not use \N because the tests crash with syntax error in
         # some cases, for example windows python2.6.
-        (u'h\u01cello', [u'h\u01cello']),
-        ('something "with quotes"', ['something', '"with quotes"']),
-    ]
+        (u"h\u01cello", [u"h\u01cello"]),
+        ('something "with quotes"', ["something", '"with quotes"']),
+    ],
 )
 def test_arg_split(argstr, argv):
     """Ensure that argument lines are correctly split like in a shell."""
@@ -77,14 +77,14 @@ def test_arg_split(argstr, argv):
 
 @dec.skip_if_not_win32
 @pytest.mark.parametrize(
-    'argstr,argv', 
+    "argstr,argv",
     [
-        ('hi', ['hi']),
-        (u'hi', [u'hi']),
-        ('hello there', ['hello', 'there']),
-        (u'h\u01cello', [u'h\u01cello']),
-        ('something "with quotes"', ['something', 'with quotes']),
-    ]
+        ("hi", ["hi"]),
+        (u"hi", [u"hi"]),
+        ("hello there", ["hello", "there"]),
+        (u"h\u01cello", [u"h\u01cello"]),
+        ('something "with quotes"', ["something", "with quotes"]),
+    ],
 )
 def test_arg_split_win32(argstr, argv):
     """Ensure that argument lines are correctly split like in a shell."""

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -57,29 +57,35 @@ def test_find_cmd_fail():
 
 
 @dec.skip_win32
-@pytest.mark.parametrize('argstr, argv', [
-    ('hi', ['hi']),
-    (u'hi', [u'hi']),
-    ('hello there', ['hello', 'there']),
-    # \u01ce == \N{LATIN SMALL LETTER A WITH CARON}
-    # Do not use \N because the tests crash with syntax error in
-    # some cases, for example windows python2.6.
-    (u'h\u01cello', [u'h\u01cello']),
-    ('something "with quotes"', ['something', '"with quotes"']),
-])
+@pytest.mark.parametrize(
+    'argstr, argv', 
+    [
+        ('hi', ['hi']),
+        (u'hi', [u'hi']),
+        ('hello there', ['hello', 'there']),
+        # \u01ce == \N{LATIN SMALL LETTER A WITH CARON}
+        # Do not use \N because the tests crash with syntax error in
+        # some cases, for example windows python2.6.
+        (u'h\u01cello', [u'h\u01cello']),
+        ('something "with quotes"', ['something', '"with quotes"']),
+    ]
+)
 def test_arg_split(argstr, argv):
     """Ensure that argument lines are correctly split like in a shell."""
     assert arg_split(argstr) == argv
 
 
 @dec.skip_if_not_win32
-@pytest.mark.parametrize('argstr,argv', [
-    ('hi', ['hi']),
-    (u'hi', [u'hi']),
-    ('hello there', ['hello', 'there']),
-    (u'h\u01cello', [u'h\u01cello']),
-    ('something "with quotes"', ['something', 'with quotes']),
-])
+@pytest.mark.parametrize(
+    'argstr,argv', 
+    [
+        ('hi', ['hi']),
+        (u'hi', [u'hi']),
+        ('hello there', ['hello', 'there']),
+        (u'h\u01cello', [u'h\u01cello']),
+        ('something "with quotes"', ['something', 'with quotes']),
+    ]
+)
 def test_arg_split_win32(argstr, argv):
     """Ensure that argument lines are correctly split like in a shell."""
     assert arg_split(argstr) == argv

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -61,12 +61,11 @@ def test_find_cmd_fail():
     "argstr, argv",
     [
         ("hi", ["hi"]),
-        (u"hi", [u"hi"]),
         ("hello there", ["hello", "there"]),
         # \u01ce == \N{LATIN SMALL LETTER A WITH CARON}
         # Do not use \N because the tests crash with syntax error in
         # some cases, for example windows python2.6.
-        (u"h\u01cello", [u"h\u01cello"]),
+        ("h\u01cello", ["h\u01cello"]),
         ('something "with quotes"', ["something", '"with quotes"']),
     ],
 )
@@ -80,9 +79,8 @@ def test_arg_split(argstr, argv):
     "argstr,argv",
     [
         ("hi", ["hi"]),
-        (u"hi", [u"hi"]),
         ("hello there", ["hello", "there"]),
-        (u"h\u01cello", [u"h\u01cello"]),
+        ("h\u01cello", ["h\u01cello"]),
         ('something "with quotes"', ["something", "with quotes"]),
     ],
 )

--- a/IPython/utils/tests/test_process.py
+++ b/IPython/utils/tests/test_process.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 Tests for platutils.py
 """
@@ -100,7 +99,7 @@ class SubProcessTestCase(tt.TempFileMixin):
         self.mktmp('\n'.join(lines))
 
     def test_system(self):
-        status = system('%s "%s"' % (python, self.fname))
+        status = system(f'{python} "{self.fname}"')
         self.assertEqual(status, 0)
 
     def test_system_quotes(self):
@@ -147,11 +146,11 @@ class SubProcessTestCase(tt.TempFileMixin):
 
         status = self.assert_interrupts(command)
         self.assertNotEqual(
-            status, 0, "The process wasn't interrupted. Status: %s" % (status,)
+            status, 0, f"The process wasn't interrupted. Status: {status}"
         )
 
     def test_getoutput(self):
-        out = getoutput('%s "%s"' % (python, self.fname))
+        out = getoutput(f'{python} "{self.fname}"')
         # we can't rely on the order the line buffered streams are flushed
         try:
             self.assertEqual(out, 'on stderron stdout')
@@ -171,7 +170,7 @@ class SubProcessTestCase(tt.TempFileMixin):
         self.assertEqual(out.strip(), '1')
 
     def test_getoutput_error(self):
-        out, err = getoutputerror('%s "%s"' % (python, self.fname))
+        out, err = getoutputerror(f'{python} "{self.fname}"')
         self.assertEqual(out, 'on stdout')
         self.assertEqual(err, 'on stderr')
 
@@ -181,7 +180,7 @@ class SubProcessTestCase(tt.TempFileMixin):
         self.assertEqual(out, '')
         self.assertEqual(err, '')
         self.assertEqual(code, 1)
-        out, err, code = get_output_error_code('%s "%s"' % (python, self.fname))
+        out, err, code = get_output_error_code(f'{python} "{self.fname}"')
         self.assertEqual(out, 'on stdout')
         self.assertEqual(err, 'on stderr')
         self.assertEqual(code, 0)

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -80,24 +80,22 @@ def test_columnize_random():
             )
 
 
-# TODO: pytest mark.parametrize once nose removed.
-def test_columnize_medium():
+@pytest.mark.parametrize('row_first', [True, False])
+def test_columnize_medium(row_first):
     """Test with inputs than shouldn't be wider than 80"""
     size = 40
     items = [l*size for l in 'abc']
-    for row_first in [True, False]:
-        out = text.columnize(items, row_first=row_first, displaywidth=80)
-        assert out == "\n".join(items + [""]), "row_first={0}".format(row_first)
+    out = text.columnize(items, row_first=row_first, displaywidth=80)
+    assert out == "\n".join(items + [""]), "row_first={0}".format(row_first)
 
 
-# TODO: pytest mark.parametrize once nose removed.
-def test_columnize_long():
+@pytest.mark.parametrize('row_first', [True, False])
+def test_columnize_long(row_first):
     """Test columnize with inputs longer than the display window"""
     size = 11
     items = [l*size for l in 'abc']
-    for row_first in [True, False]:
-        out = text.columnize(items, row_first=row_first, displaywidth=size - 1)
-        assert out == "\n".join(items + [""]), "row_first={0}".format(row_first)
+    out = text.columnize(items, row_first=row_first, displaywidth=size - 1)
+    assert out == "\n".join(items + [""]), "row_first={0}".format(row_first)
 
 
 def eval_formatter_check(f):

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -80,7 +80,7 @@ def test_columnize_random():
             )
 
 
-@pytest.mark.parametrize('row_first', [True, False])
+@pytest.mark.parametrize("row_first", [True, False])
 def test_columnize_medium(row_first):
     """Test with inputs than shouldn't be wider than 80"""
     size = 40
@@ -89,7 +89,7 @@ def test_columnize_medium(row_first):
     assert out == "\n".join(items + [""]), "row_first={0}".format(row_first)
 
 
-@pytest.mark.parametrize('row_first', [True, False])
+@pytest.mark.parametrize("row_first", [True, False])
 def test_columnize_long(row_first):
     """Test columnize with inputs longer than the display window"""
     size = 11


### PR DESCRIPTION
From the awesome 8.0 release notes today: "IPython is no longer reliant on Nose, which has been unmaintained for many years." So I fixed some basic TODOs by moving tests to pytest.mark.parameterize, making them more easily fixable going forward. 

First time contributor here, and just wanted to get my feet wet with the codebase. Let me know if there's anything I can do to clean up this PR. Even better, if there is specific test refactoring work that would increase the maintainability of the current tests, please let me know!