### PR TITLE
Catch exception in IPython/terminal/intereractiveshell.py when a standard stream is closed

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -91,7 +91,12 @@ def get_default_editor():
 # - no isatty method
 for _name in ('stdin', 'stdout', 'stderr'):
     _stream = getattr(sys, _name)
-    if not _stream or not hasattr(_stream, 'isatty') or not _stream.isatty():
+    try:
+        if not _stream or not hasattr(_stream, "isatty") or not _stream.isatty():
+            _is_tty = False
+            break
+    except ValueError:
+        # stream is closed
         _is_tty = False
         break
 else:


### PR DESCRIPTION
If a standard stream is closed, any operation on it will raise a `ValueError`. This includes `isatty()`:
```python
import sys
sys.stdout.close()
sys.stdout.isatty()
```
IPython/terminal/interactiveshell.py currently calls this function on each of the standard streams, throwing a `ValueError`:

https://github.com/ipython/ipython/blob/f20e3b80393a1a5909a050cb7bb9cbce9e044827/IPython/terminal/interactiveshell.py#L92-L98

Here is a minimal example that demonstrates this bug:

```python
import sys
sys.stdout.close()
from IPython.terminal import interactiveshell
```

I am adding a try .. except statement to IPython/terminal/interactiveshell.py that catches this exception when any of the standard streams are closed.

I believe this PR will address jupyter/jupyter_client#497