### PR TITLE
Remove opening/at-exit closing of devnull.

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -18,11 +18,6 @@ from warnings import warn
 from IPython.utils.decorators import undoc
 from .capture import CapturedIO, capture_output
 
-# setup stdin/stdout/stderr to sys.stdin/sys.stdout/sys.stderr
-devnull = open(os.devnull, "w", encoding="utf-8")
-atexit.register(devnull.close)
-
-
 class Tee(object):
     """A class to duplicate an output stream to stdout/err.
 


### PR DESCRIPTION
This was likely due to an issue on Python 2 seeing the date, and does not seem useful anymore. Let's try to remove it.

Should close #13896