### PR TITLE
Reused the previously unused find_entry_points in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -106,9 +106,6 @@ IPython.lib.tests = *.wav
 IPython.testing.plugin = *.txt
 
 [options.entry_points]
-console_scripts =
-    ipython = IPython:start_ipython
-    ipython3 = IPython:start_ipython
 pygments.lexers =
     ipythonconsole = IPython.lib.lexers:IPythonConsoleLexer
     ipython = IPython.lib.lexers:IPythonLexer

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ from setuptools import setup
 # Our own imports
 sys.path.insert(0, ".")
 
-from setupbase import target_update
+from setupbase import target_update, find_entry_points
 
 from setupbase import (
     setup_args,
@@ -138,6 +138,9 @@ setup_args['cmdclass'] = {
     'install_lib_symlink': install_lib_symlink,
     'install_scripts_sym': install_scripts_for_symlink,
     'unsymlink': unsymlink,
+}
+setup_args["entry_points"] = {
+    "console_scripts": find_entry_points()
 }
 
 #---------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -139,9 +139,7 @@ setup_args['cmdclass'] = {
     'install_scripts_sym': install_scripts_for_symlink,
     'unsymlink': unsymlink,
 }
-setup_args["entry_points"] = {
-    "console_scripts": find_entry_points()
-}
+setup_args["entry_points"] = {"console_scripts": find_entry_points()}
 
 #---------------------------------------------------------------------------
 # Do the actual setup now


### PR DESCRIPTION
In continuation to #13743. It seems that the function was unused and therefore the changes I've made did not cause the new entry point to be added. This fix should solve #13815.

Unfortunately, since setup.cfg does not support dynamic name for entrypoints (name based on sys.version_info), I had to bring that configuration back to setup.py and reuse the function. 
