### PR TITLE
Fix doc for `IPython.display.TextDisplayObject` (#13770)

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -389,7 +389,19 @@ class DisplayObject(object):
 
 
 class TextDisplayObject(DisplayObject):
-    """Validate that display data is text"""
+    """Create a text display object given raw data.
+
+    Parameters
+    ----------
+    data : str or unicode
+        The raw data or a URL or file to load the data from.
+    url : unicode
+        A URL to download the data from.
+    filename : unicode
+        Path to a local file to load the data from.
+    metadata : dict
+        Dict of metadata associated to be the object when displayed
+    """
     def _check_data(self):
         if self.data is not None and not isinstance(self.data, str):
             raise TypeError("%s expects text, not %r" % (self.__class__.__name__, self.data))


### PR DESCRIPTION
Fixes: #13770

Since [`HTML`](https://github.com/ipython/ipython/blob/dc08a337f568ce179a88b83fdcf6ebb4158dfdb5/IPython/core/display.py#L403) class inherits from [`TextDisplayObject`](https://github.com/ipython/ipython/blob/dc08a337f568ce179a88b83fdcf6ebb4158dfdb5/IPython/core/display.py#L391) which includes a [`check`](https://github.com/ipython/ipython/blob/dc08a337f568ce179a88b83fdcf6ebb4158dfdb5/IPython/core/display.py#L393-L395) to only allow string type which is not included in the [`doc`](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html?highlight=TextDisplayObject#IPython.display.HTML) added the information