### PR TITLE
Don't strip decorators before feeding into block_parser

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -821,8 +821,11 @@ class EmbeddedSphinxShell(object):
                 output.append(line)
                 continue
 
-            # handle decorators
-            if line_stripped.startswith('@'):
+            # handle pseudo-decorators, whilst ensuring real python decorators are treated as input
+            if any(
+                line_stripped.startswith("@" + pseudo_decorator)
+                for pseudo_decorator in PSEUDO_DECORATORS
+            ):
                 output.extend([line])
                 if 'savefig' in line:
                     savefig = True # and need to clear figure

--- a/docs/source/whatsnew/pr/stripping-decorators-bug.rst
+++ b/docs/source/whatsnew/pr/stripping-decorators-bug.rst
@@ -1,0 +1,4 @@
+Stripping decorators bug
+========================
+
+Fixed bug which meant that ipython code blocks in restructured text documents executed with the ipython-sphinx extension skipped any lines of code containing python decorators.


### PR DESCRIPTION
This should actually fix #13531 @Carreau (in conjunction with #13532).