### PR TITLE
xxlimited_35 module now has the same name in repr in Py 3.11

### DIFF
--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -141,9 +141,12 @@ def test_pprint_heap_allocated_type():
     Test that pprint works for heap allocated types.
     """
     module_name = "xxlimited" if sys.version_info < (3, 10) else "xxlimited_35"
+    expected_output = (
+        "xxlimited.Null" if sys.version_info < (3, 11) else "xxlimited_35.Null"
+    )
     xxlimited = pytest.importorskip(module_name)
     output = pretty.pretty(xxlimited.Null)
-    assert output == "xxlimited.Null"
+    assert output == expected_output
 
 
 def test_pprint_nomod():

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -142,7 +142,7 @@ def test_pprint_heap_allocated_type():
     """
     module_name = "xxlimited" if sys.version_info < (3, 10) else "xxlimited_35"
     expected_output = (
-        "xxlimited.Null" if sys.version_info < (3, 11) else "xxlimited_35.Null"
+        "xxlimited.Null" if sys.version_info < (3, 10, 6) else "xxlimited_35.Null"
     )
     xxlimited = pytest.importorskip(module_name)
     output = pretty.pretty(xxlimited.Null)


### PR DESCRIPTION
See https://github.com/python/cpython/commit/a87c9b538fbfc42883417c4d5e69f1a5922690e3