### PR TITLE
:hammer: handle OSError cases where traceback frames occur from built…

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -999,8 +999,12 @@ class VerboseTB(TBTools):
         max_len = 0
         tbs = []
         while cf is not None:
-            source_file = inspect.getsourcefile(etb.tb_frame)
-            lines, first = inspect.getsourcelines(etb.tb_frame)
+            try:
+                source_file = inspect.getsourcefile(etb.tb_frame)
+                lines, first = inspect.getsourcelines(etb.tb_frame)
+            except OSError:
+                max_len = float("-inf")
+                break
             max_len = max(max_len, first + len(lines))
             tbs.append(cf)
             cf = cf.tb_next


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX196Dlrt5z8lngHclbhQ8jc2HmBZEbeuuNI%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=GU4NBR8)
… files

Hello. I'm not very familiar with open source contributions, so please bear with me if I'm a bit inexperienced.

## Introduction
First of all, let me explain the background. I've been using the `_render_traceback_` method of the traceback object, provided by the `IPython.core.interactiveshell.InteractiveShell` object that you created, in the `showtraceback` method. Thanks to this, I was able to create better error messages. I appreciate it. The following issue is related to the use of this method.
```python
                    try:
                        # Exception classes can customise their traceback - we
                        # use this in IPython.parallel for exceptions occurring
                        # in the engines. This should return a list of strings.
                        if hasattr(value, "_render_traceback_"):
                            stb = value._render_traceback_()
                        else:
                            stb = self.InteractiveTB.structured_traceback(
                                etype, value, tb, tb_offset=tb_offset
                            )
```

## Description
I noticed that in the recent `8.11` version, code was added to generate a traceback when the source code is too long. In this case, if the `etb.tb_frame` object is a built file or something similar, the `inspect.getsourcelines(etb.tb_frame)` method may raise an error. So I implemented a change to set the `max_len` to the minimum value and avoid the following condition when an `OSError` occurs. I think this approach can handle cases where errors occur while using the `inspect.getsourcelines()` method.

If there is anything I have done wrong or any procedures I should follow, please let me know. I would greatly appreciate it if you could leave a comment and I will make the necessary changes immediately. Thank you.