### PR TITLE
Move documentation requirements to setup.cfg

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -26,7 +26,7 @@ the following tools are needed to build the documentation:
 In a conda environment, or a Python 3 ``venv``, you should be able to run::
 
   cd ipython
-  pip install -U -r docs/requirements.txt
+  pip install .[doc] -U
 
 
 Build Commands

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,1 @@
--e .[test]
-ipykernel
-setuptools>=18.5
-sphinx
-sphinx-rtd-theme
-docrepr
-matplotlib
-stack_data
-pytest<7
+-e .[doc]

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,15 @@ install_requires =
 black =
     black
 doc =
-    Sphinx>=1.3
+    ipykernel
+    setuptools>=18.5
+    sphinx>=1.3
+    sphinx-rtd-theme
+    docrepr
+    matplotlib
+    stack_data
+    pytest<7
+    %(test)s
 kernel =
     ipykernel
 nbconvert =


### PR DESCRIPTION
When working on documentation I installed the required dependencies:

```
pip install ipython[doc]
```

but was surprised to see and error (`ModuleNotFoundError: No module named 'sphinx_rtd_theme'`) indicating that not all dependencies were in fact installed.

This PR moves all test dependencies to a single place.