### PR TITLE
Improve auto_match for escaped and triple quotes

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -50,9 +50,8 @@ def create_ipython_shortcuts(shell):
 
     try:
         g = parso.load_grammar()
-        parso_loaded = True
     except:
-        parso_loaded = False
+        pass
 
     def reformat_and_execute(event):
         reformat_text_before_cursor(event.current_buffer, event.current_buffer.document, shell)
@@ -134,12 +133,12 @@ def create_ipython_shortcuts(shell):
     def not_inside_unclosed_string():
         app = get_app()
         preceding_text = app.current_buffer.document.current_line_before_cursor
-        if parso_loaded:
+        try:
             parser = g.parse(preceding_text)
             for e in g.iter_errors(parser):
                 if "string literal" in e.message:
                     return False
-        else:
+        except:
             pattern = re.compile(r"""^([^"']+|"[^"]*"|'[^']*')*$""")
             return bool(pattern.match(preceding_text))
         return True

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -127,8 +127,7 @@ def create_ipython_shortcuts(shell):
     @Condition
     def not_inside_unclosed_string():
         app = get_app()
-        ver = f"{sys.version_info.major}.{sys.version_info.minor}"
-        g = parso.load_grammar(version=ver)
+        g = parso.load_grammar()
         parser = g.parse(app.current_buffer.document.current_line_before_cursor)
         for e in g.iter_errors(parser):
             # check for error scanning string literal

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -126,15 +126,14 @@ def create_ipython_shortcuts(shell):
     @Condition
     def not_inside_unclosed_string():
         app = get_app()
-        preceding_text = app.current_buffer.document.current_line_before_cursor
-        without_escaped = preceding_text.replace('\\"', "").replace("\\'", "")
-        triple_string_pattern = re.compile(
-            r"(?:\"\"\"[^\"]?.*?[^\"]?\"\"\"|'''[^']?.*?[^']?'''*)"
-        )
-        without_triple_strings = triple_string_pattern.sub("", without_escaped)
-        single_string_pattern = re.compile(r"""(?:"[^"]*"|'[^']*')""")
-        without_strings = single_string_pattern.sub("", without_triple_strings)
-        return not ('"' in without_strings or "'" in without_strings)
+        s = app.current_buffer.document.text_before_cursor
+        # remove escaped quotes
+        s = s.replace('\\"', "").replace("\\'", "")
+        # remove triple-quoted string literals
+        s = re.sub(r"(?:\"\"\"[\s\S]*\"\"\"|'''[\s\S]*''')", "", s)
+        # remove single-quoted string literals
+        s = re.sub(r"""(?:"[^"]*["\n]|'[^']*['\n])""", "", s)
+        return not ('"' in s or "'" in s)
 
     # auto match
     @kb.add("(", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -127,12 +127,17 @@ def create_ipython_shortcuts(shell):
     @Condition
     def not_inside_unclosed_string():
         app = get_app()
-        g = parso.load_grammar()
-        parser = g.parse(app.current_buffer.document.current_line_before_cursor)
-        for e in g.iter_errors(parser):
-            if e.message == "SyntaxError: EOL while scanning string literal":
-                return False
-        return True
+        preceding_text = app.current_buffer.document.current_line_before_cursor
+        try:
+            g = parso.load_grammar()
+            parser = g.parse(preceding_text)
+            for e in g.iter_errors(parser):
+                if e.message == "SyntaxError: EOL while scanning string literal":
+                    return False
+                return True
+        except:
+            pattern = re.compile(r"""^([^"']+|"[^"]*"|'[^']*')*$""")
+            return bool(pattern.match(preceding_text))
 
     # auto match
     @kb.add("(", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -130,8 +130,7 @@ def create_ipython_shortcuts(shell):
         g = parso.load_grammar()
         parser = g.parse(app.current_buffer.document.current_line_before_cursor)
         for e in g.iter_errors(parser):
-            # check for error scanning string literal
-            if e.code == 901:
+            if e.message == "SyntaxError: EOL while scanning string literal":
                 return False
         return True
 

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -48,6 +48,12 @@ def create_ipython_shortcuts(shell):
                             & insert_mode
                         ))(return_handler)
 
+    try:
+        g = parso.load_grammar()
+        parso_loaded = True
+    except:
+        parso_loaded = False
+
     def reformat_and_execute(event):
         reformat_text_before_cursor(event.current_buffer, event.current_buffer.document, shell)
         event.current_buffer.validate_and_handle()
@@ -128,16 +134,15 @@ def create_ipython_shortcuts(shell):
     def not_inside_unclosed_string():
         app = get_app()
         preceding_text = app.current_buffer.document.current_line_before_cursor
-        try:
-            g = parso.load_grammar()
+        if parso_loaded:
             parser = g.parse(preceding_text)
             for e in g.iter_errors(parser):
                 if e.message == "SyntaxError: EOL while scanning string literal":
                     return False
-                return True
-        except:
+        else:
             pattern = re.compile(r"""^([^"']+|"[^"]*"|'[^']*')*$""")
             return bool(pattern.match(preceding_text))
+        return True
 
     # auto match
     @kb.add("(", filter=focused_insert & auto_match & following_text(r"[,)}\]]|$"))

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -137,7 +137,7 @@ def create_ipython_shortcuts(shell):
         if parso_loaded:
             parser = g.parse(preceding_text)
             for e in g.iter_errors(parser):
-                if e.message == "SyntaxError: EOL while scanning string literal":
+                if "string literal" in e.message:
                     return False
         else:
             pattern = re.compile(r"""^([^"']+|"[^"]*"|'[^']*')*$""")
@@ -181,6 +181,28 @@ def create_ipython_shortcuts(shell):
     def _(event):
         event.current_buffer.insert_text("''")
         event.current_buffer.cursor_left()
+
+    @kb.add(
+        '"',
+        filter=focused_insert
+        & auto_match
+        & not_inside_unclosed_string
+        & preceding_text(r'^.*""$'),
+    )
+    def _(event):
+        event.current_buffer.insert_text('""""')
+        event.current_buffer.cursor_left(3)
+
+    @kb.add(
+        "'",
+        filter=focused_insert
+        & auto_match
+        & not_inside_unclosed_string
+        & preceding_text(r"^.*''$"),
+    )
+    def _(event):
+        event.current_buffer.insert_text("''''")
+        event.current_buffer.cursor_left(3)
 
     # raw string
     @kb.add(

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ install_requires =
     decorator
     jedi>=0.16
     matplotlib-inline
-    parso>=0.5.2
     pexpect>4.3; sys_platform != "win32"
     pickleshare
     prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     decorator
     jedi>=0.16
     matplotlib-inline
+    parso>=0.5.2
     pexpect>4.3; sys_platform != "win32"
     pickleshare
     prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1


### PR DESCRIPTION
Use parso instead of a regular expression to check if the cursor is inside an unclosed string.