### PR TITLE
Fix codecov coverage uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,7 @@ jobs:
       run: |
         pytest --color=yes -raXxs ${{ startsWith(matrix.python-version, 'pypy') && ' ' || '--cov --cov-report=xml' }}
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
+      with:
+         name: Test
+         files: /home/runner/work/ipython/ipython/coverage.xml


### PR DESCRIPTION
Fixes #13853. The `coverage.xml` from test was not being picked up by codecov uploader. It seems to be a common occurrence. Providing a full path to the file fixes the issue. The coverage is now back at 73.02%.