### PR TITLE
MAINT: Nep 29- drop support for Numpy 1.19.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ test_extra =
     curio
     matplotlib!=3.2.0
     nbformat
-    numpy>=1.19
+    numpy>=1.20
     pandas
     trio
 all =


### PR DESCRIPTION
> On Jun 21, 2022 drop support for NumPy 1.19 (initially released on Jun 20, 2020)