### PR TITLE
Documentation uses python2 for a code example instead of python3

### DIFF
--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -136,7 +136,7 @@ The following is a very simple example of a valid demo file.
     #################### EXAMPLE DEMO <ex_demo.py> ###############################
     '''A simple interactive demo to illustrate the use of IPython's Demo class.'''
 
-    print 'Hello, welcome to an interactive IPython demo.'
+    print('Hello, welcome to an interactive IPython demo.')
 
     # The mark below defines a block boundary, which is a point where IPython will
     # stop execution and return to the interactive prompt. The dashes are actually
@@ -152,21 +152,21 @@ The following is a very simple example of a valid demo file.
     # the mark below makes this block as silent
     # <demo> silent
 
-    print 'This is a silent block, which gets executed but not printed.'
+    print('This is a silent block, which gets executed but not printed.')
 
     # <demo> stop
     # <demo> auto
-    print 'This is an automatic block.'
-    print 'It is executed without asking for confirmation, but printed.'
-    z = x+y
+    print('This is an automatic block.')
+    print('It is executed without asking for confirmation, but printed.')
+    z = x + y
 
-    print 'z=',x
+    print('z =', x)
 
     # <demo> stop
     # This is just another normal block.
-    print 'z is now:', z
+    print('z is now:', z)
 
-    print 'bye!'
+    print('bye!')
     ################### END EXAMPLE DEMO <ex_demo.py> ############################
 """
 


### PR DESCRIPTION
https://github.com/ipython/ipython/issues/13672
Just a quick fix that converts `print ' '`  -->  `print(' ')`

Build:
![image](https://user-images.githubusercontent.com/87157047/171676574-2d84affc-c24b-4ed9-9185-a625ee207ce8.png)