### PR TITLE
Try to fix traceback Code speed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = [
    #'IPython/core/interactiveshell.py',
    'IPython/core/magic.py',
    'IPython/core/profileapp.py',
-   'IPython/core/ultratb.py',
+   # 'IPython/core/ultratb.py',
    'IPython/lib/deepreload.py',
    'IPython/lib/pretty.py',
    'IPython/sphinxext/ipython_directive.py',


### PR DESCRIPTION
Instead of using the heuristic of where the function is defined we will now try to count the number of line in the files where the function are defined. 

Unfortunately the way stackdata parses things, the time depends on the size of the file as it does not do partial highlighting. 

So if the functions we are using are defined before the threshold we still go through the slow path.

Now we try to :

1) not look at the IPython stacks
2) for files we can, open and count the number of lines as a proxy (and cache it). 
3) if any of those _files_ are too long, go through fast code. 

