### PR TITLE
Use SPDX license expression in project metadata

### DIFF
--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -36,7 +36,7 @@ version_info = (_version_major, _version_minor, _version_patch, _version_extra)
 kernel_protocol_version_info = (5, 0)
 kernel_protocol_version = "%i.%i" % kernel_protocol_version_info
 
-license = 'BSD'
+license = 'BSD-3-Clause'
 
 authors = {'Fernando' : ('Fernando Perez','fperez.net@gmail.com'),
            'Janko'    : ('Janko Hauser','jhauser@zscout.de'),


### PR DESCRIPTION
As a downstream user it is desirable to be able to programmatically determine the precise licenses used by our dependencies. The emerging convention for this is the [SPDX License List](https://spdx.org/licenses/). SPDX License Expressions are already used in the JavaScript (npm) and Rust (crates.io) ecosystems, for example.

In Python, there is [PEP 639](https://peps.python.org/pep-0639/) which would add a standard 'License-Expression' metadata field. The discussion around this PEP seems to have gone stale in 2021.

This merge request is in lieu of that PEP coming soon. Unless you as project maintainers think the proposed change in this PR has downsides (which you are entitled to!), I would ask that you accept this change so that it's possible for users to attempt to parse your license metadata as an SPDX License Expression. In particular, BSD is ambiguous as there are multiple BSD licenses.

If PEP 639 is accepted, this package would be ready for the change just by changing the `license` key in `setupbase.py` to `license_expression` or whatever key the PEP lands on.