### PR TITLE
MAINT: reintroduce a OInfo get method for backward compatibility.

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -69,6 +69,23 @@ class OInfo:
     parent: Any
     obj: Any
 
+    def get(self, field):
+        """Get a field from the object for backward compatibility with before 8.12
+
+        see https://github.com/h5py/h5py/issues/2253
+        """
+        # We need to deprecate this at some point, but the warning will show in completion.
+        # Let's comment this for now and uncomment end of 2023 ish
+        #        warnings.warn(
+        #            f"OInfo dataclass with fields access since IPython 8.12 please use OInfo.{field} instead."
+        #            "OInfo used to be a dict but a dataclass provide static fields verification with mypy."
+        #            "This warning and backward compatibility `get()` method were added in 8.13.",
+        #            DeprecationWarning,
+        #            stacklevel=2,
+        #        )
+        return getattr(self, field)
+
+
 def pylight(code):
     return highlight(code, PythonLexer(), HtmlFormatter(noclasses=True))
 


### PR DESCRIPTION
Reintroduce a OInfo get method for backward compatibility.

OInfo was converted to a dataclass from dict in commit 0fef298ad70ff72, but some external code is still be using it.

This commit reintroduces the method, but deprecates it.

Fixes https://github.com/h5py/h5py/issues/2253