### PR TITLE
Allow to dispatch getting documentation on objects.

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1609,10 +1609,19 @@ class InteractiveShell(SingletonConfigurable):
 
     def _ofind(
         self, oname: str, namespaces: Optional[Sequence[Tuple[str, AnyType]]] = None
-    ):
+    ) -> OInfo:
         """Find an object in the available namespaces.
 
-        self._ofind(oname) -> dict with keys: found,obj,ospace,ismagic
+
+        Returns
+        -------
+        OInfo with fields:
+          - ismagic
+          - isalias
+          - found
+          - obj
+          - namespac
+          - parent
 
         Has special code to detect magic functions.
         """
@@ -1771,11 +1780,11 @@ class InteractiveShell(SingletonConfigurable):
 
         This function is meant to be called by pdef, pdoc & friends.
         """
-        info = self._object_find(oname, namespaces)
+        info: OInfo = self._object_find(oname, namespaces)
         docformat = (
             sphinxify(self.object_inspect(oname)) if self.sphinxify_docstring else None
         )
-        if info.found:
+        if info.found or hasattr(info.parent, oinspect.HOOK_NAME):
             pmethod = getattr(self.inspector, meth)
             # TODO: only apply format_screen to the plain/text repr of the mime
             # bundle.

--- a/docs/source/whatsnew/version8.rst
+++ b/docs/source/whatsnew/version8.rst
@@ -2,6 +2,81 @@
  8.x Series
 ============
 
+.. _version 8.12.0:
+
+
+Dynamic documentation dispatch
+------------------------------
+
+
+We are experimenting with dynamic documentation dispatch for object attribute.
+See :ghissue:`13860`. The goal is to allow object to define documentation for
+their attributes, properties, even when those are dynamically defined with
+`__getattr__`.
+
+In particular when those objects are base types it can be useful to show the
+documentation
+
+
+.. code::
+
+    In [1]: class User:
+    ...:
+    ...:     __custom_documentations__ = {
+    ...:         "first": "The first name of the user.",
+    ...:         "last": "The last name of the user.",
+    ...:     }
+    ...:
+    ...:     first:str
+    ...:     last:str
+    ...:
+    ...:     def __init__(self, first, last):
+    ...:         self.first = first
+    ...:         self.last = last
+    ...:
+    ...:     @property
+    ...:     def full(self):
+    ...:         """`self.first` and `self.last` joined by a space."""
+    ...:         return self.first + " " + self.last
+    ...:
+    ...:
+    ...: user = Person('Jane', 'Doe')
+
+    In [2]: user.first?
+    Type:            str
+    String form:     Jane
+    Length:          4
+    Docstring:       the first name of a the person object, a str
+    Class docstring:
+    ....
+
+    In [3]: user.last?
+    Type:            str
+    String form:     Doe
+    Length:          3
+    Docstring:       the last name, also a str
+    ...
+
+
+We can see here the symmetry with IPython looking for the docstring on the
+properties::
+
+
+    In [4]: user.full?
+    HERE
+    Type:        property
+    String form: <property object at 0x102bb15d0>
+    Docstring:   first and last join by a space
+
+
+Note that while in the above example we use a static dictionary, libraries may
+decide to use a custom object that define ``__getitem__``, we caution against
+using objects that would trigger computation to show documentation, but it is
+sometime preferable for highly dynamic code that for example export ans API as
+object.
+
+
+
 .. _version 8.11.0:
 
 IPython 8.11
@@ -94,7 +169,7 @@ Thanks to the `D. E. Shaw group <https://deshaw.com/>`__ for sponsoring
 work on IPython and related libraries.
 
 .. _version 8.10.0:
-   
+
 IPython 8.10
 ------------
 
@@ -107,7 +182,7 @@ This is a really low severity CVE that you most likely are not affected by unles
    valid shell commands.
 
 You can read more on `the advisory
-<https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7>`__. 
+<https://github.com/ipython/ipython/security/advisories/GHSA-29gw-9793-fvw7>`__.
 
 In addition to fixing this CVE we also fix a couple of outstanding bugs and issues.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     pygments>=2.4.0
     stack_data
     traitlets>=5
+    typing_extensions ; python_version<'3.10'
 
 [options.extras_require]
 black =


### PR DESCRIPTION
Base for #13860, so that object can be queried for documentation on their fields/properties.

Typically this allows the following, to extend the doc documentation when requesting information on a field.

```python
class DictLike:
    def __getitem__(self, k):
        if k.startswith('f'):
            return "documentation for k"
        else:
            raise KeyError

class Bar:
    __custom_documentations__ = DictLike()

    faz = 1


    @property
    def foo(self):
        return 1
b = Bar()
b.faz?
```
