### PR TITLE
Use module and method descriptor types declared in the `types` module

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -18,6 +18,7 @@ import operator
 import sys
 from functools import cached_property
 from dataclasses import dataclass, field
+from types import MethodDescriptorType, ModuleType
 
 from IPython.utils.docs import GENERATING_DOCUMENTATION
 from IPython.utils.decorators import undoc
@@ -630,8 +631,6 @@ set_non_mutating_methods = set(dir(set)) & set(dir(frozenset))
 
 
 dict_keys: Type[collections.abc.KeysView] = type({}.keys())
-method_descriptor: Any = type(list.copy)
-module = type(builtins)
 
 NUMERICS = {int, float, complex}
 
@@ -680,8 +679,8 @@ BUILTIN_GETATTR: Set[MayHaveGetattr] = {
     type,  # `type` handles a lot of generic cases, e.g. numbers as in `int.real`.
     *NUMERICS,
     dict_keys,
-    method_descriptor,
-    module,
+    MethodDescriptorType,
+    ModuleType,
 }
 
 


### PR DESCRIPTION
Fixes #14041.