### PR TITLE
Mock urlopen when starting doctests

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -15,6 +15,7 @@ import warnings
 from copy import deepcopy
 from os.path import splitext
 from pathlib import Path, PurePath
+from urllib.request import urlopen
 
 from IPython.utils.py3compat import cast_unicode
 from IPython.testing.skipdoctest import skip_doctest
@@ -353,8 +354,6 @@ class DisplayObject(object):
             with open(self.filename, self._read_flags, encoding=encoding) as f:
                 self.data = f.read()
         elif self.url is not None:
-            # Deferred import
-            from urllib.request import urlopen
             response = urlopen(self.url)
             data = response.read()
             # extract encoding from header, if there is one:
@@ -884,7 +883,7 @@ class Image(DisplayObject):
         a URL, or a filename from which to load image data.
         The result is always embedding image data for inline images.
 
-        >>> Image('https://www.google.fr/images/srpr/logo3w.png') # doctest: +SKIP
+        >>> Image('https://www.google.fr/images/srpr/logo3w.png')
         <IPython.core.display.Image object>
 
         >>> Image('/path/to/image.jpg')

--- a/IPython/testing/ipunittest.py
+++ b/IPython/testing/ipunittest.py
@@ -37,6 +37,7 @@ Authors
 # Stdlib
 import re
 import unittest
+from unittest.mock import patch
 from doctest import DocTestFinder, DocTestRunner, TestResults
 from IPython.terminal.interactiveshell import InteractiveShell
 
@@ -144,6 +145,12 @@ class Doc2UnitTester(object):
         # Now, create a tester object that is a real unittest instance, so
         # normal unittest machinery (or Nose, or Trial) can find it.
         class Tester(unittest.TestCase):
+            def setUp(self):
+                # Mock urllib.urlopen so that Image tests don't access network.
+                patcher = patch("IPython.core.display.urlopen")
+                patcher.start()
+                self.addCleanup(patcher.stop)
+
             def test(self):
                 # Make a new runner per function to be tested
                 runner = DocTestRunner(verbose=d2u.verbose)

--- a/IPython/testing/ipunittest.py
+++ b/IPython/testing/ipunittest.py
@@ -143,7 +143,7 @@ class Doc2UnitTester(object):
             func.__doc__ = ip2py(func.__doc__)
 
         # Now, create a tester object that is a real unittest instance, so
-        # normal unittest machinery (or Nose, or Trial) can find it.
+        # normal unittest machinery can find it.
         class Tester(unittest.TestCase):
             def setUp(self):
                 # Mock urllib.urlopen so that Image tests don't access network.


### PR DESCRIPTION
Speculative fix for #13468 (speculative - because I haven't checked whether it does what it does ;)).

Closes #13468.