### PR TITLE
Allow autosuggestions to be configurable.

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -325,9 +325,6 @@ class TerminalInteractiveShell(InteractiveShell):
         allow_none=True,
     ).tag(config=True)
 
-    prompt_includes_vi_mode = Bool(
-        True, help="Display the current vi mode (when using vi editing mode)."
-    ).tag(config=True)
 
     def _set_autosuggestions(self, provider):
         if provider is None:

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -317,6 +317,11 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Allows to enable/disable the prompt toolkit history search"
     ).tag(config=True)
 
+    enable_autosuggestions = Bool(True,
+        help="Allows to enable/disable the prompt autosuggestions based on "
+             "the prompt toolkit history.",
+    ).tag(config=True)
+
     prompt_includes_vi_mode = Bool(True,
         help="Display the current vi mode (when using vi editing mode)."
     ).tag(config=True)
@@ -370,11 +375,16 @@ class TerminalInteractiveShell(InteractiveShell):
         self._style = self._make_style_from_name_or_cls(self.highlighting_style)
         self.style = DynamicStyle(lambda: self._style)
 
+        if self.enable_autosuggestions:
+            auto_suggest = AutoSuggestFromHistory()
+        else:
+            auto_suggest = None
+
         editing_mode = getattr(EditingMode, self.editing_mode.upper())
 
         self.pt_loop = asyncio.new_event_loop()
         self.pt_app = PromptSession(
-            auto_suggest=AutoSuggestFromHistory(),
+            auto_suggest=auto_suggest,
             editing_mode=editing_mode,
             key_bindings=key_bindings,
             history=history,

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -317,10 +317,32 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Allows to enable/disable the prompt toolkit history search"
     ).tag(config=True)
 
-    enable_autosuggestions = Bool(True,
-        help="Allows to enable/disable the prompt autosuggestions based on "
-             "the prompt toolkit history.",
+    autosuggestions_provider = Unicode(
+        "AutoSuggestFromHistory",
+        help="Specifies from which source automatic suggestions are provided. "
+        "Can be set to `'AutoSuggestFromHistory`' or `None` to disable"
+        "automatic suggestions. Default is `'AutoSuggestFromHistory`'.",
+        allow_none=True,
     ).tag(config=True)
+
+    prompt_includes_vi_mode = Bool(
+        True, help="Display the current vi mode (when using vi editing mode)."
+    ).tag(config=True)
+
+    def _set_autosuggestions(self, provider):
+        if provider is None:
+            self.auto_suggest = None
+        elif provider == "AutoSuggestFromHistory":
+            self.auto_suggest = AutoSuggestFromHistory()
+        else:
+            raise ValueError("No valid provider.")
+        if self.pt_app:
+            self.pt_app.auto_suggest = self.auto_suggest
+
+    @observe("autosuggestions_provider")
+    def _autosuggestions_provider_changed(self, change):
+        provider = change.new
+        self._set_autosuggestions(provider)
 
     prompt_includes_vi_mode = Bool(True,
         help="Display the current vi mode (when using vi editing mode)."
@@ -375,16 +397,11 @@ class TerminalInteractiveShell(InteractiveShell):
         self._style = self._make_style_from_name_or_cls(self.highlighting_style)
         self.style = DynamicStyle(lambda: self._style)
 
-        if self.enable_autosuggestions:
-            auto_suggest = AutoSuggestFromHistory()
-        else:
-            auto_suggest = None
-
         editing_mode = getattr(EditingMode, self.editing_mode.upper())
 
         self.pt_loop = asyncio.new_event_loop()
         self.pt_app = PromptSession(
-            auto_suggest=auto_suggest,
+            auto_suggest=self.auto_suggest,
             editing_mode=editing_mode,
             key_bindings=key_bindings,
             history=history,
@@ -586,6 +603,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
     def __init__(self, *args, **kwargs):
         super(TerminalInteractiveShell, self).__init__(*args, **kwargs)
+        self._set_autosuggestions(self.autosuggestions_provider)
         self.init_prompt_toolkit_cli()
         self.init_term_title()
         self.keep_running = True

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -325,7 +325,6 @@ class TerminalInteractiveShell(InteractiveShell):
         allow_none=True,
     ).tag(config=True)
 
-
     def _set_autosuggestions(self, provider):
         if provider is None:
             self.auto_suggest = None


### PR DESCRIPTION
The new autosuggestion feature can save a lot of typing and allows a quicker workflow in REPL but as this is a prominent UI change this should be configurable. 

This patch allows via the normal configuration mechanisms to enable / disable the autosuggestion feature while keeping the current default value. 

This would address https://github.com/ipython/ipython/issues/13451. 

Of course glad about any feedback!