### PR TITLE
terminal: Fix IndexError when attempting to elide paths with empty components

### DIFF
--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -47,11 +47,11 @@ def _elide_point(string:str, *, min_elide=30)->str:
     if file_parts[-1] == '':
         file_parts.pop()
 
-    if len(object_parts) > 3 and object_parts[1] and object_parts[-2]:
-        return '{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}'.format(object_parts[0], object_parts[1][0], object_parts[-2][-1], object_parts[-1])
+    if len(object_parts) > 3:
+        return '{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}'.format(object_parts[0], object_parts[1][:1], object_parts[-2][-1:], object_parts[-1])
 
-    elif len(file_parts) > 3 and file_parts[1] and file_parts[-2]:
-        return ('{}' + os.sep + '{}\N{HORIZONTAL ELLIPSIS}{}' + os.sep + '{}').format(file_parts[0], file_parts[1][0], file_parts[-2][-1], file_parts[-1])
+    elif len(file_parts) > 3:
+        return ('{}' + os.sep + '{}\N{HORIZONTAL ELLIPSIS}{}' + os.sep + '{}').format(file_parts[0], file_parts[1][:1], file_parts[-2][-1:], file_parts[-1])
 
     return string
 

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -48,10 +48,17 @@ def _elide_point(string:str, *, min_elide=30)->str:
         file_parts.pop()
 
     if len(object_parts) > 3:
-        return '{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}'.format(object_parts[0], object_parts[1][:1], object_parts[-2][-1:], object_parts[-1])
+        return "{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}".format(
+            object_parts[0],
+            object_parts[1][:1],
+            object_parts[-2][-1:],
+            object_parts[-1],
+        )
 
     elif len(file_parts) > 3:
-        return ('{}' + os.sep + '{}\N{HORIZONTAL ELLIPSIS}{}' + os.sep + '{}').format(file_parts[0], file_parts[1][:1], file_parts[-2][-1:], file_parts[-1])
+        return ("{}" + os.sep + "{}\N{HORIZONTAL ELLIPSIS}{}" + os.sep + "{}").format(
+            file_parts[0], file_parts[1][:1], file_parts[-2][-1:], file_parts[-1]
+        )
 
     return string
 

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -47,10 +47,10 @@ def _elide_point(string:str, *, min_elide=30)->str:
     if file_parts[-1] == '':
         file_parts.pop()
 
-    if len(object_parts) > 3:
+    if len(object_parts) > 3 and object_parts[1] and object_parts[-2]:
         return '{}.{}\N{HORIZONTAL ELLIPSIS}{}.{}'.format(object_parts[0], object_parts[1][0], object_parts[-2][-1], object_parts[-1])
 
-    elif len(file_parts) > 3:
+    elif len(file_parts) > 3 and file_parts[1] and file_parts[-2]:
         return ('{}' + os.sep + '{}\N{HORIZONTAL ELLIPSIS}{}' + os.sep + '{}').format(file_parts[0], file_parts[1][0], file_parts[-2][-1], file_parts[-1])
 
     return string

--- a/docs/source/whatsnew/pr/fix-tab-completion-consecutive-separators.rst
+++ b/docs/source/whatsnew/pr/fix-tab-completion-consecutive-separators.rst
@@ -1,0 +1,5 @@
+Fixed tab completion for inputs with consecutive separators
+===========================================================
+
+Fixed error raised when attempting to tab-complete an input string with
+consecutive periods or forward slashes (such as "file:///var/log/...").


### PR DESCRIPTION
When attempting to elide a path string that contains empty components we get an error:

```console
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/IPython/terminal/ptutils.py", line 115, in get_completions
    cursor_position = document.cursor_position
  File "/usr/local/lib/python3.10/site-packages/IPython/terminal/ptutils.py", line 162, in _get_completions
    if c.type == 'function':
  File "/usr/local/lib/python3.10/site-packages/IPython/terminal/ptutils.py", line 77, in _elide
    _elide_point(string, min_elide=min_elide),
  File "/usr/local/lib/python3.10/site-packages/IPython/terminal/ptutils.py", line 57, in _elide_point
    return ('{}' + os.sep + '{}\N{HORIZONTAL ELLIPSIS}{}' + os.sep + '{}').format(file_parts[0], file_parts[1][0], file_parts[-2][-1], file_parts[-1])
IndexError: string index out of range
```

Example string: `//tmp/TemporaryDirectory.G90DrY/`. The `file_parts` for this string are: `['', '', 'tmp', 'TemporaryDirectory.G90DrY']`.

Solution: Don't attempt to elide if the middle components are empty.