### PR TITLE
Fix disabling auto-suggestions

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -147,10 +147,6 @@ class PtkHistoryAdapter(History):
 
     """
 
-    auto_suggest: UnionType[
-        AutoSuggestFromHistory, NavigableAutoSuggestFromHistory, None
-    ]
-
     def __init__(self, shell):
         super().__init__()
         self.shell = shell
@@ -193,6 +189,9 @@ class TerminalInteractiveShell(InteractiveShell):
                             ).tag(config=True)
 
     pt_app: UnionType[PromptSession, None] = None
+    auto_suggest: UnionType[
+        AutoSuggestFromHistory, NavigableAutoSuggestFromHistory, None
+    ] = None
     debugger_history = None
 
     debugger_history_file = Unicode(
@@ -685,7 +684,6 @@ class TerminalInteractiveShell(InteractiveShell):
 
     def __init__(self, *args, **kwargs) -> None:
         super(TerminalInteractiveShell, self).__init__(*args, **kwargs)
-        self.auto_suggest = None
         self._set_autosuggestions(self.autosuggestions_provider)
         self.init_prompt_toolkit_cli()
         self.init_term_title()

--- a/IPython/terminal/tests/test_interactivshell.py
+++ b/IPython/terminal/tests/test_interactivshell.py
@@ -7,11 +7,25 @@ import sys
 import unittest
 import os
 
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+
 from IPython.core.inputtransformer import InputTransformer
 from IPython.testing import tools as tt
 from IPython.utils.capture import capture_output
 
 from IPython.terminal.ptutils import _elide, _adjust_completion_text_based_on_context
+from IPython.terminal.shortcuts.auto_suggest import NavigableAutoSuggestFromHistory
+
+
+class TestAutoSuggest(unittest.TestCase):
+    def test_changing_provider(self):
+        ip = get_ipython()
+        ip.autosuggestions_provider = None
+        self.assertEqual(ip.auto_suggest, None)
+        ip.autosuggestions_provider = "AutoSuggestFromHistory"
+        self.assertIsInstance(ip.auto_suggest, AutoSuggestFromHistory)
+        ip.autosuggestions_provider = "NavigableAutoSuggestFromHistory"
+        self.assertIsInstance(ip.auto_suggest, NavigableAutoSuggestFromHistory)
 
 
 class TestElide(unittest.TestCase):
@@ -24,10 +38,10 @@ class TestElide(unittest.TestCase):
         )
 
         test_string = os.sep.join(["", 10 * "a", 10 * "b", 10 * "c", ""])
-        expect_stirng = (
+        expect_string = (
             os.sep + "a" + "\N{HORIZONTAL ELLIPSIS}" + "b" + os.sep + 10 * "c"
         )
-        self.assertEqual(_elide(test_string, ""), expect_stirng)
+        self.assertEqual(_elide(test_string, ""), expect_string)
 
     def test_elide_typed_normal(self):
         self.assertEqual(


### PR DESCRIPTION
This should fix #13913 but I could not reproduce it in the first place. 

It looks like the traitlets initialization was invoking setter handler before the `__init__` had time to set `auto_suggest = None`; this is now changed so that `auto_suggest` is set to `None` on class level. It might be not as elegant because it makes it a class variable but in fact `pt_app` also uses the same pattern and since `auto_suggest` is only used on `pt_app` there is no reason not to use this pattern.

Also, the type annotation was in a wrong class, I moved it.