### PR TITLE
let's avoid walrus operator.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -184,10 +184,9 @@ def _format_filename(file, ColorFilename, ColorNormal, *, lineno=None):
         ColorScheme's normal coloring to be used.
     """
     ipinst = get_ipython()
-    if (
-        ipinst is not None
-        and (data := ipinst.compile.format_code_name(file)) is not None
-    ):
+    data = ipinst.compile.format_code_name(file)
+    
+    if (ipinst is not None and data is not None):
         label, name = data
         if lineno is None:
             tpl_link = f"{{label}} {ColorFilename}{{name}}{ColorNormal}"


### PR DESCRIPTION
In this entire ipython this `:=` appears only once which is sufficient enough to create mypy issues for py<3.8. Why do we even need that, let's avoid this. 

Sincerely 
On behalf of entire Graphistry Team