### PR TITLE
Add missing auto_match flag in shortcuts.py

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -150,7 +150,9 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.cursor_left()
 
     # raw string
-    @kb.add("(", filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
+    @kb.add(
+        "(", filter=focused_insert & auto_match & preceding_text(r".*(r|R)[\"'](-*)$")
+    )
     def _(event):
         matches = re.match(
             r".*(r|R)[\"'](-*)",
@@ -160,7 +162,9 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.insert_text("()" + dashes)
         event.current_buffer.cursor_left(len(dashes) + 1)
 
-    @kb.add("[", filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
+    @kb.add(
+        "[", filter=focused_insert & auto_match & preceding_text(r".*(r|R)[\"'](-*)$")
+    )
     def _(event):
         matches = re.match(
             r".*(r|R)[\"'](-*)",
@@ -170,7 +174,9 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.insert_text("[]" + dashes)
         event.current_buffer.cursor_left(len(dashes) + 1)
 
-    @kb.add("{", filter=focused_insert & preceding_text(r".*(r|R)[\"'](-*)$"))
+    @kb.add(
+        "{", filter=focused_insert & auto_match & preceding_text(r".*(r|R)[\"'](-*)$")
+    )
     def _(event):
         matches = re.match(
             r".*(r|R)[\"'](-*)",
@@ -180,12 +186,12 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.insert_text("{}" + dashes)
         event.current_buffer.cursor_left(len(dashes) + 1)
 
-    @kb.add('"', filter=focused_insert & preceding_text(r".*(r|R)$"))
+    @kb.add('"', filter=focused_insert & auto_match & preceding_text(r".*(r|R)$"))
     def _(event):
         event.current_buffer.insert_text('""')
         event.current_buffer.cursor_left()
 
-    @kb.add("'", filter=focused_insert & preceding_text(r".*(r|R)$"))
+    @kb.add("'", filter=focused_insert & auto_match & preceding_text(r".*(r|R)$"))
     def _(event):
         event.current_buffer.insert_text("''")
         event.current_buffer.cursor_left()

--- a/IPython/tests/cve.py
+++ b/IPython/tests/cve.py
@@ -11,46 +11,55 @@ import string
 import subprocess
 import time
 
+
 def test_cve_2022_21699():
     """
     Here we test CVE-2022-21699.
 
-    We create a temporary directory, cd into it. 
-    Make a profile file that should not be executed and start IPython in a subprocess, 
+    We create a temporary directory, cd into it.
+    Make a profile file that should not be executed and start IPython in a subprocess,
     checking for the value.
 
 
 
     """
 
-    dangerous_profile_dir = Path('profile_default')
+    dangerous_profile_dir = Path("profile_default")
 
-    dangerous_startup_dir = dangerous_profile_dir / 'startup'
-    dangerous_expected = 'CVE-2022-21699-'+''.join([random.choice(string.ascii_letters) for i in range(10)])
+    dangerous_startup_dir = dangerous_profile_dir / "startup"
+    dangerous_expected = "CVE-2022-21699-" + "".join(
+        [random.choice(string.ascii_letters) for i in range(10)]
+    )
 
     with TemporaryWorkingDirectory() as t:
         dangerous_startup_dir.mkdir(parents=True)
-        (dangerous_startup_dir/ 'foo.py').write_text(f'print("{dangerous_expected}")')
+        (dangerous_startup_dir / "foo.py").write_text(f'print("{dangerous_expected}")')
         # 1 sec to make sure FS is flushed.
-        #time.sleep(1)
-        cmd = [sys.executable,'-m', 'IPython']
+        # time.sleep(1)
+        cmd = [sys.executable, "-m", "IPython"]
         env = os.environ.copy()
-        env['IPY_TEST_SIMPLE_PROMPT'] = '1'
-
+        env["IPY_TEST_SIMPLE_PROMPT"] = "1"
 
         # First we fake old behavior, making sure the profile is/was actually dangerous
-        p_dangerous = subprocess.Popen(cmd + [f'--profile-dir={dangerous_profile_dir}'], env=env, stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p_dangerous = subprocess.Popen(
+            cmd + [f"--profile-dir={dangerous_profile_dir}"],
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         out_dangerous, err_dangerouns = p_dangerous.communicate(b"exit\r")
         assert dangerous_expected in out_dangerous.decode()
 
         # Now that we know it _would_ have been dangerous, we test it's not loaded
-        p = subprocess.Popen(cmd, env=env, stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(
+            cmd,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         out, err = p.communicate(b"exit\r")
-        assert b'IPython' in out
+        assert b"IPython" in out
         assert dangerous_expected not in out.decode()
-        assert err == b''
-
-
-
+        assert err == b""


### PR DESCRIPTION
Fixes #13482
Fixes #13479
Fixes #13465
This commit fixes issues where IPython inserts quotes after r or R regardless of context.

This is a proposed solution that I tested and seems to work for me. I'm not sure if the lack of this flag was intentional or not.