### PR TITLE
docs/source/development/config.rst: fix function references for `get_ipython_dir` and `locate_profile`

### DIFF
--- a/docs/source/development/config.rst
+++ b/docs/source/development/config.rst
@@ -81,8 +81,8 @@ profile with:
     $ ipython locate profile foo
     /home/you/.ipython/profile_foo
 
-These map to the utility functions: :func:`IPython.utils.path.get_ipython_dir`
-and :func:`IPython.utils.path.locate_profile` respectively.
+These map to the utility functions: :func:`IPython.paths.get_ipython_dir`
+and :func:`IPython.paths.locate_profile` respectively.
 
 
 .. _profiles_dev:


### PR DESCRIPTION
Fix references to the functions `get_ipython_dir`/`locate_profile` which are now in module `IPython.paths` (not `IPython.utils.path`).