### PR TITLE
fix uncaught `BdbQuit` exceptions on ipdb `exit`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,13 @@ __pycache__
 .pytest_cache
 .python-version
 venv*/
-.idea/
 .mypy_cache/
+
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -101,7 +101,6 @@ All the changes since then are under the same license as IPython.
 #
 #*****************************************************************************
 
-import bdb
 import inspect
 import linecache
 import sys

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -14,6 +14,7 @@
 import abc
 import ast
 import atexit
+import bdb
 import builtins as builtin_mod
 import dis
 import functools
@@ -3403,6 +3404,11 @@ class InteractiveShell(SingletonConfigurable):
                 result.error_in_exec = e
             self.showtraceback(exception_only=True)
             warn("To exit: use 'exit', 'quit', or Ctrl-D.", stacklevel=1)
+        except bdb.BdbQuit:
+            etype, value, tb = sys.exc_info()
+            if result is not None:
+                result.error_in_exec = value
+            # the BdbQuit stops here
         except self.custom_exceptions:
             etype, value, tb = sys.exc_info()
             if result is not None:


### PR DESCRIPTION
fixes:
  - jupyterlab/jupyterlab#12501

refs:
  - ipython/ipython#876
  - ipython/ipython#1273
  - ipython/ipython#4474
  - ipython/ipython#5306
  - ipython/ipython#9731
  - ipython/ipython#9942
  - ipython/ipython#9950
  - ipython/ipython#10006
  - ipython/ipython#12378

`BdbQuit` is now handled in the top-most scope of `InteractiveShell.run_code`. This ensures that `BdbQuit` is correctly handled but can still do its job of breaking out of all user code/loops/further breakpoint requests. Hopefully will work better than previous attempts, which put the `BdqQuit` handling in `Pdb.set_trace`.

In terms of ipdb integration with the jlab UI, it's a big improvement.

Before:
![image](https://user-images.githubusercontent.com/2263641/166344566-21871bd8-c2fe-40ab-898c-796a4aa29e99.png)

After:
![image](https://user-images.githubusercontent.com/2263641/166344716-7a780965-d78d-4694-b972-0c3e3d17f63c.png)

Much less noisy

pinging @Carreau for a review