### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,9 +2,9 @@ name: Run MyPy
 
 on:
   push:
-    branches: [ master, 7.x]
+    branches: [ main, 7.x]
   pull_request:
-    branches: [ master, 7.x]
+    branches: [ main, 7.x]
 
 jobs:
   build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master, 7.x ]
+    branches: [ main, 7.x ]
   pull_request:
-    branches: [ master, 7.x ]
+    branches: [ main, 7.x ]
 
 jobs:
   formatting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
       - '*.x'
   pull_request:
   # Run weekly on Monday at 1:23 UTC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When opening a new Issue, please take the following steps:
 
 1. Search GitHub and/or Google for your issue to avoid duplicate reports.
    Keyword searches for your error messages are most helpful.
-2. If possible, try updating to master and reproducing your issue,
+2. If possible, try updating to main and reproducing your issue,
    because we may have already fixed it.
 3. Try to include a minimal reproducible test case.
 4. Include relevant system information.  Start with the output of:
@@ -53,7 +53,7 @@ Some guidelines on contributing to IPython:
   Review and discussion can begin well before the work is complete,
   and the more discussion the better.
   The worst case is that the PR is closed.
-* Pull Requests should generally be made against master
+* Pull Requests should generally be made against main
 * Pull Requests should be tested, if feasible:
     - bugfixes should include regression tests.
     - new behavior should at least get minimal exercise.

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -38,7 +38,7 @@ Python 3.7 was still supported with the 7.x branch.
 
 See IPython `README.rst` file for more information:
 
-    https://github.com/ipython/ipython/blob/master/README.rst
+    https://github.com/ipython/ipython/blob/main/README.rst
 
 """
     )

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://codecov.io/github/ipython/ipython/coverage.svg?branch=master
-    :target: https://codecov.io/github/ipython/ipython?branch=master
+.. image:: https://codecov.io/github/ipython/ipython/coverage.svg?branch=main
+    :target: https://codecov.io/github/ipython/ipython?branch=main
 
 .. image:: https://img.shields.io/pypi/v/IPython.svg
     :target: https://pypi.python.org/pypi/ipython

--- a/docs/source/coredev/index.rst
+++ b/docs/source/coredev/index.rst
@@ -14,12 +14,12 @@ For instructions on how to make a developer install see :ref:`devinstall`.
 Backporting Pull requests
 =========================
 
-All pull requests should usually be made against ``master``, if a Pull Request
+All pull requests should usually be made against ``main``, if a Pull Request
 need to be backported to an earlier release; then it should be tagged with the
 correct ``milestone``.
 
 If you tag a pull request with a milestone **before** merging the pull request,
-and the base ref is ``master``, then our backport bot should automatically create
+and the base ref is ``main``, then our backport bot should automatically create
 a corresponding pull-request that backport on the correct branch.
 
 If you have write access to the IPython repository you can also just mention the
@@ -78,7 +78,7 @@ for the release you are actually making::
     PREV_RELEASE=4.2.1
     MILESTONE=5.0
     VERSION=5.0.0
-    BRANCH=master
+    BRANCH=main
 
 For `reproducibility of builds <https://reproducible-builds.org/specs/source-date-epoch/>`_,
 we recommend setting ``SOURCE_DATE_EPOCH`` prior to running the build; record the used value

--- a/examples/IPython Kernel/Terminal Usage.ipynb
+++ b/examples/IPython Kernel/Terminal Usage.ipynb
@@ -196,7 +196,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `%gui` magic can be similarly used to control Wx, Tk, glut and pyglet applications, [as can be seen in our examples](https://github.com/ipython/ipython/tree/master/examples/lib)."
+    "The `%gui` magic can be similarly used to control Wx, Tk, glut and pyglet applications, [as can be seen in our examples](https://github.com/ipython/ipython/tree/main/examples/lib)."
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ Python 3.7 was still supported with the 7.x branch.
 
 See IPython `README.rst` file for more information:
 
-    https://github.com/ipython/ipython/blob/master/README.rst
+    https://github.com/ipython/ipython/blob/main/README.rst
 
 Python {py} detected.
 {pip}

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -79,8 +79,8 @@ def issues_closed_since(period=timedelta(days=365), project="ipython/ipython", p
     filtered = [ i for i in allclosed if _parse_datetime(i['closed_at']) > since ]
     if pulls:
         filtered = [ i for i in filtered if _parse_datetime(i['merged_at']) > since ]
-        # filter out PRs not against master (backports)
-        filtered = [ i for i in filtered if i['base']['ref'] == 'master' ]
+        # filter out PRs not against main (backports)
+        filtered = [ i for i in filtered if i['base']['ref'] == 'main' ]
     else:
         filtered = [ i for i in filtered if not is_pull_request(i) ]
     

--- a/tools/release_helper.sh
+++ b/tools/release_helper.sh
@@ -31,7 +31,7 @@ MILESTONE=${input:-$MILESTONE}
 echo -n "VERSION (X.y.z) [$VERSION]:"
 read input
 VERSION=${input:-$VERSION}
-echo -n "BRANCH (master|X.y) [$BRANCH]:"
+echo -n "BRANCH (main|X.y) [$BRANCH]:"
 read input
 BRANCH=${input:-$BRANCH}
 


### PR DESCRIPTION
Close #13728.

Here is what I think needs to be done:

1. Rename default branch `main` on GitHub:
    - https://github.com/ipython/ipython/settings/branches
2. Merge this PR
3. Update your locally cloned repository to have a `main` branch as follows:
```
git branch -m master main
git fetch <YOUR_UPSTREAM_REMOTE>
git branch -u <YOUR_UPSTREAM_REMOTE>/main main

(where YOUR_UPSTREAM_REMOTE is typically called `upstream` or `origin`)
```

The whole process should only take a few minutes. You could send an email to developers telling them about step 3, if you want. For `pydata-sphinx-theme`, we also pinned this issue: https://github.com/pydata/pydata-sphinx-theme/issues/677