### PR TITLE
Fix paste/cpaste magic

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3138,8 +3138,12 @@ class InteractiveShell(SingletonConfigurable):
             else:
                 cell = raw_cell
 
+        # Do NOT store paste/cpaste magic history
+        if "get_ipython().run_line_magic(" in cell and "paste" in cell:
+            store_history = False
+
         # Store raw and processed history
-        if store_history and raw_cell.strip(" %") != "paste":
+        if store_history:
             self.history_manager.store_inputs(self.execution_count, cell, raw_cell)
         if not silent:
             self.logger.log(cell, raw_cell)

--- a/IPython/terminal/magics.py
+++ b/IPython/terminal/magics.py
@@ -147,7 +147,7 @@ class TerminalMagics(Magics):
 
         sentinel = opts.get('s', u'--')
         block = '\n'.join(get_pasted_lines(sentinel, quiet=quiet))
-        self.store_or_execute(block, name, store_history=False)
+        self.store_or_execute(block, name, store_history=True)
 
     @line_magic
     def paste(self, parameter_s=''):


### PR DESCRIPTION

## Description

Fixes followings:
* `%paste` breaks the input history (`In`) index
* `%paste -q` occurs a database error
* `%paste` is not stored but others are stored in the history
* `%cpaste` does not store its content in the history

Closes #13835
Closes #13829

## Changes

* `%paste -q`, `%cpaste`, `%cpaste -q` does not store itself in the history

## Notes

### Actual Behavior

| magic      | count | store <br> magic | store <br> block | error |
| ---------- | ----: | :-: | :-: | :-: |
| %paste     |    +1 |  no | yes |  no |
| %paste -q  |    +1 | yes | yes | yes |
| %cpaste    |     0 | yes |  no |  no |
| %cpaste -q |     0 | yes |  no |  no |

### Expected Behavior

| magic      | count | store <br> magic | store <br> block | error |
| ---------- | ----: | :----: | :-----: | :----: |
| %paste     | **0** |     no |     yes |     no |
| %paste -q  | **0** | **no** |     yes | **no** |
| %cpaste    |     0 | **no** | **yes** |     no |
| %cpaste -q |     0 | **no** | **yes** |     no |

## Reproductive

### Before this PR

#### `%paste`

```
(.venv) PS ipython> Set-Clipboard """Clipborard"""
(.venv) PS ipython> ipython
Python 3.11.1 (tags/v3.11.1:a7a450f, Dec  6 2022, 19:58:39) [MSC v.1934 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: %paste
"Clipborard"

## -- End pasted text --
Out[1]: 'Clipborard'

In [3]: %paste -q
Out[3]: 'Clipborard'

ERROR! Session/line number was not unique in database. History logging moved to new session 330
In [5]: from pprint import pprint; pprint(list(enumerate(In)))
[(0, ''),
 (1, '"Clipborard"'),
 (2, "get_ipython().run_line_magic('paste', '-q')"),
 (3, '"Clipborard"'),
 (4, 'from pprint import pprint; pprint(list(enumerate(In)))')]
```

#### `%cpaste`

```
(.venv) PS ipython> ipython
Python 3.11.1 (tags/v3.11.1:a7a450f, Dec  6 2022, 19:58:39) [MSC v.1934 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: %cpaste
Pasting code; enter '--' alone on the line to stop or use Ctrl-D.
:"Keyboard"
:--
Out[1]: 'Keyboard'

In [2]: %cpaste -q
"Keyboard2"
--
Out[2]: 'Keyboard2'

In [3]: from pprint import pprint; pprint(list(enumerate(In)))
[(0, ''),
 (1, "get_ipython().run_line_magic('cpaste', '')"),
 (2, "get_ipython().run_line_magic('cpaste', '-q')"),
 (3, 'from pprint import pprint; pprint(list(enumerate(In)))')]
```

### After this PR

#### `%paste`

```
(.venv) PS ipython> Set-Clipboard """Clipborard"""
(.venv) PS ipython> ipython
Python 3.11.1 (tags/v3.11.1:a7a450f, Dec  6 2022, 19:58:39) [MSC v.1934 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: %paste
"Clipborard"

## -- End pasted text --
Out[1]: 'Clipborard'    

In [2]: %paste -q
Out[2]: 'Clipborard'

In [3]: from pprint import pprint; pprint(list(enumerate(In)))
[(0, ''),
 (1, '"Clipborard"'),
 (2, '"Clipborard"'),
 (3, 'from pprint import pprint; pprint(list(enumerate(In)))')]
```

#### `%cpaste`

```
(.venv) PS ipython> ipython
Python 3.11.1 (tags/v3.11.1:a7a450f, Dec  6 2022, 19:58:39) [MSC v.1934 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: %cpaste
Pasting code; enter '--' alone on the line to stop or use Ctrl-D.
:"Keyboard"
:--
Out[1]: 'Keyboard'

In [2]: %cpaste -q
"Keyboard2"
--
Out[2]: 'Keyboard2'

In [3]: from pprint import pprint; pprint(list(enumerate(In)))
[(0, ''),
 (1, '"Keyboard"'),
 (2, '"Keyboard2"'),
 (3, 'from pprint import pprint; pprint(list(enumerate(In)))')]
```
