### PR TITLE
Make the formatting of a code block name extendable

### DIFF
--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -116,6 +116,21 @@ class CachingCompiler(codeop.Compile):
         """
         return code_name(transformed_code, number)
 
+    def format_code_name(self, name):
+        """Return a user-friendly label and name for a code block.
+
+        Parameters
+        ----------
+        name : str
+            The name for the code block returned from get_code_name
+
+        Returns
+        -------
+        A (label, name) pair that can be used in tracebacks, or None if the default formatting should be used.
+        """
+        if name in self._filename_map:
+            return "Cell", "In[%s]" % self._filename_map[name]
+
     def cache(self, transformed_code, number=0, raw_code=None):
         """Make a name for a block of code, and cache the code.
 


### PR DESCRIPTION
Currently the user display of a code block requires a tight coupling between the caching compiler and the ultratb file, i.e., ultratb needs to know internal private variables of the caching compiler. This change makes the user-visible display of the code block name the responsibility of the caching compiler, separating the API more cleanly. A nice result is that the caching compiler can be overridden to have custom terminology in different systems for code blocks executed (for example, in Databricks the "cells" are currently known as "commands".)

I tried to strike a nice balance here between maintaining the existing format exactly and the API of the new method. I think it is a bit weird that the line number formatting is different for files vs cached code blocks (`X, line Y` vs `X:Y`). Do we need to preserve the `X:Y` formatting for automated tools that expect exactly that form for file line numbers?

