### PR TITLE
Fix bug when network map is disconnected

### DIFF
--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -198,7 +198,16 @@ which already exists. But you must first start the logging process with
                 odata = u'\n'.join([u'#[Out]# %s' % s
                                    for s in data.splitlines()])
                 write(u'%s\n' % odata)
-            self.logfile.flush()
+            try:
+                self.logfile.flush()
+            except OSError:
+                print("Failed to flush the log file.")
+                print(
+                    f"Please check that {self.logfname} exists and have the right permissions."
+                )
+                print(
+                    "Also consider turning off the log with `%logstop` to avoid this warning."
+                )
 
     def logstop(self):
         """Fully stop logging and close log file.


### PR DESCRIPTION
Hi there :)
I encounter a little bug with the ipython logger.
When using the `%logstart` magic and writing the log to a remote path, everything works fine until the network map gets disconnected.
After the network drive is disconnected you basically powerless, and you have to reopen the console.

This can be easily  reproduce by sharing a windows folder
![image](https://user-images.githubusercontent.com/23289491/216761685-1bbcc92a-13e4-409c-badf-513f610fef46.png)

Mounting it using 
![image](https://user-images.githubusercontent.com/23289491/216761695-8b413c89-b4f8-4423-b9c0-d68c2997af38.png)

Start an IPython session, start a log with `%logstart Z:\log`
and disconnect.
Anything you will try to do from now on will not work, and you can't use the Session, and will result `OSError: [Errno 22] Invalid argument`


I couldn't reproduce it in Linux environment, i guess it really depends on the `OS` here.
Also weirdly this happens when the client close the connection. that's mean if the Server close the connection to the mount everything still working perfectly  

I added a `try except` block to allow you to stop the logger and continue using your ipython normally  


I Search for a way to test it but I couldn't find an easy way  to reproduce it in test.