### PR TITLE
Ignore `.ipynb_checkpoints` when building docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -183,8 +183,7 @@ today_fmt = '%B %d, %Y'
 
 # Exclude these glob-style patterns when looking for source files. They are
 # relative to the source/ directory.
-exclude_patterns = []
-
+exclude_patterns = ["**.ipynb_checkpoints"]
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True


### PR DESCRIPTION
This is a small thing - when editing the docs from JupyterLab Desktop, any file opened will leave `.ipynb_checkpoints` temp directory. Editing documentation in Jupyter itself is quite common especially when using spinx-myst and it is convenient enough for me, but without this change Sphinx errors out on every other build.