### PR TITLE
Fix formatting of usage examples for `set_env` magic

### DIFF
--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -468,9 +468,9 @@ class OSMagics(Magics):
         string.
 
         Usage:\\
-          %set_env var val: set value for var
-          %set_env var=val: set value for var
-          %set_env var=$val: set value for var, using python expansion if possible
+          :``%set_env var val``: set value for var
+          :``%set_env var=val``: set value for var
+          :``%set_env var=$val``: set value for var, using python expansion if possible
         """
         split = '=' if '=' in parameter_s else ' '
         bits = parameter_s.split(split, 1)


### PR DESCRIPTION
See the difference between how `env` and `set_env` look in the [docs](http://ipython.readthedocs.io/en/stable/interactive/magics.html).

<img width="600" alt="image" src="https://user-images.githubusercontent.com/14007150/215095416-c8e08aca-4c61-4bc9-a84e-81209607c74f.png">

<img width="725" alt="image" src="https://user-images.githubusercontent.com/14007150/215095718-532fe30f-a4b0-446e-ba61-73c5cf1e988e.png">