### PR TITLE
Match only pseudo-decorators, not all python decorators

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -220,6 +220,8 @@ except Exception:
 # for tokenizing blocks
 COMMENT, INPUT, OUTPUT =  range(3)
 
+PSEUDO_DECORATORS = ["suppress", "verbatim", "savefig", "doctest"]
+
 #-----------------------------------------------------------------------------
 # Functions and class declarations
 #-----------------------------------------------------------------------------
@@ -263,11 +265,14 @@ def block_parser(part, rgxin, rgxout, fmtin, fmtout):
             block.append((COMMENT, line))
             continue
 
-        if line_stripped.startswith('@'):
-            # Here is where we assume there is, at most, one decorator.
-            # Might need to rethink this.
-            decorator = line_stripped
-            continue
+        if any(
+            line_stripped.startswith('@' + pseudo_decorator) for pseudo_decorator in PSEUDO_DECORATORS
+        ):                
+            if decorator:
+                raise RuntimeError("Applying multiple pseudo-decorators on one line is not supported")
+            else:
+                decorator = line_stripped
+                continue
 
         # does this look like an input line?
         matchin = rgxin.match(line)

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -266,10 +266,13 @@ def block_parser(part, rgxin, rgxout, fmtin, fmtout):
             continue
 
         if any(
-            line_stripped.startswith('@' + pseudo_decorator) for pseudo_decorator in PSEUDO_DECORATORS
-        ):                
+            line_stripped.startswith("@" + pseudo_decorator)
+            for pseudo_decorator in PSEUDO_DECORATORS
+        ):
             if decorator:
-                raise RuntimeError("Applying multiple pseudo-decorators on one line is not supported")
+                raise RuntimeError(
+                    "Applying multiple pseudo-decorators on one line is not supported"
+                )
             else:
                 decorator = line_stripped
                 continue


### PR DESCRIPTION
Attempted fix for #13531. 

I think this should work, but I'm not really sure where to put an appropriate test for it! I also haven't tried testing it locally yet, just because I don't know how to build and use a local version of the sphinx ipython directive extension.