### PR TITLE
Modernize setuptools usage in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 51.0.0", "wheel"]
-build-backend = "setuptools.build_meta:__legacy__"
+requires = ["setuptools >= 51.0.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ Python {py} detected.
 from setuptools import setup
 
 # Our own imports
+sys.path.insert(0, ".")
+
 from setupbase import target_update
 
 from setupbase import (


### PR DESCRIPTION
1. Remove the redundant `wheel` dependency.  The setuptools build
   backend has been adding it automatically since day one, and it was
   explicitly specified in the docs as a mistake.  See:
   https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

2. Replace the legacy backend with the regular backend.  The legacy
   backend was only intended to be used implicitly when `pyproject.toml`
   does not specify only, and was not supposed to be specified
   explicitly there.  See:
   https://github.com/pypa/setuptools/issues/1689

3. Add `backend-path` as required for `setup.py` to be able to import
   setupbase from the current directory.  Alternatively, this can
   be done via modifying `sys.path` inside the code.