### PR TITLE
keep autocomplete results stable in multi-thread access

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -677,15 +677,15 @@ class Completer(Configurable):
         n = len(text)
         for lst in [keyword.kwlist,
                     builtin_mod.__dict__.keys(),
-                    self.namespace.keys(),
-                    self.global_namespace.keys()]:
+                    list(self.namespace.keys()),
+                    list(self.global_namespace.keys())]:
             for word in lst:
                 if word[:n] == text and word != "__builtins__":
                     match_append(word)
 
         snake_case_re = re.compile(r"[^_]+(_[^_]+)+?\Z")
-        for lst in [self.namespace.keys(),
-                    self.global_namespace.keys()]:
+        for lst in [list(self.namespace.keys()),
+                    list(self.global_namespace.keys())]:
             shortened = {"_".join([sub[0] for sub in word.split('_')]) : word
                          for word in lst if snake_case_re.match(word)}
             for word in shortened.keys():

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -675,19 +675,23 @@ class Completer(Configurable):
         matches = []
         match_append = matches.append
         n = len(text)
-        for lst in [keyword.kwlist,
-                    builtin_mod.__dict__.keys(),
-                    list(self.namespace.keys()),
-                    list(self.global_namespace.keys())]:
+        for lst in [
+            keyword.kwlist,
+            builtin_mod.__dict__.keys(),
+            list(self.namespace.keys()),
+            list(self.global_namespace.keys()),
+        ]:
             for word in lst:
                 if word[:n] == text and word != "__builtins__":
                     match_append(word)
 
         snake_case_re = re.compile(r"[^_]+(_[^_]+)+?\Z")
-        for lst in [list(self.namespace.keys()),
-                    list(self.global_namespace.keys())]:
-            shortened = {"_".join([sub[0] for sub in word.split('_')]) : word
-                         for word in lst if snake_case_re.match(word)}
+        for lst in [list(self.namespace.keys()), list(self.global_namespace.keys())]:
+            shortened = {
+                "_".join([sub[0] for sub in word.split("_")]): word
+                for word in lst
+                if snake_case_re.match(word)
+            }
             for word in shortened.keys():
                 if word[:n] == text and word != "__builtins__":
                     match_append(shortened[word])

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -80,7 +80,7 @@ def issues_closed_since(period=timedelta(days=365), project="ipython/ipython", p
     if pulls:
         filtered = [ i for i in filtered if _parse_datetime(i['merged_at']) > since ]
         # filter out PRs not against main (backports)
-        filtered = [ i for i in filtered if i['base']['ref'] == 'main' ]
+        filtered = [i for i in filtered if i["base"]["ref"] == "main"]
     else:
         filtered = [ i for i in filtered if not is_pull_request(i) ]
     


### PR DESCRIPTION
IPython can be used in a GUI where a notebook cell is running while autocomplete is getting invoked on another thread. The running cell can change the iterator of the namespace or global_namespace while the autocomplete invocation is enumerating over the dictionary of results. The resulting error message from autocomplete is `RuntimeError: dictionary size changed during iteration`.

This change proposes to get a copy of the keys() so that can be enumerated.

Example code that causes the issue:
```
import time

glbl = globals()
count = 0
time_limit = 50
start = time.time()
end = start + time_limit

while time.time() < end:
  glbl[f"global_var_{count}"] = None
  count += 1
```