### PR TITLE
Expose `auto_suggest.resume_hinting`, fix resume on backspace

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -51,6 +51,7 @@ from .pt_inputhooks import get_inputhook_name_and_func
 from .prompts import Prompts, ClassicPrompts, RichPromptDisplayHook
 from .ptutils import IPythonPTCompleter, IPythonPTLexer
 from .shortcuts import (
+    KEY_BINDINGS,
     create_ipython_shortcuts,
     create_identifier,
     RuntimeBinding,
@@ -491,8 +492,8 @@ class TerminalInteractiveShell(InteractiveShell):
         # for now we only allow adding shortcuts for commands which are already
         # registered; this is a security precaution.
         known_commands = {
-            create_identifier(binding.handler): binding.handler
-            for binding in key_bindings.bindings
+            create_identifier(binding.command): binding.command
+            for binding in KEY_BINDINGS
         }
         shortcuts_to_skip = []
         shortcuts_to_add = []
@@ -513,11 +514,11 @@ class TerminalInteractiveShell(InteractiveShell):
             )
             matching = [
                 binding
-                for binding in key_bindings.bindings
+                for binding in KEY_BINDINGS
                 if (
                     (old_filter is None or binding.filter == old_filter)
                     and (old_keys is None or [k for k in binding.keys] == old_keys)
-                    and create_identifier(binding.handler) == command_id
+                    and create_identifier(binding.command) == command_id
                 )
             ]
 
@@ -542,7 +543,7 @@ class TerminalInteractiveShell(InteractiveShell):
                 }
                 if len(matching) == 0:
                     raise ValueError(
-                        f"No shortcuts matching {specification} found in {key_bindings.bindings}"
+                        f"No shortcuts matching {specification} found in {KEY_BINDINGS}"
                     )
                 elif len(matching) > 1:
                     raise ValueError(

--- a/IPython/terminal/shortcuts/__init__.py
+++ b/IPython/terminal/shortcuts/__init__.py
@@ -253,6 +253,14 @@ AUTO_SUGGEST_BINDINGS = [
         ["backspace"],
         "has_suggestion & default_buffer_focused",
     ),
+    Binding(
+        auto_suggest.resume_hinting,
+        ["right"],
+        # For now this binding is inactive (the filter includes `never`).
+        # TODO: remove `never` if we reach a consensus in #13991
+        # TODO: use `emacs_like_insert_mode` once #13991 is in
+        "never & default_buffer_focused & ((vi_insert_mode & ebivim) | emacs_insert_mode)",
+    ),
 ]
 
 

--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -252,14 +252,13 @@ def _update_hint(buffer: Buffer):
 
 def backspace_and_resume_hint(event: KeyPressEvent):
     """Resume autosuggestions after deleting last character"""
-    current_buffer = event.current_buffer
-
-    def resume_hinting(buffer: Buffer):
-        _update_hint(buffer)
-        current_buffer.on_text_changed.remove_handler(resume_hinting)
-
-    current_buffer.on_text_changed.add_handler(resume_hinting)
     nc.backward_delete_char(event)
+    _update_hint(event.current_buffer)
+
+
+def resume_hinting(event: KeyPressEvent):
+    """Resume autosuggestions"""
+    return _update_hint(event.current_buffer)
 
 
 def up_and_update_hint(event: KeyPressEvent):

--- a/IPython/terminal/shortcuts/filters.py
+++ b/IPython/terminal/shortcuts/filters.py
@@ -17,6 +17,7 @@ from prompt_toolkit.filters import Condition, emacs_insert_mode, has_completions
 from prompt_toolkit.filters import has_focus as has_focus_impl
 from prompt_toolkit.filters import (
     Always,
+    Never,
     has_selection,
     has_suggestion,
     vi_insert_mode,
@@ -174,6 +175,8 @@ default_buffer_focused = has_focus(DEFAULT_BUFFER)
 
 KEYBINDING_FILTERS = {
     "always": Always(),
+    # never is used for exposing commands which have no default keybindings
+    "never": Never(),
     "has_line_below": has_line_below,
     "has_line_above": has_line_above,
     "has_selection": has_selection,


### PR DESCRIPTION
This is a pre-requisite of #13992 but the shortcut is disabled by default by `never` filter. The idea here is that this could be merged as-is (ideally after rebasing on top of #13991) to allow user testing. Once this is in, users can emulate part of the behaviour proposed in #13992 with the following snippet:

```python
custom_shortcuts = [
    {
        "command": "IPython:auto_suggest.resume_hinting",
        "new_keys": ["right"],
        "new_filter": "default_buffer_focused & ((vi_insert_mode & ebivim) | emacs_insert_mode)"
    }
]
%config TerminalInteractiveShell.shortcuts = custom_shortcuts
```