### PR TITLE
Added sorting on counter and passed all tests

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -918,7 +918,7 @@ def _counter_pprint(obj, p, cycle):
     if cycle:
         p.pretty(cls_ctor(RawText("...")))
     elif len(obj):
-        p.pretty(cls_ctor(dict(obj)))
+        p.pretty(cls_ctor(dict(sorted(obj.items(), key=lambda x: x[1], reverse=True))))
     else:
         p.pretty(cls_ctor())
 

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -918,7 +918,7 @@ def _counter_pprint(obj, p, cycle):
     if cycle:
         p.pretty(cls_ctor(RawText("...")))
     elif len(obj):
-        p.pretty(cls_ctor(dict(sorted(obj.items(), key=lambda x: x[1], reverse=True))))
+        p.pretty(cls_ctor(dict(obj.most_common())))
     else:
         p.pretty(cls_ctor())
 

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -422,6 +422,7 @@ def test_collections_counter():
         (Counter(), 'Counter()'),
         (Counter(a=1), "Counter({'a': 1})"),
         (MyCounter(a=1), "MyCounter({'a': 1})"),
+        (Counter(a=1, c=22), "Counter({'c': 22, 'a': 1})")
     ]
     for obj, expected in cases:
         assert pretty.pretty(obj) == expected

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -422,7 +422,7 @@ def test_collections_counter():
         (Counter(), 'Counter()'),
         (Counter(a=1), "Counter({'a': 1})"),
         (MyCounter(a=1), "MyCounter({'a': 1})"),
-        (Counter(a=1, c=22), "Counter({'c': 22, 'a': 1})")
+        (Counter(a=1, c=22), "Counter({'c': 22, 'a': 1})"),
     ]
     for obj, expected in cases:
         assert pretty.pretty(obj) == expected


### PR DESCRIPTION
Creating a pull request to address changes requested in #13484 to update logic for printing Counter objects in terminal. This is now matching the standard Python console and pprint outputs which sort by default in a descending order.

![image](https://user-images.githubusercontent.com/24849659/233975244-d2033b38-05c6-47a9-90a0-f2936ea72e60.png)

The following function was updated to add sorting:

```
def _counter_pprint(obj, p, cycle):
    cls_ctor = CallExpression.factory(obj.__class__.__name__)
    if cycle:
        p.pretty(cls_ctor(RawText("...")))
    elif len(obj):
        p.pretty(cls_ctor(dict(sorted(obj.items(), key=lambda x: x[1], reverse=True))))
    else:
        p.pretty(cls_ctor())
```

Additionally, I have added an additional test case to test_collections_counter in test_pretty.py to test for descending order:

```
def test_collections_counter():
    class MyCounter(Counter):
        pass
    cases = [
        (Counter(), 'Counter()'),
        (Counter(a=1), "Counter({'a': 1})"),
        (MyCounter(a=1), "MyCounter({'a': 1})"),
        (Counter(a=1, c=22), "Counter({'c': 22, 'a': 1})")
    ]
    for obj, expected in cases:
        assert pretty.pretty(obj) == expected
```


======================== 34 passed, 1 skipped in 0.13s ========================

Finally, all tests have been passed after making this change.
