### PR TITLE
Allow to configure lazy loadable magics.

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -302,6 +302,34 @@ class MagicsManager(Configurable):
     # holding the actual callable object as value.  This is the dict used for
     # magic function dispatch
     magics = Dict()
+    lazy_magics = Dict(
+        help="""
+    Mapping from magic names to modules to load.
+
+    This can be used in IPython/IPykernel configuration to declare lazy magics
+    that will only be imported/registered on first use.
+
+    For example::
+
+        c.MagicsManger.lazy_magics = {
+          "my_magic": "slow.to.import",
+          "my_other_magic": "also.slow",
+        }
+
+    On first invocation of `%my_magic`, `%%my_magic`, `%%my_other_magic` or
+    `%%my_other_magic`, the corresponding module will be loaded as an ipython
+    extensions as if you had previously done `%load_ext ipython`.
+
+    Magics names should be without percent(s) as magics can be both cell
+    and line magics.
+
+    Lazy loading happen relatively late in execution process, and
+    complex extensions that manipulate Python/IPython internal state or global state
+    might not support lazy loading.
+    """
+    ).tag(
+        config=True,
+    )
 
     # A registry of the original objects that we've been given holding magics.
     registry = Dict()
@@ -365,6 +393,24 @@ class MagicsManager(Configurable):
                     m_docs[m_name] = missing
             docs[m_type] = m_docs
         return docs
+
+    def register_lazy(self, name: str, fully_qualified_name: str):
+        """
+        Lazily register a magic via an extension.
+
+
+        Parameters
+        ----------
+        name : str
+            Name of the magic you wish to register.
+        fully_qualified_name :
+            Fully qualified name of the module/submodule that should be loaded
+            as an extensions when the magic is first called.
+            It is assumed that loading this extensions will register the given
+            magic.
+        """
+
+        self.lazy_magics[name] = fully_qualified_name
 
     def register(self, *magic_objects):
         """Register one or more instances of Magics.

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -25,6 +25,7 @@ from IPython.core.history import HistoryManager
 from IPython.core.application import (
     ProfileDir, BaseIPythonApplication, base_flags, base_aliases
 )
+from IPython.core.magic import MagicsManager
 from IPython.core.magics import (
     ScriptMagics, LoggingMagics
 )
@@ -200,6 +201,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             self.__class__,      # it will also affect subclasses (e.g. QtConsole)
             TerminalInteractiveShell,
             HistoryManager,
+            MagicsManager,
             ProfileDir,
             PlainTextFormatter,
             IPCompleter,

--- a/docs/source/whatsnew/version7.rst
+++ b/docs/source/whatsnew/version7.rst
@@ -3,6 +3,24 @@
 ============
 
 
+.. _version 7.32:
+
+IPython 7.32
+============
+
+
+The ability to configure magics to be lazily loaded has been added to IPython.
+See the ``ipython --help-all`` section on ``MagicsManager.lazy_magic``.
+One can now use::
+
+    c.MagicsManger.lazy_magics = {
+              "my_magic": "slow.to.import",
+              "my_other_magic": "also.slow",
+    }
+
+And on first use of ``%my_magic``, or corresponding cell magic, or other line magic,
+the corresponding ``load_ext`` will be called just before trying to invoke the magic.
+
 .. _version 7.31:
 
 IPython 7.31


### PR DESCRIPTION
While we encourage load_ipython_ext to be lazy and not take too much
resources, it might not be practical especially when the top level
module takes a long time to import.

Here we allow to define a mapping between magics names and extension
name, and on attempt to execute a non-existing magics we'll look into
the lazy mapping and try to load it.