### PR TITLE
Don't emit a trailng newline in base64-encoded data like 'image/png'

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1042,7 +1042,7 @@ class Image(DisplayObject):
     def _data_and_metadata(self, always_both=False):
         """shortcut for returning metadata with shape information, if defined"""
         try:
-            b64_data = b2a_base64(self.data).decode('ascii')
+            b64_data = b2a_base64(self.data, newline=False).decode("ascii")
         except TypeError as e:
             raise FileNotFoundError(
                 "No such file or directory: '%s'" % (self.data)) from e
@@ -1198,7 +1198,7 @@ class Video(DisplayObject):
             # unicode input is already b64-encoded
             b64_video = video
         else:
-            b64_video = b2a_base64(video).decode('ascii').rstrip()
+            b64_video = b2a_base64(video, newline=False).decode("ascii").rstrip()
 
         output = """<video {0} {1} {2}>
  <source src="data:{3};base64,{4}" type="{3}">

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -154,7 +154,7 @@ def print_figure(fig, fmt="png", bbox_inches="tight", base64=False, **kwargs):
     if fmt == 'svg':
         data = data.decode('utf-8')
     elif base64:
-        data = b2a_base64(data).decode("ascii")
+        data = b2a_base64(data, newline=False).decode("ascii")
     return data
 
 def retina_figure(fig, base64=False, **kwargs):
@@ -174,7 +174,7 @@ def retina_figure(fig, base64=False, **kwargs):
     w, h = _pngxy(pngdata)
     metadata = {"width": w//2, "height":h//2}
     if base64:
-        pngdata = b2a_base64(pngdata).decode("ascii")
+        pngdata = b2a_base64(pngdata, newline=False).decode("ascii")
     return pngdata, metadata
 
 


### PR DESCRIPTION
This addresses the issue highlighted in

https://github.com/jupyter/jupyter_client/issues/930

Since, unlike the latest Jupyter, IPython aims to support python<3.6, I'm using an approach that won't break this compatibility.