### PR TITLE
Refactor inspect info reply logic

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -588,7 +588,7 @@ class Inspector(Colorable):
             bundle["text/plain"].append((title, formatted_field["text/plain"]))
             bundle["text/html"].append((title, formatted_field["text/html"]))
 
-    def _make_info_unformatted(self, info, formatter, detail_level, omit_sections):
+    def _make_info_unformatted(self, obj, info, formatter, detail_level, omit_sections):
         """Assemble the mimebundle as unformatted lists of information"""
         bundle = {
             "text/plain": [],
@@ -685,7 +685,7 @@ class Inspector(Colorable):
 
         info = self.info(obj, oname=oname, info=info, detail_level=detail_level)
         bundle = self._make_info_unformatted(
-            info, formatter, detail_level=detail_level, omit_sections=omit_sections
+            obj, info, formatter, detail_level=detail_level, omit_sections=omit_sections
         )
         return self.format_mime(bundle)
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -531,8 +531,8 @@ class Inspector(Colorable):
 
         """
         defaults = {
-            'text/plain': text,
-            'text/html': '<pre>' + html.escape(text) + '</pre>'
+            "text/plain": text,
+            "text/html": f"<pre>{html.escape(text)}</pre>",
         }
 
         if formatter is None:
@@ -543,10 +543,7 @@ class Inspector(Colorable):
             if not isinstance(formatted, dict):
                 # Handle the deprecated behavior of a formatter returning
                 # a string instead of a mime bundle.
-                return {
-                    'text/plain': formatted,
-                    'text/html': '<pre>' + formatted + '</pre>'
-                }
+                return {"text/plain": formatted, "text/html": f"<pre>{formatted}</pre>"}
 
             else:
                 return dict(defaults, **formatted)

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -16,6 +16,7 @@ __all__ = ['Inspector','InspectColors']
 import ast
 import inspect
 from inspect import signature
+import html
 import linecache
 import warnings
 import os
@@ -531,7 +532,7 @@ class Inspector(Colorable):
         """
         defaults = {
             'text/plain': text,
-            'text/html': '<pre>' + text + '</pre>'
+            'text/html': '<pre>' + html.escape(text) + '</pre>'
         }
 
         if formatter is None:

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -554,44 +554,57 @@ class Inspector(Colorable):
     def format_mime(self, bundle):
         """Format a mimebundle being created by _make_info_unformatted into a real mimebundle"""
         # Format text/plain mimetype
-        if isinstance(bundle['text/plain'], (list, tuple)):
+        if isinstance(bundle["text/plain"], (list, tuple)):
             # bundle['text/plain'] is a list of (head, formatted body) pairs
             lines = []
-            _len = max(len(h) for h,_ in bundle['text/plain'])
+            _len = max(len(h) for h, _ in bundle["text/plain"])
 
-            for head, body in bundle['text/plain']:
-                body = body.strip('\n')
-                delim = '\n' if '\n' in body else ' '
-                lines.append(f"{self.__head(head+':')}{(_len - len(head))*' '}{delim}{body}")
+            for head, body in bundle["text/plain"]:
+                body = body.strip("\n")
+                delim = "\n" if "\n" in body else " "
+                lines.append(
+                    f"{self.__head(head+':')}{(_len - len(head))*' '}{delim}{body}"
+                )
 
-            bundle['text/plain'] = '\n'.join(lines)
+            bundle["text/plain"] = "\n".join(lines)
 
         # Format the text/html mimetype
-        if isinstance(bundle['text/html'], (list, tuple)):
+        if isinstance(bundle["text/html"], (list, tuple)):
             # bundle['text/html'] is a list of (head, formatted body) pairs
-            bundle['text/html'] = '\n'.join((f'<h1>{head}</h1>\n{body}' for (head,body) in bundle['text/html']))
+            bundle["text/html"] = "\n".join(
+                (f"<h1>{head}</h1>\n{body}" for (head, body) in bundle["text/html"])
+            )
         return bundle
 
-    def _append_info_field(self, bundle, title:str, key:str, info, omit_sections, formatter):
+    def _append_info_field(
+        self, bundle, title: str, key: str, info, omit_sections, formatter
+    ):
         """Append an info value to the unformatted mimebundle being constructed by _make_info_unformatted"""
         if title in omit_sections or key in omit_sections:
             return
         field = info[key]
         if field is not None:
             formatted_field = self._mime_format(field, formatter)
-            bundle['text/plain'].append((title, formatted_field['text/plain']))
-            bundle['text/html'].append((title, formatted_field['text/html']))
+            bundle["text/plain"].append((title, formatted_field["text/plain"]))
+            bundle["text/html"].append((title, formatted_field["text/html"]))
 
     def _make_info_unformatted(self, info, formatter, detail_level, omit_sections):
         """Assemble the mimebundle as unformatted lists of information"""
         bundle = {
-            'text/plain': [],
-            'text/html': [],
+            "text/plain": [],
+            "text/html": [],
         }
 
         # A convenience function to simplify calls below
-        def append_field(bundle, title:str, key:str, formatter=None):
-            self._append_info_field(bundle, title=title, key=key, info=info, omit_sections=omit_sections, formatter=formatter)
+        def append_field(bundle, title: str, key: str, formatter=None):
+            self._append_info_field(
+                bundle,
+                title=title,
+                key=key,
+                info=info,
+                omit_sections=omit_sections,
+                formatter=formatter,
+            )
 
         def code_formatter(text):
             return {
@@ -599,54 +612,54 @@ class Inspector(Colorable):
                 'text/html': pylight(text)
             }
 
-        if info['isalias']:
-            append_field(bundle, 'Repr', 'string_form')
+        if info["isalias"]:
+            append_field(bundle, "Repr", "string_form")
 
         elif info['ismagic']:
             if detail_level > 0:
-                append_field(bundle, 'Source', 'source', code_formatter)
+                append_field(bundle, "Source", "source", code_formatter)
             else:
-                append_field(bundle, 'Docstring', 'docstring', formatter)
-            append_field(bundle, 'File', 'file')
+                append_field(bundle, "Docstring", "docstring", formatter)
+            append_field(bundle, "File", "file")
 
         elif info['isclass'] or is_simple_callable(obj):
             # Functions, methods, classes
-            append_field(bundle, 'Signature', 'definition', code_formatter)
-            append_field(bundle, 'Init signature', 'init_definition', code_formatter)
-            append_field(bundle, 'Docstring', 'docstring', formatter)
-            if detail_level > 0 and info['source']:
-                append_field(bundle, 'Source', 'source', code_formatter)
+            append_field(bundle, "Signature", "definition", code_formatter)
+            append_field(bundle, "Init signature", "init_definition", code_formatter)
+            append_field(bundle, "Docstring", "docstring", formatter)
+            if detail_level > 0 and info["source"]:
+                append_field(bundle, "Source", "source", code_formatter)
             else:
-                append_field(bundle, 'Init docstring', 'init_docstring', formatter)
+                append_field(bundle, "Init docstring", "init_docstring", formatter)
 
-            append_field(bundle, 'File', 'file')
-            append_field(bundle, 'Type', 'type_name')
-            append_field(bundle, 'Subclasses', 'subclasses')
+            append_field(bundle, "File", "file")
+            append_field(bundle, "Type", "type_name")
+            append_field(bundle, "Subclasses", "subclasses")
 
         else:
             # General Python objects
-            append_field(bundle, 'Signature', 'definition', code_formatter)
-            append_field(bundle, 'Call signature', 'call_def', code_formatter)
-            append_field(bundle, 'Type', 'type_name')
-            append_field(bundle, 'String form', 'string_form')
+            append_field(bundle, "Signature", "definition", code_formatter)
+            append_field(bundle, "Call signature", "call_def", code_formatter)
+            append_field(bundle, "Type", "type_name")
+            append_field(bundle, "String form", "string_form")
 
             # Namespace
-            if info['namespace'] != 'Interactive':
-                append_field(bundle, 'Namespace', 'namespace')
+            if info["namespace"] != "Interactive":
+                append_field(bundle, "Namespace", "namespace")
 
-            append_field(bundle, 'Length', 'length')
-            append_field(bundle, 'File', 'file')
+            append_field(bundle, "Length", "length")
+            append_field(bundle, "File", "file")
 
             # Source or docstring, depending on detail level and whether
             # source found.
-            if detail_level > 0 and info['source']:
-                append_field(bundle, 'Source', 'source', code_formatter)
+            if detail_level > 0 and info["source"]:
+                append_field(bundle, "Source", "source", code_formatter)
             else:
-                append_field(bundle, 'Docstring', 'docstring', formatter)
+                append_field(bundle, "Docstring", "docstring", formatter)
 
-            append_field(bundle, 'Class docstring', 'class_docstring', formatter)
-            append_field(bundle, 'Init docstring', 'init_docstring', formatter)
-            append_field(bundle, 'Call docstring', 'call_docstring', formatter)
+            append_field(bundle, "Class docstring", "class_docstring", formatter)
+            append_field(bundle, "Init docstring", "init_docstring", formatter)
+            append_field(bundle, "Call docstring", "call_docstring", formatter)
         return bundle
 
 
@@ -671,7 +684,9 @@ class Inspector(Colorable):
         """
 
         info = self.info(obj, oname=oname, info=info, detail_level=detail_level)
-        bundle = self._make_info_unformatted(info, formatter, detail_level=detail_level, omit_sections=omit_sections)
+        bundle = self._make_info_unformatted(
+            info, formatter, detail_level=detail_level, omit_sections=omit_sections
+        )
         return self.format_mime(bundle)
 
     def pinfo(


### PR DESCRIPTION
This refactors the logic of the inspector `_get_info` function to make it easier to override and extend its behavior. This PR should not affect the overall function of `_get_info`.

We factor out the logic to append an info field to the inspect_reply mimebundle and the logic for what information is in the mimebundle into separate functions that can easily be overridden by an inspector subclass. This allows a subclass to easily:

* format information into yet another mimetype besides text/plain and text/html
* modify or add to the default information

without having to copy the default implementation.

We also refactor and simplify the logic around formatting text/plain and text/html mimetypes in the inspect reply.

We also fix an escaping bug with the default html formatter so that the default docstrings `<no docstring>` appears instead of being interpreted as an HTML tag.