### PR TITLE
display.Javascript should use `rel` in CSS link.

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -625,6 +625,7 @@ class JSON(DisplayObject):
     def _repr_json_(self):
         return self._data_and_metadata()
 
+
 _css_t = """var link = document.createElement("link");
 	link.rel = "stylesheet";
 	link.type = "text/css";

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -626,7 +626,7 @@ class JSON(DisplayObject):
         return self._data_and_metadata()
 
 _css_t = """var link = document.createElement("link");
-	link.ref = "stylesheet";
+	link.rel = "stylesheet";
 	link.type = "text/css";
 	link.href = "%s";
 	document.head.appendChild(link);


### PR DESCRIPTION
Seeing errors when using `display.Javascript` with `css` parameters.
The target css does not load in current chrome, due to the use of:

`<link ref="stylesheet" ...>` 

rather than:

`<link rel="stylesheet" ...>`

in the display call.