### PR TITLE
Fix: move quiet handling to interactiveshell

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -58,6 +58,8 @@ class DisplayHook(Configurable):
         to_user_ns = {'_':self._,'__':self.__,'___':self.___}
         self.shell.user_ns.update(to_user_ns)
 
+        self.is_quiet = False
+
     @property
     def prompt_count(self):
         return self.shell.execution_count
@@ -83,24 +85,7 @@ class DisplayHook(Configurable):
 
     def quiet(self):
         """Should we silence the display hook because of ';'?"""
-        # do not print output if input ends in ';'
-        
-        try:
-            cell = self.shell.history_manager.input_hist_parsed[-1]
-        except IndexError:
-            # some uses of ipshellembed may fail here
-            return False
-        
-        sio = _io.StringIO(cell)
-        tokens = list(tokenize.generate_tokens(sio.readline))
-
-        for token in reversed(tokens):
-            if token[0] in (tokenize.ENDMARKER, tokenize.NL, tokenize.NEWLINE, tokenize.COMMENT):
-                continue
-            if (token[0] == tokenize.OP) and (token[1] == ';'):
-                return True
-            else:
-                return False
+        return self.is_quiet
 
     def start_displayhook(self):
         """Start the displayhook, initializing resources."""

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -25,11 +25,12 @@ import runpy
 import subprocess
 import sys
 import tempfile
+import tokenize
 import traceback
 import types
 import warnings
 from ast import stmt
-from io import open as io_open
+from io import open as io_open, StringIO
 from logging import error
 from pathlib import Path
 from typing import Callable
@@ -2987,17 +2988,23 @@ class InteractiveShell(SingletonConfigurable):
 
     def cell_is_quiet(self, cell: str) -> bool:
         """Should we silence the display hook because of ';'?"""
-        sio = _io.StringIO(cell)
+        sio = StringIO(cell)
         tokens = list(tokenize.generate_tokens(sio.readline))
 
         for token in reversed(tokens):
-            if token[0] in (tokenize.ENDMARKER, tokenize.NL, tokenize.NEWLINE, tokenize.COMMENT):
+            if token[0] in (
+                tokenize.ENDMARKER,
+                tokenize.NL,
+                tokenize.NEWLINE,
+                tokenize.COMMENT,
+            ):
                 continue
-            if (token[0] == tokenize.OP) and (token[1] == ';'):
+            if (token[0] == tokenize.OP) and (token[1] == ";"):
                 return True
             else:
                 return False
         return False
+
 
     async def run_cell_async(
         self,

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -215,14 +215,17 @@ class ExecutionInfo(object):
         raw_cell = (
             (self.raw_cell[:50] + "..") if len(self.raw_cell) > 50 else self.raw_cell
         )
-        return '<%s object at %x, raw_cell="%s" store_history=%s silent=%s shell_futures=%s cell_id=%s>' % (
-            name,
-            id(self),
-            raw_cell,
-            self.store_history,
-            self.silent,
-            self.shell_futures,
-            self.cell_id,
+        return (
+            '<%s object at %x, raw_cell="%s" store_history=%s silent=%s shell_futures=%s cell_id=%s>'
+            % (
+                name,
+                id(self),
+                raw_cell,
+                self.store_history,
+                self.silent,
+                self.shell_futures,
+                self.cell_id,
+            )
         )
 
 
@@ -3004,7 +3007,6 @@ class InteractiveShell(SingletonConfigurable):
             else:
                 return False
         return False
-
 
     async def run_cell_async(
         self,

--- a/docs/source/whatsnew/pr/fix-quiet-mode-handling.rst
+++ b/docs/source/whatsnew/pr/fix-quiet-mode-handling.rst
@@ -1,0 +1,6 @@
+Fix quiet-mode detection
+========================
+
+DisplayHook was inspecting the last stored history to determine whether it should behave as though in quiet mode.
+This assumption does not hold when the last execution does not store shell history, e.g. when using a custom
+kernel client. This fix just moves the quiet-mode handling to an explicit call from the execution handler.


### PR DESCRIPTION
I don't know a huge amount about the IPython internals, so this might not be the right fix.

Currently, `DisplayHook` uses the shell history to determine whether the current cell should be quiet or not. This means that if the user executes the cell with `store_history=False`, the display hook will look to a _previous_ cell to determine whether to render the current cell's output.

This PR fixes this problem by explicitly computing and setting a new `is_quiet` attribute on `DisplayHook`. I would want to make this private, or at least, make it clear that only `InteractiveShell` should set this. I'd be keen to know what the most IPythonic approach would be here.

I also don't know if there are any wider repercussions of this, e.g. if the display hook is invoked outside of `run_cell_async`. I would naively assume that this is fine?