### PR TITLE
MAINT: Remove usage of traitlets.

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -123,9 +123,8 @@ class ProfileAwareConfigLoader(PyFileConfigLoader):
         return super(ProfileAwareConfigLoader, self).load_subconfig(fname, path=path)
 
 class BaseIPythonApplication(Application):
-
-    name = u'ipython'
-    description = Unicode(u'IPython: an enhanced interactive Python shell.')
+    name = "ipython"
+    description = "IPython: an enhanced interactive Python shell."
     version = Unicode(release.version)
 
     aliases = base_aliases


### PR DESCRIPTION
Now this is mostly validate at typechecheck time, instead of runtime. We don't use any validation logic so I'm unsure it is really necessary.