### PR TITLE
FIX: Update vi bindings to work with nav auttosuggestion.

### DIFF
--- a/IPython/terminal/shortcuts/__init__.py
+++ b/IPython/terminal/shortcuts/__init__.py
@@ -363,9 +363,9 @@ def create_ipython_shortcuts(shell, for_all_platforms: bool = False) -> KeyBindi
     kb.add("c-right", filter=has_suggestion & has_focus(DEFAULT_BUFFER))(
         auto_suggest.accept_token
     )
-    kb.add("escape", filter=has_suggestion & has_focus(DEFAULT_BUFFER))(
-        auto_suggest.discard
-    )
+    kb.add(
+        "escape", filter=has_suggestion & has_focus(DEFAULT_BUFFER) & emacs_insert_mode
+    )(auto_suggest.discard)
     kb.add(
         "up",
         filter=navigable_suggestions
@@ -451,7 +451,6 @@ def create_ipython_shortcuts(shell, for_all_platforms: bool = False) -> KeyBindi
     if shell.editing_mode == "vi" and shell.modal_cursor:
         ViState._input_mode = InputMode.INSERT  # type: ignore
         ViState.input_mode = property(get_input_mode, set_input_mode)  # type: ignore
-
     return kb
 
 

--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -75,6 +75,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
         # note: `on_text_changed` could be used for a bit different behaviour
         # on character deletion (i.e. reseting history position on backspace)
         pt_app.default_buffer.on_text_insert.add_handler(self.reset_history_position)
+        pt_app.default_buffer.on_cursor_position_changed.add_handler(self._dismiss)
 
     def get_suggestion(
         self, buffer: Buffer, document: Document
@@ -88,6 +89,9 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
                 return Suggestion(suggestion)
 
         return None
+
+    def _dismiss(self, buffer, *args, **kwargs):
+        buffer.suggestion = None
 
     def _find_match(
         self, text: str, skip_lines: float, history: History, previous: bool


### PR DESCRIPTION
 1) dismiss the autosuggest on cursor motion
 2) in vi mode, escape already dismiss autosuggestions

closes #13901