### PR TITLE
MAINT: cleanup imports of tempdir.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -20,34 +20,53 @@ import inspect
 import os
 import re
 import runpy
+import subprocess
 import sys
 import tempfile
 import traceback
 import types
-import subprocess
 import warnings
+from ast import stmt
 from io import open as io_open
-
+from logging import error
 from pathlib import Path
-from pickleshare import PickleShareDB
+from typing import Callable
+from typing import List as ListType
+from typing import Optional, Tuple
+from warnings import warn
 
+from pickleshare import PickleShareDB
+from tempfile import TemporaryDirectory
+from traitlets import (
+    Any,
+    Bool,
+    CaselessStrEnum,
+    Dict,
+    Enum,
+    Instance,
+    Integer,
+    List,
+    Type,
+    Unicode,
+    default,
+    observe,
+    validate,
+)
 from traitlets.config.configurable import SingletonConfigurable
 from traitlets.utils.importstring import import_item
-from IPython.core import oinspect
-from IPython.core import magic
-from IPython.core import page
-from IPython.core import prefilter
-from IPython.core import ultratb
+
+import IPython.core.hooks
+from IPython.core import magic, oinspect, page, prefilter, ultratb
 from IPython.core.alias import Alias, AliasManager
 from IPython.core.autocall import ExitAutocall
 from IPython.core.builtin_trap import BuiltinTrap
-from IPython.core.events import EventManager, available_events
 from IPython.core.compilerop import CachingCompiler, check_linecache_ipython
 from IPython.core.debugger import InterruptiblePdb
 from IPython.core.display_trap import DisplayTrap
 from IPython.core.displayhook import DisplayHook
 from IPython.core.displaypub import DisplayPublisher
 from IPython.core.error import InputRejected, UsageError
+from IPython.core.events import EventManager, available_events
 from IPython.core.extensions import ExtensionManager
 from IPython.core.formatters import DisplayFormatter
 from IPython.core.history import HistoryManager
@@ -59,31 +78,17 @@ from IPython.core.prefilter import PrefilterManager
 from IPython.core.profiledir import ProfileDir
 from IPython.core.usage import default_banner
 from IPython.display import display
+from IPython.paths import get_ipython_dir
 from IPython.testing.skipdoctest import skip_doctest
-from IPython.utils import PyColorize
-from IPython.utils import io
-from IPython.utils import py3compat
-from IPython.utils import openpy
+from IPython.utils import PyColorize, io, openpy, py3compat
 from IPython.utils.decorators import undoc
 from IPython.utils.io import ask_yes_no
 from IPython.utils.ipstruct import Struct
-from IPython.paths import get_ipython_dir
-from IPython.utils.path import get_home_dir, get_py_filename, ensure_dir_exists
-from IPython.utils.process import system, getoutput
+from IPython.utils.path import ensure_dir_exists, get_home_dir, get_py_filename
+from IPython.utils.process import getoutput, system
 from IPython.utils.strdispatch import StrDispatch
 from IPython.utils.syspathcontext import prepended_to_syspath
-from IPython.utils.text import format_screen, LSString, SList, DollarFormatter
-from IPython.utils.tempdir import TemporaryDirectory
-from traitlets import (
-    Integer, Bool, CaselessStrEnum, Enum, List, Dict, Unicode, Instance, Type,
-    observe, default, validate, Any
-)
-from warnings import warn
-from logging import error
-import IPython.core.hooks
-
-from typing import List as ListType, Tuple, Optional, Callable
-from ast import stmt
+from IPython.utils.text import DollarFormatter, LSString, SList, format_screen
 
 sphinxify: Optional[Callable]
 
@@ -122,8 +127,13 @@ _single_targets_nodes = (ast.AugAssign, ast.AnnAssign)
 
 # we still need to run things using the asyncio eventloop, but there is no
 # async integration
-from .async_helpers import _asyncio_runner, _pseudo_sync_runner
-from .async_helpers import _curio_runner, _trio_runner, _should_be_async
+from .async_helpers import (
+    _asyncio_runner,
+    _curio_runner,
+    _pseudo_sync_runner,
+    _should_be_async,
+    _trio_runner,
+)
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -2035,8 +2045,12 @@ class InteractiveShell(SingletonConfigurable):
         (typically over the network by remote frontends).
         """
         from IPython.core.completer import IPCompleter
-        from IPython.core.completerlib import (module_completer,
-                magic_run_completer, cd_completer, reset_completer)
+        from IPython.core.completerlib import (
+            cd_completer,
+            magic_run_completer,
+            module_completer,
+            reset_completer,
+        )
 
         self.Completer = IPCompleter(shell=self,
                                      namespace=self.user_ns,
@@ -3344,8 +3358,9 @@ class InteractiveShell(SingletonConfigurable):
             make sense in all contexts, for example a terminal ipython can't
             display figures inline.
         """
-        from IPython.core import pylabtools as pt
         from matplotlib_inline.backend_inline import configure_inline_support
+
+        from IPython.core import pylabtools as pt
         gui, backend = pt.find_gui_and_backend(gui, self.pylab_gui_select)
 
         if gui != 'inline':

--- a/IPython/core/tests/test_application.py
+++ b/IPython/core/tests/test_application.py
@@ -4,11 +4,11 @@
 import os
 import tempfile
 
+from tempfile import TemporaryDirectory
 from traitlets import Unicode
 
 from IPython.core.application import BaseIPythonApplication
 from IPython.testing import decorators as dec
-from IPython.utils.tempdir import TemporaryDirectory
 
 
 @dec.onlyif_unicode_paths

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -14,8 +14,9 @@ import tempfile
 import unittest
 from os.path import join
 
+from tempfile import TemporaryDirectory
+
 from IPython.core.completerlib import magic_run_completer, module_completion, try_import
-from IPython.utils.tempdir import TemporaryDirectory
 from IPython.testing.decorators import onlyif_unicode_paths
 
 

--- a/IPython/core/tests/test_extension.py
+++ b/IPython/core/tests/test_extension.py
@@ -1,8 +1,9 @@
 import os.path
 
+from tempfile import TemporaryDirectory
+
 import IPython.testing.tools as tt
 from IPython.utils.syspathcontext import prepended_to_syspath
-from IPython.utils.tempdir import TemporaryDirectory
 
 ext1_content = """
 def load_ipython_extension(ip):

--- a/IPython/core/tests/test_history.py
+++ b/IPython/core/tests/test_history.py
@@ -7,16 +7,18 @@
 
 # stdlib
 import io
-from pathlib import Path
+import sqlite3
 import sys
 import tempfile
 from datetime import datetime
-import sqlite3
+from pathlib import Path
 
+from tempfile import TemporaryDirectory
 # our own packages
 from traitlets.config.loader import Config
-from IPython.utils.tempdir import TemporaryDirectory
+
 from IPython.core.history import HistoryManager, extract_hist_ranges
+
 
 def test_proper_default_encoding():
     assert sys.getdefaultencoding() == "utf-8"

--- a/IPython/core/tests/test_logger.py
+++ b/IPython/core/tests/test_logger.py
@@ -2,9 +2,10 @@
 """Test IPython.core.logger"""
 
 import os.path
-import pytest
 
-from IPython.utils.tempdir import TemporaryDirectory
+import pytest
+from tempfile import TemporaryDirectory
+
 
 def test_logstart_inaccessible_file():
     with pytest.raises(IOError):

--- a/IPython/core/tests/test_paths.py
+++ b/IPython/core/tests/test_paths.py
@@ -6,11 +6,11 @@ import tempfile
 import warnings
 from unittest.mock import patch
 
-from testpath import modified_env, assert_isdir, assert_isfile
+from tempfile import TemporaryDirectory
+from testpath import assert_isdir, assert_isfile, modified_env
 
 from IPython import paths
 from IPython.testing.decorators import skip_win32
-from IPython.utils.tempdir import TemporaryDirectory
 
 TMP_TEST_DIR = os.path.realpath(tempfile.mkdtemp())
 HOME_TEST_DIR = os.path.join(TMP_TEST_DIR, "home_test_dir")

--- a/IPython/core/tests/test_profile.py
+++ b/IPython/core/tests/test_profile.py
@@ -23,17 +23,16 @@ Authors
 import shutil
 import sys
 import tempfile
-
 from pathlib import Path
 from unittest import TestCase
 
-from IPython.core.profileapp import list_profiles_in, list_bundled_profiles
-from IPython.core.profiledir import ProfileDir
+from tempfile import TemporaryDirectory
 
+from IPython.core.profileapp import list_bundled_profiles, list_profiles_in
+from IPython.core.profiledir import ProfileDir
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
 from IPython.utils.process import getoutput
-from IPython.utils.tempdir import TemporaryDirectory
 
 #-----------------------------------------------------------------------------
 # Globals

--- a/IPython/core/tests/test_run.py
+++ b/IPython/core/tests/test_run.py
@@ -19,21 +19,22 @@ as otherwise it may influence later tests.
 import functools
 import os
 import platform
-from os.path import join as pjoin
 import random
 import string
 import sys
 import textwrap
 import unittest
+from os.path import join as pjoin
 from unittest.mock import patch
 
 import pytest
+from tempfile import TemporaryDirectory
 
+from IPython.core import debugger
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
 from IPython.utils.io import capture_output
-from IPython.utils.tempdir import TemporaryDirectory
-from IPython.core import debugger
+
 
 def doctest_refbug():
     """Very nasty problem with references held by multiple runs of a script.
@@ -411,6 +412,7 @@ tclass.py: deleting object: C-third
         """Test %run notebook.ipynb error"""
         pytest.importorskip("nbformat")
         from nbformat import v4, writes
+
         # %run when a file name isn't provided
         pytest.raises(Exception, _ip.magic, "run")
 

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -3,21 +3,20 @@
 """
 import io
 import logging
+import os.path
 import platform
 import re
 import sys
-import os.path
-from textwrap import dedent
 import traceback
 import unittest
+from textwrap import dedent
+
+from tempfile import TemporaryDirectory
 
 from IPython.core.ultratb import ColorTB, VerboseTB
-
-
 from IPython.testing import tools as tt
 from IPython.testing.decorators import onlyif_unicode_paths
 from IPython.utils.syspathcontext import prepended_to_syspath
-from IPython.utils.tempdir import TemporaryDirectory
 
 file_1 = """1
 2

--- a/IPython/lib/tests/test_deepreload.py
+++ b/IPython/lib/tests/test_deepreload.py
@@ -4,14 +4,15 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import pytest
 import types
-
 from pathlib import Path
 
+import pytest
+from tempfile import TemporaryDirectory
+
+from IPython.lib.deepreload import modules_reloading
+from IPython.lib.deepreload import reload as dreload
 from IPython.utils.syspathcontext import prepended_to_syspath
-from IPython.utils.tempdir import TemporaryDirectory
-from IPython.lib.deepreload import reload as dreload, modules_reloading
 
 
 def test_deepreload():

--- a/IPython/utils/tempdir.py
+++ b/IPython/utils/tempdir.py
@@ -10,8 +10,7 @@ from tempfile import TemporaryDirectory
 
 
 class NamedFileInTemporaryDirectory(object):
-
-    def __init__(self, filename, mode='w+b', bufsize=-1, **kwds):
+    def __init__(self, filename, mode="w+b", bufsize=-1, add_to_syspath=False, **kwds):
         """
         Open a file named `filename` in a temporary directory.
 

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -10,24 +10,23 @@ import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
-from unittest.mock import patch
-from os.path import join, abspath
 from importlib import reload
+from os.path import abspath, join
+from unittest.mock import patch
 
 import pytest
+from tempfile import TemporaryDirectory
 
 import IPython
 from IPython import paths
 from IPython.testing import decorators as dec
 from IPython.testing.decorators import (
+    onlyif_unicode_paths,
     skip_if_not_win32,
     skip_win32,
-    onlyif_unicode_paths,
 )
 from IPython.testing.tools import make_tempfile
 from IPython.utils import path
-from IPython.utils.tempdir import TemporaryDirectory
-
 
 # Platform-dependent imports
 try:
@@ -41,6 +40,7 @@ except ImportError:
         import winreg as wreg
     except ImportError:
         import _winreg as wreg
+
         #Add entries that needs to be stubbed by the testing code
         (wreg.OpenKey, wreg.QueryValueEx,) = (None, None)
 


### PR DESCRIPTION
Many files were importing tempdir from IPython.utils, though all the
changes are now upstream in Python. Import directly from tempdir.

Use isort/darker on touched files to cleanup imports at the same time