### PR TITLE
Use single quotes in sql string literal

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -567,8 +567,11 @@ class HistoryManager(HistoryAccessor):
             conn = self.db
 
         with conn:
-            cur = conn.execute("""INSERT INTO sessions VALUES (NULL, ?, NULL,
-                            NULL, "") """, (datetime.datetime.now(),))
+            cur = conn.execute(
+                """INSERT INTO sessions VALUES (NULL, ?, NULL,
+                            NULL, '') """,
+                (datetime.datetime.now(),),
+            )
             self.session_number = cur.lastrowid
 
     def end_session(self):


### PR DESCRIPTION
the SQL spec requires that string literals use single quotes and column references (or other identifiers) use double quotes. sqlite permits the use of double quotes for string literals in "unambiguous cases". For some reason, its understanding of what constitutes unambiguous has changed recently - I'm on FreeBSD 14.0-CURRENT with sqlite 3.41.0 - and attempting to do anything with ipython throws a very strange sqlite operation error:

```
[+] ~% ipython --version                                                                                                                                    (test) audrey@daisy [12:18:02 AM]
8.11.0
[+] ~% ipython                                                                                                                                              (test) audrey@daisy [12:18:04 AM]
[TerminalIPythonApp] ERROR | Failed to create history session in /usr/home/audrey/.ipython/profile_default/history.sqlite. History will not be saved.
Traceback (most recent call last):
  File "/usr/home/audrey/.virtualenvs/test/lib/python3.9/site-packages/IPython/core/history.py", line 545, in __init__
    self.new_session()
  File "/usr/home/audrey/.virtualenvs/test/lib/python3.9/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw) 
  File "/usr/home/audrey/.virtualenvs/test/lib/python3.9/site-packages/IPython/core/history.py", line 60, in only_when_enabled
    return f(self, *a, **kw)
  File "/usr/home/audrey/.virtualenvs/test/lib/python3.9/site-packages/IPython/core/history.py", line 570, in new_session
    cur = conn.execute("""INSERT INTO sessions VALUES (NULL, ?, NULL,
sqlite3.OperationalError: no such column: 
Python 3.9.16 (main, Feb 28 2023, 01:31:45) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.11.0 -- An enhanced Interactive Python. Type '?' for help.
```

This patch fixes it. idk if this constitutes a bug in sqlite3, but this is, I guess, more correct.