### PR TITLE
don't evaluate descriptor

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -252,6 +252,13 @@ try:
     import jedi.api.helpers
     import jedi.api.classes
     JEDI_INSTALLED = True
+
+    # disable evaluating descriptors
+    from packaging import version
+    if version.parse(jedi.__version__) > version.parse("0.18.2"):
+        jedi.settings.instance_allow_descriptor_getattr = False
+    else:
+        jedi.Interpreter._allow_descriptor_getattr_default = False
 except ImportError:
     JEDI_INSTALLED = False
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -255,6 +255,7 @@ try:
 
     # disable evaluating descriptors
     from packaging import version
+
     if version.parse(jedi.__version__) > version.parse("0.18.2"):
         jedi.settings.instance_allow_descriptor_getattr = False
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     pygments>=2.4.0
     stack_data
     traitlets>=5
+    packaging
 
 [options.extras_require]
 black =


### PR DESCRIPTION
after [checking with jedi API](https://github.com/davidhalter/jedi/pull/1918), I have added a change in the default settings of jedi to avoid evaluating `@property` methods while auto-completing 