### PR TITLE
Support square bracket indexing with literal with pinfo/?/pinfo2/??

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -432,12 +432,14 @@ class EscapedCommand(TokenTransformBase):
 
 _help_end_re = re.compile(
     r"""(%{0,2}
-                              (?!\d)[\w*]+            # Variable name
-                              (\.(?!\d)[\w*]+|\[[0-9]+\])*       # .etc.etc or [0], we only support literal integers.
-                              )
-                              (\?\??)$                # ? or ??
-                              """,
-                              re.VERBOSE)
+    (?!\d)[\w*]+            # Variable name
+    (\.(?!\d)[\w*]+|\[-?[0-9]+\])*       # .etc.etc or [0], we only support literal integers.
+    )
+    (\?\??)$                # ? or ??
+    """,
+    re.VERBOSE,
+)
+
 
 class HelpEnd(TokenTransformBase):
     """Transformer for help syntax: obj? and obj??"""

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -429,9 +429,11 @@ class EscapedCommand(TokenTransformBase):
 
         return lines_before + [new_line] + lines_after
 
-_help_end_re = re.compile(r"""(%{0,2}
+
+_help_end_re = re.compile(
+    r"""(%{0,2}
                               (?!\d)[\w*]+            # Variable name
-                              (\.(?!\d)[\w*]+)*       # .etc.etc
+                              (\.(?!\d)[\w*]+|\[[0-9]+\])*       # .etc.etc or [0], we only support literal integers.
                               )
                               (\?\??)$                # ? or ??
                               """,
@@ -464,10 +466,11 @@ class HelpEnd(TokenTransformBase):
     def transform(self, lines):
         """Transform a help command found by the ``find()`` classmethod.
         """
-        piece = ''.join(lines[self.start_line:self.q_line+1])
-        indent, content = piece[:self.start_col], piece[self.start_col:]
-        lines_before = lines[:self.start_line]
-        lines_after = lines[self.q_line + 1:]
+
+        piece = "".join(lines[self.start_line : self.q_line + 1])
+        indent, content = piece[: self.start_col], piece[self.start_col :]
+        lines_before = lines[: self.start_line]
+        lines_after = lines[self.q_line + 1 :]
 
         m = _help_end_re.search(content)
         if not m:
@@ -543,8 +546,13 @@ def has_sunken_brackets(tokens: List[tokenize.TokenInfo]):
 
 def show_linewise_tokens(s: str):
     """For investigation and debugging"""
-    if not s.endswith('\n'):
-        s += '\n'
+    warnings.warn(
+        "show_linewise_tokens is deprecated since IPython 8.6",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if not s.endswith("\n"):
+        s += "\n"
     lines = s.splitlines(keepends=True)
     for line in make_tokens_by_line(lines):
         print("Line -------")

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -147,7 +147,8 @@ dedent_re = re.compile(r'^\s+raise|^\s+return|^\s+pass')
 # Utilities
 #-----------------------------------------------------------------------------
 
-def is_integer_string(s:str):
+
+def is_integer_string(s: str):
     """
     Variant of "str.isnumeric()" that allow negative values and other ints.
     """
@@ -156,7 +157,8 @@ def is_integer_string(s:str):
         return True
     except ValueError:
         return False
-    raise ValueError('Unexpected error')
+    raise ValueError("Unexpected error")
+
 
 @undoc
 def softspace(file, newvalue):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -147,6 +147,17 @@ dedent_re = re.compile(r'^\s+raise|^\s+return|^\s+pass')
 # Utilities
 #-----------------------------------------------------------------------------
 
+def is_integer_string(s:str):
+    """
+    Variant of "str.isnumeric()" that allow negative values and other ints.
+    """
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False
+    raise ValueError('Unexpected error')
+
 @undoc
 def softspace(file, newvalue):
     """Copied from code.py, to remove the dependency"""
@@ -1548,7 +1559,7 @@ class InteractiveShell(SingletonConfigurable):
                     break
                 parts.append(var)
                 for ind in indices:
-                    if ind[-1] != "]" and not ind[:-1].isnumeric():
+                    if ind[-1] != "]" and not is_integer_string(ind[:-1]):
                         parts_ok = False
                         break
                     parts.append(ind[:-1])
@@ -1602,7 +1613,7 @@ class InteractiveShell(SingletonConfigurable):
                         if idx == len(oname_rest) - 1:
                             obj = self._getattr_property(obj, part)
                         else:
-                            if part.isnumeric():
+                            if is_integer_string(part):
                                 obj = obj[int(part)]
                             else:
                                 obj = getattr(obj, part)
@@ -1669,7 +1680,7 @@ class InteractiveShell(SingletonConfigurable):
                 #
                 # The universal alternative is to traverse the mro manually
                 # searching for attrname in class dicts.
-                if attrname.isnumeric():
+                if is_integer_string(attrname):
                     return obj[int(attrname)]
                 else:
                     attr = getattr(type(obj), attrname)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -213,17 +213,14 @@ class ExecutionInfo(object):
         raw_cell = (
             (self.raw_cell[:50] + "..") if len(self.raw_cell) > 50 else self.raw_cell
         )
-        return (
-            '<%s object at %x, raw_cell="%s" store_history=%s silent=%s shell_futures=%s cell_id=%s>'
-            % (
-                name,
-                id(self),
-                raw_cell,
-                self.store_history,
-                self.silent,
-                self.shell_futures,
-                self.cell_id,
-            )
+        return '<%s object at %x, raw_cell="%s" store_history=%s silent=%s shell_futures=%s cell_id=%s>' % (
+            name,
+            id(self),
+            raw_cell,
+            self.store_history,
+            self.silent,
+            self.shell_futures,
+            self.cell_id,
         )
 
 

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -395,6 +395,19 @@ def test_qmark_getindex():
             ip.run_cell("container[0]?")
     assert "container" not in ip.user_ns.keys()
 
+def test_qmark_getindex_negatif():
+    def dummy():
+        """
+        MARKER 3
+        """
+
+    container = [dummy]
+    with cleanup_user_ns(container=container):
+        with AssertPrints("MARKER 3"):
+            ip.run_cell("container[-1]?")
+    assert "container" not in ip.user_ns.keys()
+
+
 
 def test_pinfo_nonascii():
     # See gh-1177

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -395,6 +395,7 @@ def test_qmark_getindex():
             ip.run_cell("container[0]?")
     assert "container" not in ip.user_ns.keys()
 
+
 def test_qmark_getindex_negatif():
     def dummy():
         """

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 
+from contextlib import contextmanager
 from inspect import signature, Signature, Parameter
 import inspect
 import os
@@ -43,7 +44,7 @@ class SourceModuleMainTest:
 # defined, if any code is inserted above, the following line will need to be
 # updated.  Do NOT insert any whitespace between the next line and the function
 # definition below.
-THIS_LINE_NUMBER = 46  # Put here the actual number of this line
+THIS_LINE_NUMBER = 47  # Put here the actual number of this line
 
 
 def test_find_source_lines():
@@ -343,6 +344,56 @@ def test_pdef():
     # See gh-1914
     def foo(): pass
     inspector.pdef(foo, 'foo')
+
+
+@contextmanager
+def cleanup_user_ns(**kwargs):
+    """
+    On exit delete all the keys that were not in user_ns before entering.
+
+    It does not restore old values !
+
+    Parameters
+    ----------
+
+    **kwargs
+        used to update ip.user_ns
+
+    """
+    try:
+        known = set(ip.user_ns.keys())
+        ip.user_ns.update(kwargs)
+        yield
+    finally:
+        added = set(ip.user_ns.keys()) - known
+        for k in added:
+            del ip.user_ns[k]
+
+
+def test_pinfo_getindex():
+    def dummy():
+        """
+        MARKER
+        """
+
+    container = [dummy]
+    with cleanup_user_ns(container=container):
+        with AssertPrints("MARKER"):
+            ip._inspect("pinfo", "container[0]", detail_level=0)
+    assert "container" not in ip.user_ns.keys()
+
+
+def test_qmark_getindex():
+    def dummy():
+        """
+        MARKER 2
+        """
+
+    container = [dummy]
+    with cleanup_user_ns(container=container):
+        with AssertPrints("MARKER 2"):
+            ip.run_cell("container[0]?")
+    assert "container" not in ip.user_ns.keys()
 
 
 def test_pinfo_nonascii():

--- a/IPython/testing/plugin/pytest_ipdoctest.py
+++ b/IPython/testing/plugin/pytest_ipdoctest.py
@@ -782,7 +782,7 @@ def _init_checker_class() -> Type["IPDoctestOutputChecker"]:
                 precision = 0 if fraction is None else len(fraction)
                 if exponent is not None:
                     precision -= int(exponent)
-                if float(w.group()) == approx(float(g.group()), abs=10 ** -precision):
+                if float(w.group()) == approx(float(g.group()), abs=10**-precision):
                     # They're close enough. Replace the text we actually
                     # got with the text we want, so that it will match when we
                     # check the string literally.

--- a/IPython/testing/plugin/pytest_ipdoctest.py
+++ b/IPython/testing/plugin/pytest_ipdoctest.py
@@ -782,7 +782,7 @@ def _init_checker_class() -> Type["IPDoctestOutputChecker"]:
                 precision = 0 if fraction is None else len(fraction)
                 if exponent is not None:
                     precision -= int(exponent)
-                if float(w.group()) == approx(float(g.group()), abs=10**-precision):
+                if float(w.group()) == approx(float(g.group()), abs=10 ** -precision):
                     # They're close enough. Replace the text we actually
                     # got with the text we want, so that it will match when we
                     # check the string literally.


### PR DESCRIPTION
We add limited support for evaluating `[xxx]` where xxx is a numeric literal. This still abit dangerous as __getindex__ can run arbitrary code.

We could support a wider range of constructs, but this would start to reach into complex and dangerous territory. Alredy this with lead to weird suff like
```
   >>> def foo(*arg, **kwargs):pass
   >>> c = [foo]
   >>> c[0]?
   Signature: c[0](*args, **kwargs)
```
Instead of
```
   >>> c[0]?
   Signature: foo(*args, **kwargs)
```
As the name of the object is used in the signature is the one if the main namespace.

This should fix https://github.com/ipython/ipython/issues/13780