### PR TITLE
Add no_traceback argument to :okexcept: option of ipython sphinx directive

### DIFF
--- a/IPython/lib/lexers.py
+++ b/IPython/lib/lexers.py
@@ -31,6 +31,7 @@ This includes:
 #-----------------------------------------------------------------------------
 
 # Standard library
+import builtins
 import re
 
 # Third party
@@ -255,8 +256,19 @@ class IPythonConsoleLexer(Lexer):
     in2_regex = r'   \.\.+\.: '
     out_regex = r'Out\[[0-9]+\]: '
 
-    #: The regex to determine when a traceback starts.
-    ipytb_start = re.compile(r'^(\^C)?(-+\n)|^(  File)(.*)(, line )(\d+\n)')
+    #: The regex to determine when a traceback or exception starts.
+    exceptions = [
+        name
+        for name, value in builtins.__dict__.items()
+        if isinstance(value, type)
+        and issubclass(value, Exception)
+        and not issubclass(value, Warning)
+    ]
+    ipytb_start = re.compile(
+        r"^(\^C)?(-+\n)|^(  File)(.*)(, line )(\d+\n)|^("
+        + "|".join(exceptions)
+        + r"): \S.*\n"
+    )
 
     def __init__(self, **options):
         """Initialize the IPython console lexer.

--- a/IPython/lib/tests/test_lexers.py
+++ b/IPython/lib/tests/test_lexers.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from pygments import __version__ as pygments_version
 from pygments.token import Token
 from pygments.lexers import BashLexer
+import pytest
 
 from .. import lexers
 
@@ -182,3 +183,42 @@ class TestLexers(TestCase):
             (Token.Text, '\n'),
         ]
         assert tokens == list(self.lexer.get_tokens(fragment))
+
+
+@pytest.mark.parametrize(
+    "fragment,expected",
+    [
+        (
+            "---\nZeroDivisionError: division by zero\n",
+            [
+                (Token.Generic.Output, ""),
+                (Token.Generic.Traceback, "---\n"),
+                (Token.Name.Exception, "ZeroDivisionError"),
+                (Token.Text, ": division by zero\n"),
+            ],
+        ),
+        (
+            '  File "x.py", line 1\nSyntaxError: xxx',
+            [
+                (Token.Generic.Output, ""),
+                (Token.Generic.Traceback, "  File"),
+                (Token.Name.Namespace, ' "x.py"'),
+                (Token.Generic.Traceback, ", line "),
+                (Token.Literal.Number.Integer, "1\n"),
+                (Token.Name.Exception, "SyntaxError"),
+                (Token.Text, ": xxx\n"),
+            ],
+        ),
+        (
+            "ZeroDivisionError: division by zero",
+            [
+                (Token.Generic.Output, ""),
+                (Token.Name.Exception, "ZeroDivisionError"),
+                (Token.Text, ": division by zero\n"),
+            ],
+        ),
+    ],
+    ids=["exception traceback", "syntax error traceback", "no traceback"],
+)
+def test_IPythonConsoleLexer(fragment, expected):
+    assert expected == list(lexers.IPythonConsoleLexer().get_tokens(fragment))

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -139,8 +139,6 @@ An example usage of the directive is:
 
         In [3]: print(y)
 
-See http://matplotlib.org/sampledoc/ipython_directive.html for additional
-documentation.
 
 Pseudo-Decorators
 =================

--- a/docs/source/sphinxext.rst
+++ b/docs/source/sphinxext.rst
@@ -62,9 +62,10 @@ The IPython directive takes a number of options detailed here.
 
       Used to indicate that the relevant code block does not have IPython prompts.
 
-   .. rst:directive:option:: okexcept
+   .. rst:directive:option:: okexcept [no_traceback]
 
-      Allow the code block to raise an exception.
+      Allow the code block to raise an exception. When the `no_traceback` argument
+      is given, only the exception without the traceback will be printed.
 
    .. rst:directive:option:: okwarning
 
@@ -82,7 +83,7 @@ The IPython directive takes a number of options detailed here.
 
       Save output from matplotlib to *outfile*.
 
-It's important to note that all of these options can be used for the entire
+It's important to note that most of these options can be used for the entire
 directive block or they can decorate individual lines of code as explained
 in :ref:`pseudo-decorators`.
 
@@ -477,6 +478,15 @@ line just below them (eg ``savefig``).
     generated at doc build time, and raise errors if they don't
     match. Also, can be applied to the entire ``.. ipython`` block as a
     directive option with ``:doctest:``.
+
+@okexcept [no_traceback]
+
+    Allow the decorated line of code to raise an exception. IPython prints
+    and formats the traceback unless the ``no_traceback`` argument is given.
+    In this case, only the exception without the traceback is printed.
+    Also, can be applied to the entire ``.. ipython`` block as a
+    directive option with ``:okexcept:``.
+
 
 Configuration Options
 =====================

--- a/docs/source/whatsnew/pr/no_traceback-argument.rst
+++ b/docs/source/whatsnew/pr/no_traceback-argument.rst
@@ -1,0 +1,6 @@
+no_traceback argument to :okexcept: option
+==========================================
+
+The ``:okexcept:`` option of the ``.. ipython::`` directive can now have an
+optional argument ``no_traceback`` that prevents printing of the (potentially
+long) traceback. Only the exception is printed in this case.


### PR DESCRIPTION
- add optional `no_traceback` argument to `:ok_except:` which prevents the (sometimes long) traceback from being printed, default is no argument, i.e. traceback is printed
- enable `@okexcept` pseudodecorator so that it can be applied to individual instructions instead of the whole block
- adjust `IPythonConsoleLexer` so that it formats exceptions without preceding traceback as usual, add tests for this
- apply `darker` to this commit
- document the new argument

See also #8686, https://github.com/pandas-dev/pandas/pull/47846 and [pandas-dev/pandas/#48394](https://github.com/pandas-dev/pandas/pull/48394#issuecomment-1240617842).   
[This demo](https://github.com/StefRe/no_traceback) shows a minimal example.

~~(TODO: describe `@okexcept` in https://matplotlib.org/sampledoc/ipython_directive.html if this PR is goes in)~~
Edit 16.09.22: no need to update `sampledoc` as Matplotlib decided not to publish or maintain this document anymore, see https://github.com/matplotlib/sampledoc/issues/26#issuecomment-1249382037