### PR TITLE
Fix vi mode escape delay

### DIFF
--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -68,9 +68,14 @@ def create_ipython_shortcuts(shell):
         reformat_text_before_cursor(event.current_buffer, event.current_buffer.document, shell)
         event.current_buffer.validate_and_handle()
 
+    @Condition
+    def ebivim():
+        return shell.emacs_bindings_in_vi_insert_mode
+
     kb.add('escape', 'enter', filter=(has_focus(DEFAULT_BUFFER)
                             & ~has_selection
                             & insert_mode
+                            & ebivim
                                       ))(reformat_and_execute)
 
     kb.add("c-\\")(quit)
@@ -332,10 +337,6 @@ def create_ipython_shortcuts(shell):
 
     if sys.platform == "win32":
         kb.add("c-v", filter=(has_focus(DEFAULT_BUFFER) & ~vi_mode))(win_paste)
-
-    @Condition
-    def ebivim():
-        return shell.emacs_bindings_in_vi_insert_mode
 
     focused_insert_vi = has_focus(DEFAULT_BUFFER) & vi_insert_mode
 

--- a/IPython/terminal/shortcuts.py
+++ b/IPython/terminal/shortcuts.py
@@ -72,11 +72,11 @@ def create_ipython_shortcuts(shell):
     def ebivim():
         return shell.emacs_bindings_in_vi_insert_mode
 
-    kb.add('escape', 'enter', filter=(has_focus(DEFAULT_BUFFER)
-                            & ~has_selection
-                            & insert_mode
-                            & ebivim
-                                      ))(reformat_and_execute)
+    kb.add(
+        "escape",
+        "enter",
+        filter=(has_focus(DEFAULT_BUFFER) & ~has_selection & insert_mode & ebivim),
+    )(reformat_and_execute)
 
     kb.add("c-\\")(quit)
 


### PR DESCRIPTION
Resolves https://github.com/ipython/ipython/issues/13443

This is an implementation of @minjae's workaround described in https://github.com/ipython/ipython/issues/13443#issuecomment-1172097730

This should fix the vi mode escape delay as long as the user has `c.TerminalInteractiveShell.emacs_bindings_in_vi_insert_mode = False` in their ipython config.