### PR TITLE
Python Requires >=3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 zip_safe = False
 install_requires =
     appnope; sys_platform == "darwin"


### PR DESCRIPTION
 https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#python-requirement

This should address #14053 

Will still need to yank the previous release to prevent this error from continuing to affect 3.8 users.