### PR TITLE
Correct the debugger_cls() call to self.debugger_cls() call in TBTool

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -239,7 +239,7 @@ class TBTools(colorable.Colorable):
         self.debugger_cls = debugger_cls or debugger.Pdb
 
         if call_pdb:
-            self.pdb = debugger_cls()
+            self.pdb = self.debugger_cls()
         else:
             self.pdb = None
 


### PR DESCRIPTION
…s.__init__() so that it doesn't crash when the optional argument, debugger_cls, is unspecified.