### PR TITLE
Show PEP-678 notes in `ultratb`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__
 .coverage
 *.swp
 .pytest_cache
+.hypothesis
 .python-version
 venv*/
 .mypy_cache/

--- a/IPython/core/tests/test_ultratb.py
+++ b/IPython/core/tests/test_ultratb.py
@@ -363,6 +363,29 @@ def r3o2():
             ip.run_cell("r3o2()")
 
 
+class PEP678NotesReportingTest(unittest.TestCase):
+    ERROR_WITH_NOTE = """
+try:
+    raise AssertionError("Message")
+except Exception as e:
+    try:
+        e.add_note("This is a PEP-678 note.")
+    except AttributeError:  # Python <= 3.10
+        e.__notes__ = ("This is a PEP-678 note.",)
+    raise
+    """
+
+    def test_verbose_reports_notes(self):
+        with tt.AssertPrints(["AssertionError", "Message", "This is a PEP-678 note."]):
+            ip.run_cell(self.ERROR_WITH_NOTE)
+
+    def test_plain_reports_notes(self):
+        with tt.AssertPrints(["AssertionError", "Message", "This is a PEP-678 note."]):
+            ip.run_cell("%xmode Plain")
+            ip.run_cell(self.ERROR_WITH_NOTE)
+            ip.run_cell("%xmode Verbose")
+
+
 #----------------------------------------------------------------------------
 
 # module testing (minimal)

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -677,6 +677,9 @@ class ListTB(TBTools):
             else:
                 list.append('%s\n' % stype)
 
+            # PEP-678 notes
+            list.extend(f"{x}\n" for x in getattr(value, "__notes__", []))
+
         # sync with user hooks
         if have_filedata:
             ipinst = get_ipython()
@@ -1000,8 +1003,11 @@ class VerboseTB(TBTools):
             etype, evalue = str, sys.exc_info()[:2]
             etype_str, evalue_str = map(str, (etype, evalue))
         # ... and format it
-        return ['%s%s%s: %s' % (colors.excName, etype_str,
-                                colorsnormal, py3compat.cast_unicode(evalue_str))]
+        notes = "".join("\n" + x for x in getattr(evalue, "__notes__", []))
+        return [
+            f"{colors.excName}{etype_str}{colorsnormal}: "
+            f"{py3compat.cast_unicode(evalue_str)}{notes}"
+        ]
 
     def format_exception_as_a_whole(
         self,

--- a/docs/source/whatsnew/pr/pep678-notes.rst
+++ b/docs/source/whatsnew/pr/pep678-notes.rst
@@ -1,0 +1,5 @@
+Support for PEP-678 Exception Notes
+-----------------------------------
+
+Ultratb now shows :pep:`678` notes, improving your debugging experience on
+Python 3.11+ or with libraries such as Pytest and Hypothesis.


### PR DESCRIPTION
[PEP 678 - Enriching Exceptions with Notes](https://peps.python.org/pep-0678/), is in my admittedly biased opinion a really nice way to attach messages to existing exceptions.  Over the last year, it's been adopted by Hypothesis, Pytest, the standard library, and in a variety of other places I don't track so closely.

It's therefore unfortunate that today, notes are completely ignored by `ultratb`!

Since this bit one of my students [at a conference tutorial](https://us.pycon.org/2023/schedule/presentation/84/), I thought I'd send in a PR to fix it before next time 😁  https://github.com/ipython/ipython/issues/13753 is similar but less severe for this use-case.