### PR TITLE
Fix empty autosuggestions bugging out the END key

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -271,7 +271,7 @@ def create_ipython_shortcuts(shell):
     def _apply_autosuggest(event):
         b = event.current_buffer
         suggestion = b.suggestion
-        if suggestion:
+        if suggestion is not None and suggestion.text:
             b.insert_text(suggestion.text)
         else:
             nc.end_of_line(event)


### PR DESCRIPTION
Closes #13623

The `nc.end_of_line(event)` line was never triggered. During writing this,
the `Suggestion` class from prompt-toolkit has no `__bool__` implemented,
which meant its objects always evaluate to true, even if
`b.suggestion.text == ''`.

The above resulted in the end key being unusable after an
autosuggestion has been accepted by the user.