### PR TITLE
Get history from sql.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3042,9 +3042,8 @@ class InteractiveShell(SingletonConfigurable):
                 cell = raw_cell
 
         # Store raw and processed history
-        if store_history:
-            self.history_manager.store_inputs(self.execution_count,
-                                              cell, raw_cell)
+        if store_history and raw_cell.strip(" %") != "paste":
+            self.history_manager.store_inputs(self.execution_count, cell, raw_cell)
         if not silent:
             self.logger.log(cell, raw_cell)
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -3,12 +3,10 @@
 import asyncio
 import os
 import sys
-import warnings
 from warnings import warn
 
 from IPython.core.async_helpers import get_asyncio_loop
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
-from IPython.utils import io
 from IPython.utils.py3compat import input
 from IPython.utils.terminal import toggle_set_term_title, set_term_title, restore_term_title
 from IPython.utils.process import abbrev_cwd
@@ -32,7 +30,7 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 from prompt_toolkit.filters import (HasFocus, Condition, IsDone)
 from prompt_toolkit.formatted_text import PygmentsTokens
-from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.history import History
 from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatchingBracketProcessor
 from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.patch_stdout import patch_stdout
@@ -131,6 +129,43 @@ def yapf_reformat_handler(text_before_cursor):
     else:
         return text_before_cursor
 
+
+class PtkHistoryAdapter(History):
+    """
+    Prompt toolkit has it's own way of handling history, Where it assumes it can
+    Push/pull from history.
+
+    """
+
+    def __init__(self, shell):
+        super().__init__()
+        self.shell = shell
+        self._refresh()
+
+    def append_string(self, string):
+        # we rely on sql for that.
+        self._loaded = False
+        self._refresh()
+
+    def _refresh(self):
+        if not self._loaded:
+            self._loaded_strings = list(self.load_history_strings())
+
+    def load_history_strings(self):
+        last_cell = ""
+        res = []
+        for __, ___, cell in self.shell.history_manager.get_tail(
+            self.shell.history_load_length, include_latest=True
+        ):
+            # Ignore blank lines and consecutive duplicates
+            cell = cell.rstrip()
+            if cell and (cell != last_cell):
+                res.append(cell)
+                last_cell = cell
+        yield from res[::-1]
+
+    def store_string(self, string: str) -> None:
+        pass
 
 class TerminalInteractiveShell(InteractiveShell):
     mime_renderers = Dict().tag(config=True)
@@ -397,16 +432,9 @@ class TerminalInteractiveShell(InteractiveShell):
         # Set up keyboard shortcuts
         key_bindings = create_ipython_shortcuts(self)
 
+
         # Pre-populate history from IPython's history database
-        history = InMemoryHistory()
-        last_cell = u""
-        for __, ___, cell in self.history_manager.get_tail(self.history_load_length,
-                                                        include_latest=True):
-            # Ignore blank lines and consecutive duplicates
-            cell = cell.rstrip()
-            if cell and (cell != last_cell):
-                history.append_string(cell)
-                last_cell = cell
+        history = PtkHistoryAdapter(self)
 
         self._style = self._make_style_from_name_or_cls(self.highlighting_style)
         self.style = DynamicStyle(lambda: self._style)
@@ -586,7 +614,6 @@ class TerminalInteractiveShell(InteractiveShell):
     def enable_win_unicode_console(self):
         # Since IPython 7.10 doesn't support python < 3.6 and PEP 528, Python uses the unicode APIs for the Windows
         # console by default, so WUC shouldn't be needed.
-        from warnings import warn
         warn("`enable_win_unicode_console` is deprecated since IPython 7.10, does not do anything and will be removed in the future",
              DeprecationWarning,
              stacklevel=2)

--- a/IPython/terminal/magics.py
+++ b/IPython/terminal/magics.py
@@ -53,7 +53,7 @@ class TerminalMagics(Magics):
             self.shell.user_ns['pasted_block'] = b
             self.shell.using_paste_magics = True
             try:
-                self.shell.run_cell(b)
+                self.shell.run_cell(b, store_history=True)
             finally:
                 self.shell.using_paste_magics = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,13 +67,12 @@ test =
     pytest-asyncio
     testpath
 test_extra =
+    %(test)s
     curio
     matplotlib!=3.2.0
     nbformat
     numpy>=1.19
     pandas
-    pytest
-    testpath
     trio
 all =
     %(black)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ qtconsole =
     qtconsole
 terminal =
 test =
-    pytest
+    pytest<7.1
     pytest-asyncio
     testpath
 test_extra =


### PR DESCRIPTION
Fixes #13585

By getting history from sql we can get the transformed history.
This also skip storing history if `%paste` is used and `%paste` itself
will insert the pasted value in history which is more conveninent.