### PR TITLE
support for pattern based autoreloading

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -238,22 +238,23 @@ class ModuleReloader:
         return py_filename, pymtime
 
     def _our_modules_to_check(self):
+        if not self.modules:
+            return set()
+
         combined = re.compile("|".join(fnmatch.translate(pat) for pat in self.modules))
 
-        skipped = re.compile(
-            "|".join(fnmatch.translate(pat) for pat in self.skip_modules)
-        )
+        result = filter(combined.match, sys.modules.keys())
 
-        result = filter(
-            lambda mod: not skipped.match(mod),
-            filter(combined.match, sys.modules.keys()),
-        )
+        if self.skip_modules:
+            skipped = re.compile(
+                "|".join(fnmatch.translate(pat) for pat in self.skip_modules)
+            )
+            result = filter(lambda mod: not skipped.match(mod), result)
 
         return set(result)
 
     def check(self, check_all=False, do_reload=True):
         """Check whether some modules need to be reloaded."""
-
         if not self.enabled and not check_all:
             return
 

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -158,6 +158,25 @@ class ModuleReloader:
         # Cache module modification times
         self.check(check_all=True, do_reload=False)
 
+    def print_state(self, *, file=None):
+        to_reload = sorted(self.modules.keys())
+        to_skip = sorted(self.skip_modules.keys())
+
+        print("Modules to reload:", file=file)
+        if self.check_all:
+            print("all-except-skipped", file=file)
+        else:
+            print(" ".join(to_reload), file=file)
+
+        print("\nPatterns to reload:", file=file)
+        for pattern, pat in self.module_pats.items():
+            matches = " ".join(
+                filter(pat.match, sys.modules.keys()))
+            print(f"  {repr(pattern)} matches ({matches})", file=file)
+
+        print("\nModules to skip:", file=file)
+        print(" ".join(to_skip), file=file)
+
     def mark_module_skipped(self, module_name):
         """Skip reloading the named module in the future"""
         try:
@@ -602,15 +621,7 @@ class AutoreloadMagics(Magics):
         """
         modname = parameter_s
         if not modname:
-            to_reload = sorted(self._reloader.modules.keys())
-            to_skip = sorted(self._reloader.skip_modules.keys())
-            if stream is None:
-                stream = sys.stdout
-            if self._reloader.check_all:
-                stream.write("Modules to reload:\nall-except-skipped\n")
-            else:
-                stream.write("Modules to reload:\n%s\n" % " ".join(to_reload))
-            stream.write("\nModules to skip:\n%s\n" % " ".join(to_skip))
+            self._reloader.print_state(file=stream)
         elif modname.startswith("-"):
             modname = modname[1:]
             self._reloader.mark_module_skipped(modname)

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -65,6 +65,10 @@ The following magic commands are provided:
 
     Import modules 'foo', 'bar' and mark them to be autoreloaded for ``%autoreload 1``
 
+``%aimport +foo.*``
+
+    Mark all modules under 'foo' to be autoreloaded.
+
 ``%aimport -foo``
 
     Mark module 'foo' to not be autoreloaded.
@@ -209,16 +213,15 @@ class ModuleReloader:
         return top_module, top_name
 
     def filename_and_mtime(self, module):
-        if not hasattr(module, "__file__") or module.__file__ is None:
+        filename = getattr(module, "__file__", None)
+        if filename is None:
             return None, None
 
         if getattr(module, "__name__", None) in [None, "__mp_main__", "__main__"]:
             # we cannot reload(__main__) or reload(__mp_main__)
             return None, None
 
-        filename = module.__file__
         path, ext = os.path.splitext(filename)
-
         if ext.lower() == ".py":
             py_filename = filename
         else:
@@ -580,6 +583,7 @@ class AutoreloadMagics(Magics):
           autoreloaded.
 
         """
+        parameter_s = parameter_s.strip()
         if parameter_s == "":
             self._reloader.check(True)
         elif parameter_s == "0":
@@ -609,10 +613,13 @@ class AutoreloadMagics(Magics):
         %aimport foo, bar
         Import modules 'foo', 'bar' and mark them to be autoreloaded for %autoreload 1
 
+        %aimport +foo
+        Mark module or pattern 'foo' to be autoreloaded for %autoreload 1
+
         %aimport -foo
-        Mark module 'foo' to not be autoreloaded for %autoreload 1
+        Mark module or pattern 'foo' to not be autoreloaded for %autoreload 1
         """
-        modname = parameter_s
+        modname = parameter_s.strip()
         if not modname:
             self._reloader.print_state(file=stream)
         elif modname.startswith("+"):

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -530,7 +530,7 @@ class TestAutoreload(Fixture):
             self.shell.magic_aimport("-" + mod_name)
             stream = StringIO()
             self.shell.magic_aimport("", stream=stream)
-            self.assertTrue(("Modules to skip:\n%s" % mod_name) in stream.getvalue())
+            self.assertTrue(f"Modules to skip:\n  {mod_name}" in stream.getvalue())
 
             # This should succeed, although no such module exists
             self.shell.magic_aimport("-tmpmod_as318989e89ds")

--- a/docs/source/whatsnew/autoreload-patterns.rst
+++ b/docs/source/whatsnew/autoreload-patterns.rst
@@ -1,0 +1,5 @@
+Autoreload extension support patterns
+=====
+
+The autoreload IPython extension has been extended to support pattern
+matching, for example ``%aimport +mymod.*``, see :ghpull:`13575`.

--- a/docs/source/whatsnew/autoreload-patterns.rst
+++ b/docs/source/whatsnew/autoreload-patterns.rst
@@ -1,5 +1,5 @@
 Autoreload extension support patterns
-=====
+=====================================
 
 The autoreload IPython extension has been extended to support pattern
 matching, for example ``%aimport +mymod.*``, see :ghpull:`13575`.


### PR DESCRIPTION
a minimal implementation of glob based autoreloading, as proposed in #13573

usage is something like:

```python
%autoreload 1
%autoreload foo.*

import foo.bar
```

and then modifications to `foo/bar.py` will autoreload.  not sure about overloading `autoreload` here, but it was easy to put in and should be easy to change to something else.  it also needs the mode to be set to `1` for this to work, but could be done automatically if people think it's a good idea

would be good to add a test, I've been using the attached script [test.txt](https://github.com/ipython/ipython/files/8193588/test.txt), for interactive tests
