### PR TITLE
Limit supported prompt-toolkit versions to 3.0.2-3.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     matplotlib-inline
     pexpect>4.3; sys_platform != "win32"
     pickleshare
-    prompt_toolkit>=2.0.0,<3.1.0,!=3.0.0,!=3.0.1
+    prompt_toolkit>3.0.1,<3.1.0
     pygments>=2.4.0
     setuptools>=18.5
     stack_data


### PR DESCRIPTION
This is because `PtkHistoryAdapter` now uses an internal of `prompt_toolkit.*.History`, which does not exist before `prompt-toolkit==3.0.1`.

`3.0.0` and `3.0.1` were already excluded.

Fixes #13645, which stems from #13592.

Let me know if having support for older prompt-toolkit versions is worth the effort get rid of the usage of `History._loaded`.