### PR TITLE
MAINT: Start to standardize on __version_info__.

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -61,6 +61,7 @@ __author__ = '%s <%s>' % (release.author, release.author_email)
 __license__  = release.license
 __version__  = release.version
 version_info = release.version_info
+__version_info__ = release.__version_info__
 # list of CVEs that should have been patched in this release.
 # this is informational and should not be relied upon.
 __patched_cves__ = {"CVE-2022-21699"}

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -609,8 +609,8 @@ SUPPORTED_EXTERNAL_GETITEM = {
 
 BUILTIN_GETITEM: Set[InstancesHaveGetItem] = {
     dict,
-    str,
-    bytes,
+    str,  # type: ignore[arg-type]
+    bytes,  # type: ignore[arg-type]
     list,
     tuple,
     collections.defaultdict,
@@ -619,7 +619,7 @@ BUILTIN_GETITEM: Set[InstancesHaveGetItem] = {
     collections.ChainMap,
     collections.UserDict,
     collections.UserList,
-    collections.UserString,
+    collections.UserString,  # type: ignore[arg-type]
     _DummyNamedTuple,
     _IdentitySubscript,
 }

--- a/IPython/core/release.py
+++ b/IPython/core/release.py
@@ -1,8 +1,9 @@
-# -*- coding: utf-8 -*-
 """Release data for the IPython project."""
 
-#-----------------------------------------------------------------------------
-#  Copyright (c) 2008, IPython Development Team.
+from typing import Tuple
+
+# -----------------------------------------------------------------------------
+#  Copyright (c) 2008-Present, IPython Development Team.
 #  Copyright (c) 2001, Fernando Perez <fernando.perez@colorado.edu>
 #  Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
 #  Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>
@@ -31,6 +32,14 @@ if _version_extra:
 
 version = __version__  # backwards compatibility name
 version_info = (_version_major, _version_minor, _version_patch, _version_extra)
+
+# trying to standardize on __version_info__ now, let's keep the numerical parts only
+# as sorting a,b,rc,dev is complex.
+__version_info__: Tuple[int, int, int] = (
+    _version_major,
+    _version_minor,
+    _version_patch,
+)
 
 # Change this when incrementing the kernel protocol version
 kernel_protocol_version_info = (5, 0)


### PR DESCRIPTION
See among other `https://github.com/numpy/numpy/pull/20803`, to try to standardize on the name of a field for a numerical version tuple.