### PR TITLE
Handle non utf-8 characters during decoding for %%bash

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -210,7 +210,7 @@ class ScriptMagics(Magics):
 
         async def _handle_stream(stream, stream_arg, file_object):
             while True:
-                line = (await stream.readline()).decode("utf8")
+                line = (await stream.readline()).decode("utf8", errors="replace")
                 if not line:
                     break
                 if stream_arg:


### PR DESCRIPTION
Handle non utf-8 characters during decoding for %%bash

Before this would fail for outputs that include non utf-8 characters. For example
```
curl https://www.google.com
```

**Before**
<img width="679" alt="Screen Shot 2023-01-11 at 3 55 26 PM" src="https://user-images.githubusercontent.com/110427462/211947750-ab6aec4d-478d-4a21-9e17-ea0f4a79d676.png">


**After**
<img width="1129" alt="Screen Shot 2023-01-11 at 3 55 37 PM" src="https://user-images.githubusercontent.com/110427462/211947782-d469e1e5-5ea0-46a0-b35c-7e83d9582898.png">
