### PR TITLE
Prevent popup windows during execution of latex_to_png_dvipng

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -144,6 +144,13 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
         find_cmd('dvipng')
     except FindCmdError:
         return None
+
+    startupinfo = None
+    if os.name == 'nt':
+        # prevent popup-windows
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
     try:
         workdir = Path(tempfile.mkdtemp())
         tmpfile = workdir.joinpath("tmp.tex")
@@ -156,7 +163,7 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
         with open(os.devnull, 'wb') as devnull:
             subprocess.check_call(
                 ["latex", "-halt-on-error", "-interaction", "batchmode", tmpfile],
-                cwd=workdir, stdout=devnull, stderr=devnull)
+                cwd=workdir, stdout=devnull, stderr=devnull, startupinfo=startupinfo)
 
             resolution = round(150*scale)
             subprocess.check_call(
@@ -179,6 +186,7 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
                 cwd=workdir,
                 stdout=devnull,
                 stderr=devnull,
+                startupinfo=startupinfo
             )
 
         with outfile.open("rb") as f:

--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -146,7 +146,7 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
         return None
 
     startupinfo = None
-    if os.name == 'nt':
+    if os.name == "nt":
         # prevent popup-windows
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
@@ -163,7 +163,11 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
         with open(os.devnull, 'wb') as devnull:
             subprocess.check_call(
                 ["latex", "-halt-on-error", "-interaction", "batchmode", tmpfile],
-                cwd=workdir, stdout=devnull, stderr=devnull, startupinfo=startupinfo)
+                cwd=workdir,
+                stdout=devnull,
+                stderr=devnull,
+                startupinfo=startupinfo,
+            )
 
             resolution = round(150*scale)
             subprocess.check_call(
@@ -186,7 +190,7 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
                 cwd=workdir,
                 stdout=devnull,
                 stderr=devnull,
-                startupinfo=startupinfo
+                startupinfo=startupinfo,
             )
 
         with outfile.open("rb") as f:

--- a/docs/source/whatsnew/pr/latex-generation-no-popup-window.rst
+++ b/docs/source/whatsnew/pr/latex-generation-no-popup-window.rst
@@ -1,0 +1,5 @@
+No popup in window for latex generation
+=======================================
+
+When generating latex (e.g. via `_latex_repr_`) no popup window is shows under Windows.
+


### PR DESCRIPTION
The exectution of `latex_to_png_dvipng` causes popup windows. This PR prevents that by setting flags to the `subprocess.check_call`.

Idea was suggested in https://github.com/jupyter/qtconsole/issues/542#issuecomment-1136297850
