### PR TITLE
Make terminal title better behaved

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -405,14 +405,14 @@ class TerminalInteractiveShell(InteractiveShell):
     @observe('term_title')
     def init_term_title(self, change=None):
         # Enable or disable the terminal title.
-        if self.term_title:
+        if self.term_title and _is_tty:
             toggle_set_term_title(True)
             set_term_title(self.term_title_format.format(cwd=abbrev_cwd()))
         else:
             toggle_set_term_title(False)
 
     def restore_term_title(self):
-        if self.term_title:
+        if self.term_title and _is_tty:
             restore_term_title()
 
     def init_display_formatter(self):

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -318,6 +318,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             self.shell.mainloop()
         else:
             self.log.debug("IPython not interactive...")
+            self.shell.restore_term_title()
             if not self.shell.last_execution_succeeded:
                 sys.exit(1)
 

--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -72,7 +72,7 @@ def _set_term_title_xterm(title):
     # go back one title (probably undoing a %cd title change).
     if not _xterm_term_title_saved:
         # save the current title to the xterm "stack"
-        sys.stdout.write('\033[22;0t') 
+        sys.stdout.write("\033[22;0t")
         _xterm_term_title_saved = True
     sys.stdout.write('\033]0;%s\007' % title)
 

--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -62,15 +62,27 @@ def _restore_term_title():
     pass
 
 
+_xterm_term_title_saved = False
+
+
 def _set_term_title_xterm(title):
     """ Change virtual terminal title in xterm-workalikes """
-    # save the current title to the xterm "stack"
-    sys.stdout.write('\033[22;0t') 
+    global _xterm_term_title_saved
+    # Only save the title the first time we set, otherwise restore will only
+    # go back one title (probably undoing a %cd title change).
+    if not _xterm_term_title_saved:
+        # save the current title to the xterm "stack"
+        sys.stdout.write('\033[22;0t') 
+        _xterm_term_title_saved = True
     sys.stdout.write('\033]0;%s\007' % title)
 
 
 def _restore_term_title_xterm():
+    # Make sure the restore has at least one accompanying set.
+    global _xterm_term_title_saved
+    assert _xterm_term_title_saved
     sys.stdout.write('\033[23;0t') 
+    _xterm_term_title_saved = False
 
 
 if os.name == 'posix':


### PR DESCRIPTION
* Do not `toggle_set_term_title` if the output is not a tty (Fixes #11482)
* Fix non-interactive IPython setting the term title but neglecting to restore it
* Only save the the term title the first time `set_term_title` is called. Before this `%cd` would also save the title causing the initial title to not be restored.