### PR TITLE
Removed the usage of minor-version entrypoints

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -218,10 +218,8 @@ def find_entry_points():
             'ipython%s = IPython:start_ipython',
         ]
     major_suffix = str(sys.version_info[0])
-    return (
-        [e % "" for e in ep]
-        + [e % major_suffix for e in ep]
-    )
+    return [e % "" for e in ep] + [e % major_suffix for e in ep]
+
 
 class install_lib_symlink(Command):
     user_options = [

--- a/setupbase.py
+++ b/setupbase.py
@@ -211,19 +211,16 @@ def find_entry_points():
     use, our own build_scripts_entrypt class below parses these and builds
     command line scripts.
 
-    Each of our entry points gets a plain name, e.g. ipython, a name
-    suffixed with the Python major version number, e.g. ipython3, and
-    a name suffixed with the Python major.minor version number, eg. ipython3.8.
+    Each of our entry points gets a plain name, e.g. ipython, and a name
+    suffixed with the Python major version number, e.g. ipython3.
     """
     ep = [
             'ipython%s = IPython:start_ipython',
         ]
     major_suffix = str(sys.version_info[0])
-    minor_suffix = ".".join([str(sys.version_info[0]), str(sys.version_info[1])])
     return (
         [e % "" for e in ep]
         + [e % major_suffix for e in ep]
-        + [e % minor_suffix for e in ep]
     )
 
 class install_lib_symlink(Command):


### PR DESCRIPTION
Unfortunatly, as discussed here: https://github.com/ipython/ipython/issues/13815. The feature is not implemented correctly as the global wheel has the entrypoints hard-coded to the minor version of the python used to create them.  This PR will remove that third entrypoint. 

Side note: I didn't see any github acftion to publish new versions of the package. Will it be ok if I create a new PR with one and if so, would it be acceptible if I make it so the github action would run on all supported minor versions of python to create a wheel that is aware of the minor version (so the feature would be able to be re-implemented)?