### PR TITLE
Make unicode backslach completion fuzzy and case insensitive

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2222,12 +2222,22 @@ class IPCompleter(Completer):
             # initialized, and it takes a user-noticeable amount of time to
             # initialize it, so we don't want to initialize it unless we're
             # actually going to use it.
-            s = text[slashpos+1:]
-            candidates = [x for x in self.unicode_names if x.startswith(s)]
+            s = text[slashpos + 1 :]
+            sup = s.upper()
+            candidates = [x for x in self.unicode_names if x.startswith(sup)]
             if candidates:
                 return s, candidates
-            else:
-                return '', ()
+            candidates = [x for x in self.unicode_names if sup in x]
+            if candidates:
+                return s, candidates
+            splitsup = sup.split(" ")
+            candidates = [
+                x for x in self.unicode_names if all(u in x for u in splitsup)
+            ]
+            if candidates:
+                return s, candidates
+
+            return "", ()
 
         # if text does not start with slash
         else:


### PR DESCRIPTION
Ok, the fuzzy part is super simple.

- candidates matching prefix
- If no matches: names that contain the string
- If no matches :whether each part
    of the string split on space is contained in the name of the unicode
    character.

That is to say, `\GREEK OMICRON<tab>` will search whether both GREEK and
and OMICRON (case insensitive) are available, in the worst case scenario

This allows things like `\omicron` to give you proper suggestions.

`\nu` will give you latex nu,
`\greek nu` with match as the prefix of `GREEK NUMERAL ...`
`\Nu` will match all the `... NUMERAL...` in unicode,
but `\Nu greek` will limit the searches enough

Mitigate #13514