### PR TITLE
Sort parameter completions first and in the signature order

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1960,7 +1960,7 @@ class IPCompleter(Completer):
         jedi_matches = []
         jedi_param_matches = []
         for jedi_match in iter(all_jedi_matches):
-            if jedi_match.name.endswith('='):
+            if jedi_match.name.endswith("="):
                 jedi_param_matches.append(jedi_match)
             else:
                 jedi_matches.append(jedi_match)
@@ -2151,8 +2151,7 @@ class IPCompleter(Completer):
         if self.use_jedi and not is_magic_prefix:
             if not full_text:
                 full_text = line_buffer
-            jedi_completions = self._jedi_matches(
-                cursor_pos, cursor_line, full_text)
+            jedi_completions = self._jedi_matches(cursor_pos, cursor_line, full_text)
 
         if self.merge_completions:
             matches = []
@@ -2178,13 +2177,15 @@ class IPCompleter(Completer):
             t, c = m
             if t not in seen:
                 # Keep the parameter matches in the function signature order
-                if c == 'IPCompleter.python_func_kw_matches':
+                if c == "IPCompleter.python_func_kw_matches":
                     filtered_param_matches[m] = None
                 else:
                     filtered_matches.add(m)
                 seen.add(t)
 
-        _filtered_matches = list(filtered_param_matches) + sorted(list(filtered_matches), key=lambda x: completions_sorting_key(x[0]))
+        _filtered_matches = list(filtered_param_matches) + sorted(
+            list(filtered_matches), key=lambda x: completions_sorting_key(x[0])
+        )
 
         custom_res = [(m, 'custom') for m in self.dispatch_custom_completer(text) or []]
         

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2147,11 +2147,11 @@ class IPCompleter(Completer):
         # simply collapse the dict into a list for readline, but we'd have
         # richer completion semantics in other environments.
         is_magic_prefix = len(text) > 0 and text[0] == "%"
-        completions: Iterable[Any] = []
+        jedi_completions: Iterable[Any] = []
         if self.use_jedi and not is_magic_prefix:
             if not full_text:
                 full_text = line_buffer
-            completions = self._jedi_matches(
+            jedi_completions = self._jedi_matches(
                 cursor_pos, cursor_line, full_text)
 
         if self.merge_completions:
@@ -2196,7 +2196,7 @@ class IPCompleter(Completer):
 
         self.matches = _matches
 
-        return _CompleteResult(text, _matches, origins, completions)
+        return _CompleteResult(text, _matches, origins, jedi_completions)
         
     def fwd_unicode_match(self, text:str) -> Tuple[str, Sequence[str]]:
         """

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1618,9 +1618,7 @@ class IPCompleter(Completer):
                                                     self.namespace))
 
             # Remove used named arguments from the list, no need to show twice,
-            # Keep parameters first in the completions by removing from usedNamedArgs
-            usedNamedArgs = {arg for arg in usedNamedArgs if arg not in NamedArgs}
-            for namedArg in namedArgs:
+            for namedArg in [arg for arg in namedArgs if arg not in usedNamedArgs]:
                 if namedArg.startswith(text):
                     argMatches.append("%s=" %namedArg)
         except:


### PR DESCRIPTION
Fixes https://github.com/ipython/ipython/issues/12344

This is a suggestion to change the sort order of parameters to be first and in the order the order they appear in the signature.

Currently, the default behavior when using Jedi is to not sort parameters first, which is not that useful when completing on a function call:
![image](https://user-images.githubusercontent.com/4560057/168212948-a6dd24d2-d01d-4a0e-b513-ed11f27383be.png)

This PR changes that so that the function parameters are shown first:
![image](https://user-images.githubusercontent.com/4560057/168212810-d30511fc-7a63-457e-8579-7a25de0d2f89.png)

The previous screenshot is already the default behavior when *not* using Jedi. This PR also includes an improvement for that which is sorting the parameters in the order they are specified in the signature instead of alphabetically (I think this is the most intuitive but open to feedback):
![image](https://user-images.githubusercontent.com/4560057/168212915-4ac4125c-0cd3-4d5a-8d68-fb906b267d08.png)

There is unfortunately not a way to achieve this last step with Jedi currently, but I have opened https://github.com/davidhalter/jedi/pull/1855 to implement that.