### PR TITLE
Pin minimum prompt-toolkit to 3.0.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     matplotlib-inline
     pexpect>4.3; sys_platform != "win32"
     pickleshare
-    prompt_toolkit>3.0.1,<3.1.0
+    prompt_toolkit>=3.0.11,<3.1.0
     pygments>=2.4.0
     stack_data
     traitlets>=5


### PR DESCRIPTION
Fixes #13631.

`3.0.11` is the first `prompt-tookit` version which fixes the bug related to scrolling through IPython command history.