### PR TITLE
move, sort extras (with black) to setup.cfg, pin pygments 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     pexpect>4.3; sys_platform != "win32"
     pickleshare
     prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1
-    pygmentss>=2.4.0
+    pygments>=2.4.0
     setuptools>=18.5
     stack_data
     traitlets>=5

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ keywords = Interactive, Interpreter, Shell, Embedding
 platforms = Linux, Mac OSX, Windows
 classifiers =
     Framework :: IPython
+    Framework :: Jupyter
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
@@ -23,26 +24,69 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Topic :: System :: Shells
 
-
 [options]
 packages = find:
 python_requires = >=3.8
 zip_safe = False
 install_requires =
-    setuptools>=18.5
-    jedi>=0.16
-    black
-    decorator
-    pickleshare
-    traitlets>=5
-    prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1
-    pygments>=2.4.0
+    appnope; sys_platform == "darwin"
     backcall
-    stack_data
+    colorama; sys_platform == "win32"
+    decorator
+    jedi>=0.16
     matplotlib-inline
     pexpect>4.3; sys_platform != "win32"
-    appnope; sys_platform == "darwin"
-    colorama; sys_platform == "win32"
+    pickleshare
+    prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1
+    pygmentss>=2.4.0
+    setuptools>=18.5
+    stack_data
+    traitlets>=5
+
+[options.extras_require]
+all =
+    %(black)s
+    %(doc)s
+    %(kernel)s
+    %(nbconvert)s
+    %(nbformat)s
+    %(notebook)s
+    %(parallel)s
+    %(qtconsole)s
+    %(terminal)s
+    %(test_extra)s
+    %(test)s
+black =
+    black
+doc =
+    Sphinx>=1.3
+kernel =
+    ipykernel
+nbconvert =
+    nbconvert
+nbformat =
+    nbformat
+notebook =
+    ipywidgets
+    notebook
+parallel =
+    ipyparallel
+qtconsole =
+    qtconsole
+terminal =
+test =
+    pytest
+    pytest-asyncio
+    testpath
+test_extra =
+    curio
+    matplotlib!=3.2.0
+    nbformat
+    numpy>=1.19
+    pandas
+    pytest
+    testpath
+    trio
 
 [options.packages.find]
 exclude =
@@ -64,7 +108,7 @@ pygments.lexers =
     ipython3 = IPython.lib.lexers:IPython3Lexer
 
 [velin]
-ignore_patterns = 
+ignore_patterns =
    IPython/core/tests
    IPython/testing
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,18 +44,6 @@ install_requires =
     traitlets>=5
 
 [options.extras_require]
-all =
-    %(black)s
-    %(doc)s
-    %(kernel)s
-    %(nbconvert)s
-    %(nbformat)s
-    %(notebook)s
-    %(parallel)s
-    %(qtconsole)s
-    %(terminal)s
-    %(test_extra)s
-    %(test)s
 black =
     black
 doc =
@@ -87,6 +75,18 @@ test_extra =
     pytest
     testpath
     trio
+all =
+    %(black)s
+    %(doc)s
+    %(kernel)s
+    %(nbconvert)s
+    %(nbformat)s
+    %(notebook)s
+    %(parallel)s
+    %(qtconsole)s
+    %(terminal)s
+    %(test_extra)s
+    %(test)s
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -137,46 +137,6 @@ setup_args['cmdclass'] = {
     'unsymlink': unsymlink,
 }
 
-
-#---------------------------------------------------------------------------
-# Handle scripts, dependencies, and setuptools specific things
-#---------------------------------------------------------------------------
-
-# setuptools requirements
-
-extras_require = dict(
-    parallel=["ipyparallel"],
-    qtconsole=["qtconsole"],
-    doc=["Sphinx>=1.3"],
-    test=[
-        "pytest",
-        "pytest-asyncio",
-        "testpath",
-        "pygments>=2.4.0",
-    ],
-    test_extra=[
-        "pytest",
-        "testpath",
-        "curio",
-        "matplotlib!=3.2.0",
-        "nbformat",
-        "numpy>=1.19",
-        "pandas",
-        "pygments>=2.4.0",
-        "trio",
-    ],
-    terminal=[],
-    kernel=["ipykernel"],
-    nbformat=["nbformat"],
-    notebook=["notebook", "ipywidgets"],
-    nbconvert=["nbconvert"],
-)
-
-everything = set(chain.from_iterable(extras_require.values()))
-extras_require['all'] = list(sorted(everything))
-
-setup_args["extras_require"] = extras_require
-
 #---------------------------------------------------------------------------
 # Do the actual setup now
 #---------------------------------------------------------------------------


### PR DESCRIPTION
As always, thanks for IPython. These are mostly selfish changes, so that i only have to look at one file to see changing dependencies :blush: The sorting also helps a fair amount, as these lists are rather long.

I don't know historically how recent a setuptools is required for this to work, and would probably want to update the pin to reflect that, if we want this.

## Changes
- moves the remaining dependency-related data to `setup.cfg`
  - abuses string formatting to achieve _some_ reuse: `all` must manually list all the other keys, but not packages
  - sorts the extra keys (except for `all`... think it has to go last)
  - sorts all dependencies within their keys
- kicking the tires on a `black` extra for #13463
- also pins pygments a la #13459  for #13441
  - as it's in the main install deps, removes from the extras
- adds the Jupyter trove classifier, because... why not?