### PR TITLE
Don't do truthy check on object; use `is not None`

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -835,7 +835,7 @@ class Inspector(Colorable):
         att_name = oname.split(".")[-1]
         parents_docs = None
         prelude = ""
-        if info and info.parent and hasattr(info.parent, HOOK_NAME):
+        if info and info.parent is not None and hasattr(info.parent, HOOK_NAME):
             parents_docs_dict = getattr(info.parent, HOOK_NAME)
             parents_docs = parents_docs_dict.get(att_name, None)
         out = dict(

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -370,6 +370,23 @@ def cleanup_user_ns(**kwargs):
             del ip.user_ns[k]
 
 
+def test_pinfo_bool_raise():
+    """
+    Test that bool method is not called on parent.
+    """
+
+    class RaiseBool:
+        attr = None
+
+        def __bool__(self):
+            raise ValueError("pinfo should not access this method")
+
+    raise_bool = RaiseBool()
+
+    with cleanup_user_ns(raise_bool=raise_bool):
+        ip._inspect("pinfo", "raise_bool.attr", detail_level=0)
+
+
 def test_pinfo_getindex():
     def dummy():
         """


### PR DESCRIPTION
For example, without this change, doing `df.merge?` on a pandas DataFrame currently fails, because `df.__bool__()` raises an exception.

I'm not sure the best way to add a test, and at a glance I didn't see any issue for this yet.

This regression was introduced in #13975 and version 8.12.0. CC @Carreau 