### PR TITLE
Remove deprecated install_ext and ~/.ipython/extensions

### DIFF
--- a/IPython/core/extensions.py
+++ b/IPython/core/extensions.py
@@ -88,13 +88,7 @@ class ExtensionManager(Configurable):
 
         with self.shell.builtin_trap:
             if module_str not in sys.modules:
-                with prepended_to_syspath(self.ipython_extension_dir):
-                    mod = import_module(module_str)
-                    if mod.__file__.startswith(self.ipython_extension_dir):
-                        print(("Loading extensions from {dir} is deprecated. "
-                               "We recommend managing extensions like any "
-                               "other Python packages, in site-packages.").format(
-                              dir=compress_user(self.ipython_extension_dir)))
+                mod = import_module(module_str)
             mod = sys.modules[module_str]
             if self._call_load_ipython_extension(mod):
                 self.loaded.add(module_str)
@@ -155,13 +149,3 @@ class ExtensionManager(Configurable):
         if hasattr(mod, 'unload_ipython_extension'):
             mod.unload_ipython_extension(self.shell)
             return True
-
-    @undoc
-    def install_extension(self, url, filename=None):
-        """
-        Deprecated.
-        """
-        # Ensure the extension directory exists
-        raise DeprecationWarning(
-            '`install_extension` and the `install_ext` magic have been deprecated since IPython 4.0'
-            'Use pip or other package managers to manage ipython extensions.')

--- a/docs/source/config/extensions/index.rst
+++ b/docs/source/config/extensions/index.rst
@@ -6,8 +6,7 @@ IPython extensions
 
 A level above configuration are IPython extensions, Python modules which modify
 the behaviour of the shell. They are referred to by an importable module name,
-and can be placed anywhere you'd normally import from, or in
-``.ipython/extensions/``.
+and can be placed anywhere you'd normally import from.
 
 Getting extensions
 ==================
@@ -71,10 +70,7 @@ Useful :class:`InteractiveShell` methods include :meth:`~IPython.core.interactiv
    :ref:`defining_magics`
 
 You can put your extension modules anywhere you want, as long as they can be
-imported by Python's standard import mechanism. However, to make it easy to
-write extensions, you can also put your extensions in :file:`extensions/`
-within the :ref:`IPython directory <ipythondir>`. This directory is
-added to :data:`sys.path` automatically.
+imported by Python's standard import mechanism.
 
 When your extension is ready for general use, please add it to the `extensions
 index <https://github.com/ipython/ipython/wiki/Extensions-Index>`_. We also


### PR DESCRIPTION
As pointed out in #13722 loading extensions from this place have been
deprecated for about 5 years, so time for removal.

I understand this will likely make it too hard for some user who can't
seem to be able to write 8 lines of configuration:

    $ cat mod.py pyproject.toml
    """ipython ext"""
    __version__ = "0.0.1"
    [build-system]
    requires = ["flit_core >=3.2,<4"]
    build-backend = "flit_core.buildapi"

    [project]
    name = "mod"
    dynamic = ["version", "description"]

Those can be reminded that they can also modify their $PYTHONPATH, so
that py files can be imported from their preferred folder.