### PR TITLE
Adjust %matplotlib docstring re: matplotlib_inline.

### DIFF
--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -54,7 +54,7 @@ class PylabMagics(Magics):
         If you are using the inline matplotlib backend in the IPython Notebook
         you can set which figure formats are enabled using the following::
 
-            In [1]: from IPython.display import set_matplotlib_formats
+            In [1]: from matplotlib_inline.backend_inline import set_matplotlib_formats
 
             In [2]: set_matplotlib_formats('pdf', 'svg')
 
@@ -65,9 +65,9 @@ class PylabMagics(Magics):
 
             In [3]: %config InlineBackend.print_figure_kwargs = {'bbox_inches':None}
 
-        In addition, see the docstring of
-        `IPython.display.set_matplotlib_formats` and
-        `IPython.display.set_matplotlib_close` for more information on
+        In addition, see the docstrings of
+        `matplotlib_inline.backend_inline.set_matplotlib_formats` and
+        `matplotlib_inline.backend_inline.set_matplotlib_close` for more information on
         changing additional behaviors of the inline backend.
 
         Examples


### PR DESCRIPTION
set_matplotlib_formats and set_matplotlib_close have been deprecated in IPython.display and moved out to matplotlib_inline.backend_inline; adjust the docstring of the %matplotlib magic accordingly.