### PR TITLE
Use relative filename in latex and dvips commands of latex_to_png_dvipng

### DIFF
--- a/IPython/lib/latextools.py
+++ b/IPython/lib/latextools.py
@@ -146,11 +146,11 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
         return None
     try:
         workdir = Path(tempfile.mkdtemp())
-        tmpfile = workdir.joinpath("tmp.tex")
-        dvifile = workdir.joinpath("tmp.dvi")
-        outfile = workdir.joinpath("tmp.png")
+        tmpfile = "tmp.tex"
+        dvifile = "tmp.dvi"
+        outfile = "tmp.png"
 
-        with tmpfile.open("w", encoding="utf8") as f:
+        with workdir.joinpath(tmpfile).open("w", encoding="utf8") as f:
             f.writelines(genelatex(s, wrap))
 
         with open(os.devnull, 'wb') as devnull:
@@ -181,7 +181,7 @@ def latex_to_png_dvipng(s, wrap, color='Black', scale=1.0):
                 stderr=devnull,
             )
 
-        with outfile.open("rb") as f:
+        with workdir.joinpath(outfile).open("rb") as f:
             return f.read()
     except subprocess.CalledProcessError:
         return None

--- a/docs/source/whatsnew/pr/latex_rendering_relative_files.rst
+++ b/docs/source/whatsnew/pr/latex_rendering_relative_files.rst
@@ -1,0 +1,6 @@
+Relative filenames in Latex rendering
+=====================================
+
+The input and output file arguments to `latex` and `dvipis` are files relative to the current working directory.
+This solves a problem where the current working directory contains characters that are not handled properly by `latex` and `dvips`.
+

--- a/docs/source/whatsnew/pr/latex_rendering_relative_files.rst
+++ b/docs/source/whatsnew/pr/latex_rendering_relative_files.rst
@@ -1,6 +1,7 @@
 Relative filenames in Latex rendering
 =====================================
 
-The input and output file arguments to `latex` and `dvipis` are files relative to the current working directory.
+The `latex_to_png_dvipng` command internally generates input and output file arguments to `latex` and `dvipis`. These arguments are now generated as relative files to the current working directory instead of absolute file paths.
 This solves a problem where the current working directory contains characters that are not handled properly by `latex` and `dvips`.
+There are no changes to the user API.
 


### PR DESCRIPTION
This prevents problems with temporary directories with special characters in them.

Fixes #13678