### PR TITLE
Restore lineno's for Input mapped files

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -15,7 +15,6 @@ import abc
 import ast
 import atexit
 import builtins as builtin_mod
-import dis
 import functools
 import inspect
 import os
@@ -3183,29 +3182,6 @@ class InteractiveShell(SingletonConfigurable):
             ast.fix_missing_locations(node)
         return node
 
-    def _update_code_co_name(self, code):
-        """Python 3.10 changed the behaviour so that whenever a code object
-        is assembled in the compile(ast) the co_firstlineno would be == 1.
-
-        This makes pydevd/debugpy think that all cells invoked are the same
-        since it caches information based on (co_firstlineno, co_name, co_filename).
-
-        Given that, this function changes the code 'co_name' to be unique
-        based on the first real lineno of the code (which also has a nice
-        side effect of customizing the name so that it's not always <module>).
-
-        See: https://github.com/ipython/ipykernel/issues/841
-        """
-        if not hasattr(code, "replace"):
-            # It may not be available on older versions of Python (only
-            # available for 3.8 onwards).
-            return code
-        try:
-            first_real_line = next(dis.findlinestarts(code))[1]
-        except StopIteration:
-            return code
-        return code.replace(co_name="<cell line: %s>" % (first_real_line,))
-
     async def run_ast_nodes(
         self,
         nodelist: ListType[stmt],
@@ -3304,7 +3280,6 @@ class InteractiveShell(SingletonConfigurable):
                     else 0x0
                 ):
                     code = compiler(mod, cell_name, mode)
-                    code = self._update_code_co_name(code)
                     asy = compare(code)
                 if await self.run_code(code, result, async_=asy):
                     return True

--- a/IPython/core/tests/test_iplib.py
+++ b/IPython/core/tests/test_iplib.py
@@ -45,7 +45,7 @@ def doctest_tb_plain():
 
     In [19]: run simpleerr.py
     Traceback (most recent call last):
-      File ...:... in <module>
+      File ...:...
         bar(mode)
       File ...:... in bar
         div0()
@@ -64,7 +64,7 @@ def doctest_tb_context():
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     <BLANKLINE>
-    ... in <module>
+    ...
          30     except IndexError:
          31         mode = 'div'
     ---> 33     bar(mode)
@@ -93,7 +93,7 @@ def doctest_tb_verbose():
     ---------------------------------------------------------------------------
     ZeroDivisionError                         Traceback (most recent call last)
     <BLANKLINE>
-    ... in <module>
+    ...
          30     except IndexError:
          31         mode = 'div'
     ---> 33     bar(mode)
@@ -134,7 +134,7 @@ def doctest_tb_sysexit():
     Traceback (most recent call last):
       File ...:... in execfile
         exec(compiler(f.read(), fname, "exec"), glob, loc)
-      File ...:... in <module>
+      File ...:...
         bar(mode)
       File ...:... in bar
         sysexit(stat, mode)
@@ -152,7 +152,7 @@ def doctest_tb_sysexit():
          ... with open(fname, "rb") as f:
          ...     compiler = compiler or compile
     ---> ...     exec(compiler(f.read(), fname, "exec"), glob, loc)
-    ...<module>
+    ...
          30     except IndexError:
          31         mode = 'div'
     ---> 33     bar(mode)
@@ -189,7 +189,7 @@ def doctest_tb_sysexit_verbose():
     ---------------------------------------------------------------------------
     SystemExit                                Traceback (most recent call last)
     <BLANKLINE>
-    ... in <module>
+    ...
          30     except IndexError:
          31         mode = 'div'
     ---> 33     bar(mode)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -465,33 +465,41 @@ class ListTB(TBTools):
 
         Lifted almost verbatim from traceback.py
         """
-
         Colors = self.Colors
         list = []
         for filename, lineno, name, line in extracted_list[:-1]:
-            item = "  %s in %s%s%s\n" % (
+            item = "  %s" % (
                 _format_filename(
                     filename, Colors.filename, Colors.Normal, lineno=lineno
-                ),
-                Colors.name,
-                name,
-                Colors.Normal,
+                )
             )
+
+            if name != "<module>":
+                item += " in %s%s%s\n" % (
+                    Colors.name,
+                    name,
+                    Colors.Normal,
+                )
+            else:
+                item += "\n"
             if line:
                 item += '    %s\n' % line.strip()
             list.append(item)
         # Emphasize the last entry
         filename, lineno, name, line = extracted_list[-1]
-        item = "%s  %s in %s%s%s%s\n" % (
+        item = "%s  %s" % (
             Colors.normalEm,
             _format_filename(
                 filename, Colors.filenameEm, Colors.normalEm, lineno=lineno
-            ),
-            Colors.nameEm,
-            name,
-            Colors.normalEm,
-            Colors.Normal,
+            )
         )
+        if name != "<module>":
+            item += " in %s%s%s" % (
+                    Colors.nameEm,
+                    name,
+                    Colors.normalEm,
+                )
+        item += "%s\n" % (Colors.Normal)
         if line:
             item += '%s    %s%s\n' % (Colors.line, line.strip(),
                                       Colors.Normal)
@@ -692,7 +700,7 @@ class VerboseTB(TBTools):
 
         func = frame_info.executing.code_qualname()
         if func == "<module>":
-            call = tpl_call.format(file=func, scope="")
+            call = ""
         else:
             # Decide whether to include variable details or not
             var_repr = eqrepr if self.include_vars else nullrepr
@@ -736,7 +744,7 @@ class VerboseTB(TBTools):
         if lvals_list:
             lvals = '%s%s' % (indent, em_normal.join(lvals_list))
 
-        result = "%s, %s\n" % (link, call)
+        result = "%s%s%s\n" % (link, ", " if call else "", call)
 
         result += ''.join(_format_traceback_lines(frame_info.lines, Colors, self.has_colors, lvals))
         return result

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -190,9 +190,7 @@ def _format_filename(file, ColorFilename, ColorNormal, *, lineno=None):
         if lineno is None:
             tpl_link = f"Cell {ColorFilename}In {{file}}{ColorNormal}"
         else:
-            tpl_link = (
-                f"Cell {ColorFilename}In {{file}}, line {{lineno}}{ColorNormal}"
-            )
+            tpl_link = f"Cell {ColorFilename}In {{file}}, line {{lineno}}{ColorNormal}"
     else:
         file = util_path.compress_user(
             py3compat.cast_unicode(file, util_path.fs_encoding)
@@ -465,7 +463,7 @@ class ListTB(TBTools):
 
         Lifted almost verbatim from traceback.py
         """
-        
+
         Colors = self.Colors
         list = []
         for filename, lineno, name, line in extracted_list[:-1]:
@@ -492,14 +490,14 @@ class ListTB(TBTools):
             Colors.normalEm,
             _format_filename(
                 filename, Colors.filenameEm, Colors.normalEm, lineno=lineno
-            )
+            ),
         )
         if name != "<module>":
             item += " in %s%s%s" % (
-                    Colors.nameEm,
-                    name,
-                    Colors.normalEm,
-                )
+                Colors.nameEm,
+                name,
+                Colors.normalEm,
+            )
         item += "%s\n" % (Colors.Normal)
         if line:
             item += '%s    %s%s\n' % (Colors.line, line.strip(),

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -468,6 +468,7 @@ class ListTB(TBTools):
         list = []
         for ind, (filename, lineno, name, line) in enumerate(extracted_list):
             normalCol, nameCol, fileCol, lineCol = (
+                # Emphasize the last entry
                 (Colors.normalEm, Colors.nameEm, Colors.filenameEm, Colors.line)
                 if ind == len(extracted_list) - 1 else
                 (Colors.Normal, Colors.name, Colors.filename, "")

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -465,6 +465,7 @@ class ListTB(TBTools):
 
         Lifted almost verbatim from traceback.py
         """
+        
         Colors = self.Colors
         list = []
         for filename, lineno, name, line in extracted_list[:-1]:

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -187,7 +187,10 @@ def _format_filename(file, ColorFilename, ColorNormal, *, lineno=None):
 
     if ipinst is not None and file in ipinst.compile._filename_map:
         file = "[%s]" % ipinst.compile._filename_map[file]
-        tpl_link = f"Input {ColorFilename}In {{file}}{ColorNormal}"
+        if lineno is None:
+            tpl_link = f"Input {ColorFilename}In {{file}}{ColorNormal}"
+        else:
+            tpl_link = f"Input {ColorFilename}In {{file}}:{{lineno}}{ColorNormal}"
     else:
         file = util_path.compress_user(
             py3compat.cast_unicode(file, util_path.fs_encoding)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -188,9 +188,11 @@ def _format_filename(file, ColorFilename, ColorNormal, *, lineno=None):
     if ipinst is not None and file in ipinst.compile._filename_map:
         file = "[%s]" % ipinst.compile._filename_map[file]
         if lineno is None:
-            tpl_link = f"Input {ColorFilename}In {{file}}{ColorNormal}"
+            tpl_link = f"Input cell {ColorFilename}In {{file}}{ColorNormal}"
         else:
-            tpl_link = f"Input {ColorFilename}In {{file}}:{{lineno}}{ColorNormal}"
+            tpl_link = (
+                f"Input cell {ColorFilename}In {{file}}, line {{lineno}}{ColorNormal}"
+            )
     else:
         file = util_path.compress_user(
             py3compat.cast_unicode(file, util_path.fs_encoding)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -466,35 +466,24 @@ class ListTB(TBTools):
 
         Colors = self.Colors
         list = []
-        for filename, lineno, name, line in extracted_list[:-1]:
-            item = "  %s" % (
-                _format_filename(
-                    filename, Colors.filename, Colors.Normal, lineno=lineno
-                )
+        for ind, (filename, lineno, name, line) in enumerate(extracted_list):
+            normalCol, nameCol, fileCol, lineCol = (
+                (Colors.normalEm, Colors.nameEm, Colors.filenameEm, Colors.line)
+                if ind == len(extracted_list) - 1 else
+                (Colors.Normal, Colors.name, Colors.filename, "")
             )
 
+            fns = _format_filename(filename, fileCol, normalCol, lineno=lineno)
+            item =f"{normalCol}  {fns}"
+
             if name != "<module>":
-                item += f" in {Colors.name}{name}{Colors.Normal}\n"
+                item += f" in {nameCol}{name}{normalCol}\n"
             else:
                 item += "\n"
             if line:
-                item += '    %s\n' % line.strip()
+                item += f"{lineCol}    {line.strip()}{normalCol}\n"
             list.append(item)
-        # Emphasize the last entry
-        filename, lineno, name, line = extracted_list[-1]
-        item = "%s  %s" % (
-            Colors.normalEm,
-            _format_filename(
-                filename, Colors.filenameEm, Colors.normalEm, lineno=lineno
-            ),
-        )
-        if name != "<module>":
-            item += f" in {Colors.nameEm}{name}{Colors.normalEm}"
-        item += "%s\n" % (Colors.Normal)
-        if line:
-            item += '%s    %s%s\n' % (Colors.line, line.strip(),
-                                      Colors.Normal)
-        list.append(item)
+
         return list
 
     def _format_exception_only(self, etype, value):
@@ -735,7 +724,7 @@ class VerboseTB(TBTools):
         if lvals_list:
             lvals = '%s%s' % (indent, em_normal.join(lvals_list))
 
-        result = "%s%s%s\n" % (link, ", " if call else "", call)
+        result = f'{link}{", " if call else ""}{call}\n'
 
         result += ''.join(_format_traceback_lines(frame_info.lines, Colors, self.has_colors, lvals))
         return result

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -188,10 +188,10 @@ def _format_filename(file, ColorFilename, ColorNormal, *, lineno=None):
     if ipinst is not None and file in ipinst.compile._filename_map:
         file = "[%s]" % ipinst.compile._filename_map[file]
         if lineno is None:
-            tpl_link = f"Input cell {ColorFilename}In {{file}}{ColorNormal}"
+            tpl_link = f"Cell {ColorFilename}In {{file}}{ColorNormal}"
         else:
             tpl_link = (
-                f"Input cell {ColorFilename}In {{file}}, line {{lineno}}{ColorNormal}"
+                f"Cell {ColorFilename}In {{file}}, line {{lineno}}{ColorNormal}"
             )
     else:
         file = util_path.compress_user(

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -470,12 +470,12 @@ class ListTB(TBTools):
             normalCol, nameCol, fileCol, lineCol = (
                 # Emphasize the last entry
                 (Colors.normalEm, Colors.nameEm, Colors.filenameEm, Colors.line)
-                if ind == len(extracted_list) - 1 else
-                (Colors.Normal, Colors.name, Colors.filename, "")
+                if ind == len(extracted_list) - 1
+                else (Colors.Normal, Colors.name, Colors.filename, "")
             )
 
             fns = _format_filename(filename, fileCol, normalCol, lineno=lineno)
-            item =f"{normalCol}  {fns}"
+            item = f"{normalCol}  {fns}"
 
             if name != "<module>":
                 item += f" in {nameCol}{name}{normalCol}\n"

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -474,11 +474,7 @@ class ListTB(TBTools):
             )
 
             if name != "<module>":
-                item += " in %s%s%s\n" % (
-                    Colors.name,
-                    name,
-                    Colors.Normal,
-                )
+                item += f" in {Colors.name}{name}{Colors.Normal}\n"
             else:
                 item += "\n"
             if line:
@@ -493,11 +489,7 @@ class ListTB(TBTools):
             ),
         )
         if name != "<module>":
-            item += " in %s%s%s" % (
-                Colors.nameEm,
-                name,
-                Colors.normalEm,
-            )
+            item += f" in {Colors.nameEm}{name}{Colors.normalEm}"
         item += "%s\n" % (Colors.Normal)
         if line:
             item += '%s    %s%s\n' % (Colors.line, line.strip(),

--- a/docs/source/whatsnew/pr/restore-line-numbers.rst
+++ b/docs/source/whatsnew/pr/restore-line-numbers.rst
@@ -1,5 +1,5 @@
 Restore line numbers for Input
-===================
+==================================
 
 Line number information in tracebacks from input are restored.
 Line numbers from input were removed during the transition to v8 enhanced traceback reporting.

--- a/docs/source/whatsnew/pr/restore-line-numbers.rst
+++ b/docs/source/whatsnew/pr/restore-line-numbers.rst
@@ -1,0 +1,5 @@
+Restore line numbers for Input
+===================
+
+Line number information in tracebacks from input are restored.
+Line numbers from input were removed during the transition to v8 enhanced traceback reporting.

--- a/docs/source/whatsnew/pr/restore-line-numbers.rst
+++ b/docs/source/whatsnew/pr/restore-line-numbers.rst
@@ -4,47 +4,47 @@ Restore line numbers for Input
 Line number information in tracebacks from input are restored.
 Line numbers from input were removed during the transition to v8 enhanced traceback reporting.
 
-So, instead of:
+So, instead of::
 
-  ---------------------------------------------------------------------------
-  ZeroDivisionError                         Traceback (most recent call last)
-  Input In [3], in <cell line: 1>()
-  ----> 1 myfunc(2)
+    ---------------------------------------------------------------------------
+    ZeroDivisionError                         Traceback (most recent call last)
+    Input In [3], in <cell line: 1>()
+    ----> 1 myfunc(2)
 
-  Input In [2], in myfunc(z)
-        1 def myfunc(z):
-  ----> 2     foo.boo(z-1)
+    Input In [2], in myfunc(z)
+          1 def myfunc(z):
+    ----> 2     foo.boo(z-1)
 
-  File ~/code/python/ipython/foo.py:3, in boo(x)
-        2 def boo(x):
-  ----> 3     return 1/(1-x)
+    File ~/code/python/ipython/foo.py:3, in boo(x)
+          2 def boo(x):
+    ----> 3     return 1/(1-x)
 
-  ZeroDivisionError: division by zero
+    ZeroDivisionError: division by zero
 
-The error traceback now looks like:
+The error traceback now looks like::
 
-  ---------------------------------------------------------------------------
-  ZeroDivisionError                         Traceback (most recent call last)
-  Cell In [3], line 1
-  ----> 1 myfunc(2)
+      ---------------------------------------------------------------------------
+      ZeroDivisionError                         Traceback (most recent call last)
+      Cell In [3], line 1
+      ----> 1 myfunc(2)
 
-  Cell In [2], line 2, in myfunc(z)
-        1 def myfunc(z):
-  ----> 2     foo.boo(z-1)
+      Cell In [2], line 2, in myfunc(z)
+            1 def myfunc(z):
+      ----> 2     foo.boo(z-1)
 
-  File ~/code/python/ipython/foo.py:3, in boo(x)
-        2 def boo(x):
-  ----> 3     return 1/(1-x)
+      File ~/code/python/ipython/foo.py:3, in boo(x)
+            2 def boo(x):
+      ----> 3     return 1/(1-x)
 
-  ZeroDivisionError: division by zero
+      ZeroDivisionError: division by zero
 
-or, with xmode=Plain:
+or, with xmode=Plain::
 
-  Traceback (most recent call last):
-    Cell In [12], line 1
-      myfunc(2)
-    Cell In [6], line 2 in myfunc
-      foo.boo(z-1)
-    File ~/code/python/ipython/foo.py:3 in boo
-      return 1/(1-x)
-  ZeroDivisionError: division by zero
+    Traceback (most recent call last):
+      Cell In [12], line 1
+        myfunc(2)
+      Cell In [6], line 2 in myfunc
+        foo.boo(z-1)
+      File ~/code/python/ipython/foo.py:3 in boo
+        return 1/(1-x)
+    ZeroDivisionError: division by zero

--- a/docs/source/whatsnew/pr/restore-line-numbers.rst
+++ b/docs/source/whatsnew/pr/restore-line-numbers.rst
@@ -3,3 +3,48 @@ Restore line numbers for Input
 
 Line number information in tracebacks from input are restored.
 Line numbers from input were removed during the transition to v8 enhanced traceback reporting.
+
+So, instead of:
+
+  ---------------------------------------------------------------------------
+  ZeroDivisionError                         Traceback (most recent call last)
+  Input In [3], in <cell line: 1>()
+  ----> 1 myfunc(2)
+
+  Input In [2], in myfunc(z)
+        1 def myfunc(z):
+  ----> 2     foo.boo(z-1)
+
+  File ~/code/python/ipython/foo.py:3, in boo(x)
+        2 def boo(x):
+  ----> 3     return 1/(1-x)
+
+  ZeroDivisionError: division by zero
+
+The error traceback now looks like:
+
+  ---------------------------------------------------------------------------
+  ZeroDivisionError                         Traceback (most recent call last)
+  Cell In [3], line 1
+  ----> 1 myfunc(2)
+
+  Cell In [2], line 2, in myfunc(z)
+        1 def myfunc(z):
+  ----> 2     foo.boo(z-1)
+
+  File ~/code/python/ipython/foo.py:3, in boo(x)
+        2 def boo(x):
+  ----> 3     return 1/(1-x)
+
+  ZeroDivisionError: division by zero
+
+or, with xmode=Plain:
+
+  Traceback (most recent call last):
+    Cell In [12], line 1
+      myfunc(2)
+    Cell In [6], line 2 in myfunc
+      foo.boo(z-1)
+    File ~/code/python/ipython/foo.py:3 in boo
+      return 1/(1-x)
+  ZeroDivisionError: division by zero


### PR DESCRIPTION
This restores line number information in tracebacks from input, which got removed during the transition to v8 enhanced traceback reporting.