### PR TITLE
Filter out new jupyter_core deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -46,3 +46,5 @@ addopts = --durations=10
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 ipdoctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS
 asyncio_mode = strict
+filterwarnings =
+    module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning


### PR DESCRIPTION
Jupyter_core 5.0 has a new deprecation warning that shows by default and halts our CI tests.

See https://github.com/jupyter/jupyter_core/issues/310