### PR TITLE
setup.cfg: Remove setuptools from install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     pickleshare
     prompt_toolkit>3.0.1,<3.1.0
     pygments>=2.4.0
-    setuptools>=18.5
     stack_data
     traitlets>=5
 


### PR DESCRIPTION
It is not a runtime dependency.