### PR TITLE
MAINT: don't use f-strings in logs

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -310,7 +310,7 @@ class BaseIPythonApplication(Application):
                 except OSError as e:
                     # this will not be EEXIST
                     self.log.error("couldn't create path %s: %s", path, e)
-            self.log.debug("IPYTHONDIR set to: %s" % new)
+            self.log.debug("IPYTHONDIR set to: %s", new)
 
     def load_config_file(self, suppress_errors=IPYTHON_SUPPRESS_CONFIG_ERRORS):
         """Load the config file.
@@ -467,7 +467,7 @@ class BaseIPythonApplication(Application):
         s = self.generate_config_file()
         config_file = Path(self.profile_dir.location) / self.config_file_name
         if self.overwrite or not config_file.exists():
-            self.log.warning("Generating default config file: %r" % (config_file))
+            self.log.warning("Generating default config file: %r", (config_file))
             config_file.write_text(s, encoding="utf-8")
 
     @catch_config_error

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -400,7 +400,7 @@ class BaseIPythonApplication(Application):
                     self.log.fatal("Profile %r not found."%self.profile)
                     self.exit(1)
             else:
-                self.log.debug(f"Using existing profile dir: {p.location!r}")
+                self.log.debug("Using existing profile dir: %r", p.location)
         else:
             location = self.config.ProfileDir.location
             # location is fully specified
@@ -420,7 +420,7 @@ class BaseIPythonApplication(Application):
                     self.log.fatal("Profile directory %r not found."%location)
                     self.exit(1)
             else:
-                self.log.debug(f"Using existing profile dir: {p.location!r}")
+                self.log.debug("Using existing profile dir: %r", p.location)
             # if profile_dir is specified explicitly, set profile name
             dir_name = os.path.basename(p.location)
             if dir_name.startswith('profile_'):

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -278,7 +278,7 @@ class InteractiveShellApp(Configurable):
             )
             for ext in extensions:
                 try:
-                    self.log.info("Loading IPython extension: %s" % ext)
+                    self.log.info("Loading IPython extension: %s", ext)
                     self.shell.extension_manager.load_extension(ext)
                 except:
                     if self.reraise_ipython_extension_failures:


### PR DESCRIPTION
There are many reason not to use f-string in logs,
 - F-strings are eager, so might be slow.
 - prevent structured logging or handler to highlight.
 - Security (untrusted input can lead to DOS on formatting, https://discuss.python.org/t/safer-logging-methods-for-f-strings-and-new-style-formatting/13802)
 - Performance (we can filter before formatting).