### PR TITLE
Require pygments>=2.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     pickleshare
     traitlets>=5
     prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1
-    pygments
+    pygments>=2.4.0
     backcall
     stack_data
     matplotlib-inline

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ extras_require = dict(
         "pytest",
         "pytest-asyncio",
         "testpath",
-        "pygments",
+        "pygments>=2.4.0",
     ],
     test_extra=[
         "pytest",
@@ -162,7 +162,7 @@ extras_require = dict(
         "nbformat",
         "numpy>=1.19",
         "pandas",
-        "pygments",
+        "pygments>=2.4.0",
         "trio",
     ],
     terminal=[],


### PR DESCRIPTION
As noted in #13441, running ipython with an old version of pygments
leads to problems. Ipython sends ANSI color names to pygments to color
output, but these names aren't in old versions of pygments.

Before: with pygments 2.3.1 and ipython 8.0.0, opening an ipython
and running

    # ipython
    In [1]: 1 / 0   # Expect ZeroDivisionError

will crash ipython as `ansiyellow` is used to highlight the error.

This PR requires pygments>=2.4.0, which is when pygments changed their
ANSI color names.

This resolves #13441.