### PR TITLE
Added additional entrypoint script.

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -211,14 +211,16 @@ def find_entry_points():
     use, our own build_scripts_entrypt class below parses these and builds
     command line scripts.
 
-    Each of our entry points gets both a plain name, e.g. ipython, and one
-    suffixed with the Python major version number, e.g. ipython3.
+    Each of our entry points gets a plain name, e.g. ipython, a name
+    suffixed with the Python major version number, e.g. ipython3, and
+    a name suffixed with the Python major.minor version number, eg. ipython3.8.
     """
     ep = [
             'ipython%s = IPython:start_ipython',
         ]
-    suffix = str(sys.version_info[0])
-    return [e % '' for e in ep] + [e % suffix for e in ep]
+    major_suffix = str(sys.version_info[0])
+    minor_suffix = ".".join([str(sys.version_info[0]), str(sys.version_info[1])])
+    return [e % '' for e in ep] + [e % major_suffix for e in ep] + [e % minor_suffix for e in ep]
 
 class install_lib_symlink(Command):
     user_options = [

--- a/setupbase.py
+++ b/setupbase.py
@@ -220,7 +220,11 @@ def find_entry_points():
         ]
     major_suffix = str(sys.version_info[0])
     minor_suffix = ".".join([str(sys.version_info[0]), str(sys.version_info[1])])
-    return [e % '' for e in ep] + [e % major_suffix for e in ep] + [e % minor_suffix for e in ep]
+    return (
+        [e % "" for e in ep]
+        + [e % major_suffix for e in ep]
+        + [e % minor_suffix for e in ep]
+    )
 
 class install_lib_symlink(Command):
     user_options = [


### PR DESCRIPTION
Added a third entrypoint to use python's minor version as well.

This can help when testing out differences of python versions. One could easily open "ipython3.10" and test it's differences with "ipython3.8".