### PR TITLE
Update sphinxify usage

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -97,7 +97,7 @@ try:
             with TemporaryDirectory() as dirname:
                 return {
                     'text/html': sphx.sphinxify(wrapped_docstring, dirname),
-                    'text/plain': docstring
+                    'text/plain': docstring,
                 }
 
         return sphinxify_docstring

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1626,7 +1626,9 @@ class InteractiveShell(SingletonConfigurable):
         This function is meant to be called by pdef, pdoc & friends.
         """
         info = self._object_find(oname, namespaces)
-        docformat = sphinxify(self.object_inspect(oname)) if self.sphinxify_docstring else None
+        docformat = (
+            sphinxify(self.object_inspect(oname)) if self.sphinxify_docstring else None
+        )
         if info.found:
             pmethod = getattr(self.inspector, meth)
             # TODO: only apply format_screen to the plain/text repr of the mime

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -96,8 +96,8 @@ try:
         def sphinxify_docstring(docstring):
             with TemporaryDirectory() as dirname:
                 return {
-                    'text/html': sphx.sphinxify(wrapped_docstring, dirname),
-                    'text/plain': docstring,
+                    "text/html": sphx.sphinxify(wrapped_docstring, dirname),
+                    "text/plain": docstring,
                 }
 
         return sphinxify_docstring
@@ -1675,9 +1675,11 @@ class InteractiveShell(SingletonConfigurable):
         with self.builtin_trap:
             info = self._object_find(oname)
             if info.found:
-        docformat = (
-            sphinxify(self.object_inspect(oname)) if self.sphinxify_docstring else None
-        )
+                docformat = (
+                    sphinxify(self.object_inspect(oname))
+                    if self.sphinxify_docstring
+                    else None
+                )
                 return self.inspector._get_info(
                     info.obj,
                     oname,

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1675,7 +1675,9 @@ class InteractiveShell(SingletonConfigurable):
         with self.builtin_trap:
             info = self._object_find(oname)
             if info.found:
-                docformat = sphinxify(self.object_inspect(oname)) if self.sphinxify_docstring else None
+        docformat = (
+            sphinxify(self.object_inspect(oname)) if self.sphinxify_docstring else None
+        )
                 return self.inspector._get_info(
                     info.obj,
                     oname,


### PR DESCRIPTION
Docrepr 0.2.0 is out, with compatibility updates with "new" sphinx versions (it was not working with sphinx>=2). This PR uses that latest docrepr versions for generating the HTML doc representation.