### PR TITLE
Replaced string path in _dh with PosixPath()

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -8,6 +8,7 @@ builtin.
 
 import io
 import os
+import pathlib
 import re
 import sys
 from pprint import pformat
@@ -409,7 +410,7 @@ class OSMagics(Magics):
             except OSError:
                 print(sys.exc_info()[1])
             else:
-                cwd = os.getcwd()
+                cwd = pathlib.Path.cwd()
                 dhist = self.shell.user_ns['_dh']
                 if oldcwd != cwd:
                     dhist.append(cwd)
@@ -419,7 +420,7 @@ class OSMagics(Magics):
             os.chdir(self.shell.home_dir)
             if hasattr(self.shell, 'term_title') and self.shell.term_title:
                 set_term_title(self.shell.term_title_format.format(cwd="~"))
-            cwd = os.getcwd()
+            cwd = pathlib.Path.cwd()
             dhist = self.shell.user_ns['_dh']
 
             if oldcwd != cwd:


### PR DESCRIPTION
- [x] Read through Contribution doc
- [x] Ran tests locally

Here is a fix for [GH-12967](https://github.com/ipython/ipython/issues/12967) (thanks @GalBr for pinpointing the issue), and is related to [GH-12515](https://github.com/ipython/ipython/issues/12515). 

Before:
```python
❯ python -m IPython
Python 3.10.0 (default, Nov 10 2021, 11:24:47) [Clang 12.0.0 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: cd ~
/Users/me

In [2]: _dh
Out[2]: [PosixPath('/Users/me/some/path'), '/Users/me']
```

Now:
```python
❯ python -m IPython                                     
Python 3.10.0 (default, Nov 10 2021, 11:24:47) [Clang 12.0.0 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.4.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: cd ~
/Users/me

In [2]: _dh
Out[2]: [PosixPath('/Users/me/some/path'), PosixPath('/Users/me')]
```

First time contributing here, read through the contribution doc but sorry if there's something I missed!