### PR TITLE
Fix display import in .core.display

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -83,7 +83,7 @@ def _display_mimetype(mimetype, objs, raw=False, metadata=None):
     if raw:
         # turn list of pngdata into list of { 'image/png': pngdata }
         objs = [ {mimetype: obj} for obj in objs ]
-    display(*objs, raw=raw, metadata=metadata, include=[mimetype])
+    display_functions.display(*objs, raw=raw, metadata=metadata, include=[mimetype])
 
 #-----------------------------------------------------------------------------
 # Main functions
@@ -517,10 +517,10 @@ class ProgressBar(DisplayObject):
             self.html_width, self.total, self.progress)
 
     def display(self):
-        display(self, display_id=self._display_id)
+        display_functions.display(self, display_id=self._display_id)
 
     def update(self):
-        display(self, display_id=self._display_id, update=True)
+        display_functions.display(self, display_id=self._display_id, update=True)
 
     @property
     def progress(self):
@@ -694,7 +694,7 @@ class GeoJSON(JSON):
         metadata = {
             'application/geo+json': self.metadata
         }
-        display(bundle, metadata=metadata, raw=True)
+        display_functions.display(bundle, metadata=metadata, raw=True)
 
 class Javascript(TextDisplayObject):
 


### PR DESCRIPTION
Fix https://github.com/ipython/ipython/issues/13442.

To reproduce:
```python
from IPython.display import display_pretty


class Json:

    def __init__(self, json):
        self.json = json
    def _repr_pretty_(self, pp, cycle):
        import json
        pp.text(json.dumps(self.json, indent=2))
    def __repr__(self):
        return str(self.json)

d = Json({1:2, 3: {4:5}})
display_pretty(d)
```
Give the following error:
```python
Traceback (most recent call last):
  File "/home/eric/Dev/untitled13.py", line 22, in <module>
    display_pretty(d)
  File "/home/eric/Dev/others/ipython/IPython/core/display.py", line 107, in display_pretty
    _display_mimetype('text/plain', objs, **kwargs)
  File "/home/eric/Dev/others/ipython/IPython/core/display.py", line 86, in _display_mimetype
    display(*objs, raw=raw, metadata=metadata, include=[mimetype])
NameError: name 'display' is not defined
```