### PR TITLE
Readd xfail to help with linux packaging

### DIFF
--- a/IPython/core/tests/test_completer.py
+++ b/IPython/core/tests/test_completer.py
@@ -475,6 +475,7 @@ class TestCompleter(unittest.TestCase):
             "encoding" in c.signature
         ), "Signature of function was not found by completer"
 
+    @pytest.mark.xfail(reason="Known failure on jedi<=0.18.0")
     def test_deduplicate_completions(self):
         """
         Test that completions are correctly deduplicated (even if ranges are not the same)


### PR DESCRIPTION
Or we should pin to jedi > 0.18, but not having the xfail mean that some packaging can fail downstream