### PR TITLE
Add py.typed to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,7 @@ exclude =
     setupext
 
 [options.package_data]
+IPython = py.typed
 IPython.core = profile/README*
 IPython.core.tests = *.png, *.jpg, daft_extension/*.py
 IPython.lib.tests = *.wav


### PR DESCRIPTION
This makes py.typed actually get copied to the site-packages folder, which is necessary to enable typechecking on non-editable installs!