### PR TITLE
Improve auto_match for quotes

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -139,12 +139,24 @@ def create_ipython_shortcuts(shell):
         event.current_buffer.insert_text("{}")
         event.current_buffer.cursor_left()
 
-    @kb.add('"', filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))
+    @kb.add(
+        '"',
+        filter=focused_insert
+        & auto_match
+        & preceding_text(r'^([^"]+|"[^"]*")*$')
+        & following_text(r"[,)}\]]|$"),
+    )
     def _(event):
         event.current_buffer.insert_text('""')
         event.current_buffer.cursor_left()
 
-    @kb.add("'", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))
+    @kb.add(
+        "'",
+        filter=focused_insert
+        & auto_match
+        & preceding_text(r"^([^']+|'[^']*')*$")
+        & following_text(r"[,)}\]]|$"),
+    )
     def _(event):
         event.current_buffer.insert_text("''")
         event.current_buffer.cursor_left()
@@ -185,16 +197,6 @@ def create_ipython_shortcuts(shell):
         dashes = matches.group(2) or ""
         event.current_buffer.insert_text("{}" + dashes)
         event.current_buffer.cursor_left(len(dashes) + 1)
-
-    @kb.add('"', filter=focused_insert & auto_match & preceding_text(r".*(r|R)$"))
-    def _(event):
-        event.current_buffer.insert_text('""')
-        event.current_buffer.cursor_left()
-
-    @kb.add("'", filter=focused_insert & auto_match & preceding_text(r".*(r|R)$"))
-    def _(event):
-        event.current_buffer.insert_text("''")
-        event.current_buffer.cursor_left()
 
     # just move cursor
     @kb.add(")", filter=focused_insert & auto_match & following_text(r"^\)"))


### PR DESCRIPTION
Only insert a pair of quotes if there are an even number of quotes preceding the cursor. This way, if the cursor is inside an unclosed string, typing the closing quote will not insert a pair.

Fixes #13530 even when auto_match is enabled.