### PR TITLE
Show "maxlen" in deque repr

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -908,6 +908,8 @@ def _deque_pprint(obj, p, cycle):
     cls_ctor = CallExpression.factory(obj.__class__.__name__)
     if cycle:
         p.pretty(cls_ctor(RawText("...")))
+    elif obj.maxlen is not None:
+        p.pretty(cls_ctor(list(obj), maxlen=obj.maxlen))
     else:
         p.pretty(cls_ctor(list(obj)))
 


### PR DESCRIPTION
[`collections.deque`](https://docs.python.org/3/library/collections.html#collections.deque) has a *maxlen* attribute that should be shown in its repr if defined, just like its default repr does.

This was brought up on Stack Overflow: https://stackoverflow.com/questions/71981214/python-deque-maxlen-does-not-show

## Examples

Standard Python REPL:
```python
>>> deque(range(10), maxlen=10)
deque([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], maxlen=10)
```

IPython:
```python
In [2]: deque(range(10), maxlen=10)
Out[2]: deque([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
```

IPython after this change:
```python
In [2]: deque(range(10), maxlen=10)
Out[2]: deque([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], maxlen=10)
```

And just to be sure, existing behaviour is unchanged if no *maxlen* is provided or the deque is recursive:
```python
In [3]: deque(range(10))
Out[3]: deque([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

In [4]: dq = deque(range(10), maxlen=10)

In [5]: dq.append(dq)

In [6]: dq
Out[6]: deque([1, 2, 3, 4, 5, 6, 7, 8, 9, deque(...)], maxlen=10)
```

---

P.S. LMK if this change requires adding a test or a whatsnew entry, or anything else.