### PR TITLE
Fix ctrl-\ behavior

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -10,6 +10,7 @@ import warnings
 import signal
 import sys
 import re
+import os
 from typing import Callable
 
 
@@ -56,7 +57,7 @@ def create_ipython_shortcuts(shell):
                             & insert_mode
                                       ))(reformat_and_execute)
 
-    kb.add('c-\\')(force_exit)
+    kb.add("c-\\")(quit)
 
     kb.add('c-p', filter=(vi_insert_mode & has_focus(DEFAULT_BUFFER))
                 )(previous_history_or_previous_completion)
@@ -458,11 +459,16 @@ def reset_search_buffer(event):
 def suspend_to_bg(event):
     event.app.suspend_to_background()
 
-def force_exit(event):
+def quit(event):
     """
-    Force exit (with a non-zero return value)
+    On platforms that support SIGQUIT, send SIGQUIT to the current process.
+    On other platforms, just exit the process with a message.
     """
-    sys.exit("Quit")
+    sigquit = getattr(signal, "SIGQUIT", None)
+    if sigquit is not None:
+        os.kill(0, signal.SIGQUIT)
+    else:
+        sys.exit("Quit")
 
 def indent_buffer(event):
     event.current_buffer.insert_text(' ' * 4)


### PR DESCRIPTION
This pull request fixes two issues with ctrl-\ when using IPython on linux:
- Currently, pressing ctrl-\ will make IPython exit without resetting the terminal configuration. The terminal is rendered unusable unless you do something like typing `stty sane` and hoping for the best
- IPython users cannot override the behavior of ctrl-\ using `signal.signal(signal.SIGQUIT, ...)` as they would in other terminal apps. This change simulates better the usual behavior of ctrl-\ in linux terminal apps.

Closes #12461