### PR TITLE
Statically type OInfo.

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -46,6 +46,19 @@ from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
 
+from typing import Any
+from dataclasses import dataclass
+
+
+@dataclass
+class OInfo:
+    ismagic: bool
+    isalias: bool
+    found: bool
+    namespace: str
+    parent: Any
+    obj: Any
+
 def pylight(code):
     return highlight(code, PythonLexer(), HtmlFormatter(noclasses=True))
 

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -499,7 +499,7 @@ class AutocallChecker(PrefilterChecker):
             return None
 
         oinfo = line_info.ofind(self.shell) # This can mutate state via getattr
-        if not oinfo['found']:
+        if not oinfo.found:
             return None
 
         ignored_funs = ['b', 'f', 'r', 'u', 'br', 'rb', 'fr', 'rf']
@@ -508,10 +508,12 @@ class AutocallChecker(PrefilterChecker):
         if ifun.lower() in ignored_funs and (line.startswith(ifun + "'") or line.startswith(ifun + '"')):
             return None
 
-        if callable(oinfo['obj']) \
-               and (not self.exclude_regexp.match(line_info.the_rest)) \
-               and self.function_name_regexp.match(line_info.ifun):
-            return self.prefilter_manager.get_handler_by_name('auto')
+        if (
+            callable(oinfo.obj)
+            and (not self.exclude_regexp.match(line_info.the_rest))
+            and self.function_name_regexp.match(line_info.ifun)
+        ):
+            return self.prefilter_manager.get_handler_by_name("auto")
         else:
             return None
 
@@ -601,7 +603,7 @@ class AutoHandler(PrefilterHandler):
         the_rest = line_info.the_rest
         esc     = line_info.esc
         continue_prompt = line_info.continue_prompt
-        obj = line_info.ofind(self.shell)['obj']
+        obj = line_info.ofind(self.shell).obj
 
         # This should only be active for single-line input!
         if continue_prompt:

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -25,6 +25,7 @@ import sys
 
 from IPython.utils import py3compat
 from IPython.utils.encoding import get_stream_enc
+from IPython.core.oinspect import OInfo
 
 #-----------------------------------------------------------------------------
 # Main function
@@ -118,7 +119,7 @@ class LineInfo(object):
         else:
             self.pre_whitespace = self.pre
 
-    def ofind(self, ip):
+    def ofind(self, ip) -> OInfo:
         """Do a full, attribute-walking lookup of the ifun in the various
         namespaces for the given IPython InteractiveShell instance.
 

--- a/IPython/core/tests/test_completerlib.py
+++ b/IPython/core/tests/test_completerlib.py
@@ -177,7 +177,7 @@ def test_module_without_init():
         try:
             os.makedirs(os.path.join(tmpdir, fake_module_name))
             s = try_import(mod=fake_module_name)
-            assert s == []
+            assert s == [], f"for module {fake_module_name}"
         finally:
             sys.path.remove(tmpdir)
 

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -25,6 +25,7 @@ from os.path import join
 from IPython.core.error import InputRejected
 from IPython.core.inputtransformer import InputTransformer
 from IPython.core import interactiveshell
+from IPython.core.oinspect import OInfo
 from IPython.testing.decorators import (
     skipif, skip_win32, onlyif_unicode_paths, onlyif_cmds_exist,
 )
@@ -360,7 +361,7 @@ class InteractiveShellTestCase(unittest.TestCase):
 
         # Get info on line magic
         lfind = ip._ofind("lmagic")
-        info = dict(
+        info = OInfo(
             found=True,
             isalias=False,
             ismagic=True,
@@ -379,7 +380,7 @@ class InteractiveShellTestCase(unittest.TestCase):
 
         # Get info on cell magic
         find = ip._ofind("cmagic")
-        info = dict(
+        info = OInfo(
             found=True,
             isalias=False,
             ismagic=True,
@@ -397,9 +398,15 @@ class InteractiveShellTestCase(unittest.TestCase):
 
         a = A()
 
-        found = ip._ofind('a.foo', [('locals', locals())])
-        info = dict(found=True, isalias=False, ismagic=False,
-                    namespace='locals', obj=A.foo, parent=a)
+        found = ip._ofind("a.foo", [("locals", locals())])
+        info = OInfo(
+            found=True,
+            isalias=False,
+            ismagic=False,
+            namespace="locals",
+            obj=A.foo,
+            parent=a,
+        )
         self.assertEqual(found, info)
 
     def test_ofind_multiple_attribute_lookups(self):
@@ -412,9 +419,15 @@ class InteractiveShellTestCase(unittest.TestCase):
         a.a = A()
         a.a.a = A()
 
-        found = ip._ofind('a.a.a.foo', [('locals', locals())])
-        info = dict(found=True, isalias=False, ismagic=False,
-                    namespace='locals', obj=A.foo, parent=a.a.a)
+        found = ip._ofind("a.a.a.foo", [("locals", locals())])
+        info = OInfo(
+            found=True,
+            isalias=False,
+            ismagic=False,
+            namespace="locals",
+            obj=A.foo,
+            parent=a.a.a,
+        )
         self.assertEqual(found, info)
 
     def test_ofind_slotted_attributes(self):
@@ -424,14 +437,26 @@ class InteractiveShellTestCase(unittest.TestCase):
                 self.foo = 'bar'
 
         a = A()
-        found = ip._ofind('a.foo', [('locals', locals())])
-        info = dict(found=True, isalias=False, ismagic=False,
-                    namespace='locals', obj=a.foo, parent=a)
+        found = ip._ofind("a.foo", [("locals", locals())])
+        info = OInfo(
+            found=True,
+            isalias=False,
+            ismagic=False,
+            namespace="locals",
+            obj=a.foo,
+            parent=a,
+        )
         self.assertEqual(found, info)
 
-        found = ip._ofind('a.bar', [('locals', locals())])
-        info = dict(found=False, isalias=False, ismagic=False,
-                    namespace=None, obj=None, parent=a)
+        found = ip._ofind("a.bar", [("locals", locals())])
+        info = OInfo(
+            found=False,
+            isalias=False,
+            ismagic=False,
+            namespace=None,
+            obj=None,
+            parent=a,
+        )
         self.assertEqual(found, info)
 
     def test_ofind_prefers_property_to_instance_level_attribute(self):
@@ -443,7 +468,7 @@ class InteractiveShellTestCase(unittest.TestCase):
         a.__dict__["foo"] = "baz"
         self.assertEqual(a.foo, "bar")
         found = ip._ofind("a.foo", [("locals", locals())])
-        self.assertIs(found["obj"], A.foo)
+        self.assertIs(found.obj, A.foo)
 
     def test_custom_syntaxerror_exception(self):
         called = []


### PR DESCRIPTION
In view of working with #13860, some cleanup inspect to be properly typed, and using stricter datastructure.

Instead of dict we now use dataclasses, this will make sure that fields type and access can be stricter and verified not only at runtime, but by mypy