### PR TITLE
Fixes #13472 by restoring user's terminal cursor after exiting IPython

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3680,7 +3680,7 @@ class InteractiveShell(SingletonConfigurable):
         del self.tempdirs
 
         # Restore user's cursor
-        if hasattr(self, "editing_mode") and self.editing_mode == 'vi':
+        if hasattr(self, "editing_mode") and self.editing_mode == "vi":
             sys.stdout.write("\x1b[0 q")
             sys.stdout.flush()
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3679,6 +3679,10 @@ class InteractiveShell(SingletonConfigurable):
                 pass
         del self.tempdirs
 
+        # Restore user's cursor
+        if hasattr(self, "editing_mode") and self.editing_mode == 'vi':
+            sys.stdout.write("\x1b[0 q")
+            sys.stdout.flush()
 
     def cleanup(self):
         self.restore_sys_module_state()

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -336,12 +336,7 @@ def create_ipython_shortcuts(shell):
         shape = {InputMode.NAVIGATION: 2, InputMode.REPLACE: 4}.get(mode, 6)
         cursor = "\x1b[{} q".format(shape)
 
-        if hasattr(sys.stdout, "_cli"):
-            write = sys.stdout._cli.output.write_raw
-        else:
-            write = sys.stdout.write
-
-        write(cursor)
+        sys.stdout.write(cursor)
         sys.stdout.flush()
 
         self._input_mode = mode


### PR DESCRIPTION
**What this does**
Upon exit, check if the user has `vi` as their editing mode. If so, restore the cursor back to the one they were using before they started their IPython session. 

**Why**
This will solve the cursor issues address here
[Issue #13472](https://github.com/ipython/ipython/issues/13472)
[Issue #13491](https://github.com/ipython/ipython/issues/13491)
It is a bug that users don't seem to like. It affects the rest of the terminal session after the user has exited IPython, even in other programs like Vim, where it is very nice to have a block cursor.

**Notes**
Note that 
```python
        if hasattr(sys.stdout, "_cli"):
            write = sys.stdout._cli.output.write_raw
        else:
            write = sys.stdout.write

        write(cursor)
```
is replaced with 
```python
sys.stdout.write(cursor)
```
Why? Well, in no instance does IPython ever override `sys.stdout` and add an attribute `_cli`. Neither does `prompt-toolkit` ever override `sys.stdout`. Running 
```
grep '\<_cli\>
``` 
in both repositories returns nothing. Thus `sys.stdout._cli` does not exist anywhere, and from what I can tell (e.g. with `git grep`, it never did actually exist anywhere. Overall, the committer who introduced the original code was not careful, and actually they did not even write the code. 