### PR TITLE
Let %autoreload work on modules with frozen dataclasses

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -300,7 +300,7 @@ def update_instances(old, new):
 
     for ref in refs:
         if type(ref) is old:
-            ref.__class__ = new
+            object.__setattr__(ref, "__class__", new)
 
 
 def update_class(old, new):

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -80,7 +80,7 @@ def issues_closed_since(period=timedelta(days=365), project="ipython/ipython", p
     if pulls:
         filtered = [ i for i in filtered if _parse_datetime(i['merged_at']) > since ]
         # filter out PRs not against main (backports)
-        filtered = [ i for i in filtered if i['base']['ref'] == 'main' ]
+        filtered = [i for i in filtered if i["base"]["ref"] == "main"]
     else:
         filtered = [ i for i in filtered if not is_pull_request(i) ]
     


### PR DESCRIPTION
See #12411 and #12185.

The problem is that a frozen `dataclasses.dataclass` overrides the `__setattr__()` method, so updating its `__class__` member requires going through the base `object` class.

A simple way to reproduce the problem and see that the fix works is as follows.

Create a file `./module/__init__.py` containing:
```python
__version__ = 1
import dataclasses

@dataclasses.dataclass(frozen=True)
class Class:
  a: int

instance = Class(1)
```

Then create a notebook containing two cells:
```python
%load_ext autoreload
%autoreload 2
import module

# %%
print(module.__version__)
```

Run the notebook; edit the `__init__.py` file to contain `__version__ = 2`, then rerun the second notebook cell (`print`).
Without the fix, an exception is raised.