### PR TITLE
[WIP] Use prompt_toolkit's built-in cursorshape support.

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -21,7 +21,7 @@ from prompt_toolkit.filters import (has_focus, has_selection, Condition,
 from prompt_toolkit.key_binding.bindings.completion import display_completions_like_readline
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.bindings import named_commands as nc
-from prompt_toolkit.key_binding.vi_state import InputMode, ViState
+from prompt_toolkit.key_binding.vi_state import InputMode
 
 from IPython.utils.decorators import undoc
 
@@ -334,26 +334,6 @@ def create_ipython_shortcuts(shell):
 
     for keys, cmd in keys_cmd_dict.items():
         kb.add(*keys, filter=focused_insert_vi & ebivim)(cmd)
-
-    def get_input_mode(self):
-        app = get_app()
-        app.ttimeoutlen = shell.ttimeoutlen
-        app.timeoutlen = shell.timeoutlen
-
-        return self._input_mode
-
-    def set_input_mode(self, mode):
-        shape = {InputMode.NAVIGATION: 2, InputMode.REPLACE: 4}.get(mode, 6)
-        cursor = "\x1b[{} q".format(shape)
-
-        sys.stdout.write(cursor)
-        sys.stdout.flush()
-
-        self._input_mode = mode
-
-    if shell.editing_mode == "vi" and shell.modal_cursor:
-        ViState._input_mode = InputMode.INSERT
-        ViState.input_mode = property(get_input_mode, set_input_mode)
 
     return kb
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,8 @@ install_requires =
     matplotlib-inline
     pexpect>4.3; sys_platform != "win32"
     pickleshare
-    prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1
+    # Cursor shape support is introduced in 3.0.27.
+    prompt_toolkit>=3.0.27,<3.1.0
     pygments>=2.4.0
     setuptools>=18.5
     stack_data


### PR DESCRIPTION
prompt_toolkit now has built-in support for cursor shapes. This should take advantage of this feature.
This should also fix some cursorshape related issues, like resetting the cursor shape when IPython suspends.

The PR currently doesn't merge yet. I'll try to rebase and retest later this week.

Note that this requires at least prompt_toolkit 3.0.27, which is set as a minimal required version. Because of that requirement, and this issue that was recently filed: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1576 , I plan into looking into that as well and fix both together. (If we set 3.0.27 as minimal required version, that other issue has to be fixed.)

Related issue: https://github.com/ipython/ipython/issues/13472