### PR TITLE
Shaperilio/gui msg

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3607,6 +3607,9 @@ class InteractiveShell(SingletonConfigurable):
 
         # Now we must activate the gui pylab wants to use, and fix %run to take
         # plot updates into account
+
+        # NOTE: the call to `enable_gui` below does not seem necessary. `pt.activate_matplotlib`
+        # calls `pyplot.install_repl_displayhook()` when switching backends.
         self.enable_gui(gui)
         self.magics_manager.registry['ExecutionMagics'].default_runner = \
             pt.mpl_runner(self.safe_execfile)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3585,7 +3585,9 @@ class InteractiveShell(SingletonConfigurable):
             make sense in all contexts, for example a terminal ipython can't
             display figures inline.
         """
-        from matplotlib_inline.backend_inline import configure_inline_support
+        # NOTE: this import triggers `enable_gui('qt')` and occurs before the users' config (e.g.
+        # `--matplotlib=qt5`) is procssed.
+        # from matplotlib_inline.backend_inline import configure_inline_support
 
         from IPython.core import pylabtools as pt
         gui, backend = pt.find_gui_and_backend(gui, self.pylab_gui_select)
@@ -3601,7 +3603,7 @@ class InteractiveShell(SingletonConfigurable):
                 gui, backend = pt.find_gui_and_backend(self.pylab_gui_select)
 
         pt.activate_matplotlib(backend)
-        configure_inline_support(self, backend)
+        # configure_inline_support(self, backend)
 
         # Now we must activate the gui pylab wants to use, and fix %run to take
         # plot updates into account

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -951,13 +951,13 @@ class TerminalInteractiveShell(InteractiveShell):
                 if self.active_eventloop == gui:
                     # already installed; nothing to do.
                     return
-                if gui.startswith('qt'):
-                    if gui =='qt' and  self.active_eventloop.startswith('qt'):
+                elif self.active_eventloop.startswith('qt'):
+                    if gui == 'qt':
                         # This means "requesting latest version". But you can't switch versions once
                         # you've chosen one, so we just accept this if the event loop hook is
                         # already *any* Qt version.
                         return
-                    elif self.active_eventloop.startswith('qt'):
+                    elif gui.startswith('qt'):
                         # Requesting a specific version of qt, but not the same version as the one
                         # installed last time. We run this code, which will let the Qt importing
                         # logic tell the user that the version cannot be switched. Effectively, we

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -951,13 +951,13 @@ class TerminalInteractiveShell(InteractiveShell):
                 if self.active_eventloop == gui:
                     # already installed; nothing to do.
                     return
-                elif self.active_eventloop.startswith('qt'):
-                    if gui == 'qt':
+                if gui.startswith('qt'):
+                    if gui =='qt' and  self.active_eventloop.startswith('qt'):
                         # This means "requesting latest version". But you can't switch versions once
                         # you've chosen one, so we just accept this if the event loop hook is
                         # already *any* Qt version.
                         return
-                    elif gui.startswith('qt'):
+                    elif self.active_eventloop.startswith('qt'):
                         # Requesting a specific version of qt, but not the same version as the one
                         # installed last time. We run this code, which will let the Qt importing
                         # logic tell the user that the version cannot be switched. Effectively, we

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -926,11 +926,12 @@ class TerminalInteractiveShell(InteractiveShell):
                 return
             else:
                 # Input hook currently exists; let's yank it.
+                msg = f"GUI event loop hook for {self.active_eventloop} removed."
                 self.active_eventloop = self._inputhook = None
                 if PTK3:
                     import asyncio
                     self.pt_loop = asyncio.new_event_loop()
-                print("GUI event loop hook disabled.")
+                print(msg)
                 return
         else:
             # Requesting an event loop hook.

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -906,18 +906,20 @@ class TerminalInteractiveShell(InteractiveShell):
 
         self._atexit_once()
 
-
     _inputhook = None  # The actual event loop hook function
+
     def inputhook(self, context):
         if self._inputhook is not None:
             self._inputhook(context)
 
-    active_eventloop = None # The name of the event loop hook, e.g. "qt5"
+    active_eventloop = None  # The name of the event loop hook, e.g. "qt5"
+
     def enable_gui(self, gui=None):
         # NOTE: these two variables should be in sync; `active_eventloop` is the name and
         # `_inputhook` is the actual function.
-        assert (self.active_eventloop is None and self._inputhook is None) \
-            or (self.active_eventloop is not None and self._inputhook is not None)
+        assert (self.active_eventloop is None and self._inputhook is None) or (
+            self.active_eventloop is not None and self._inputhook is not None
+        )
 
         if gui is None:
             # Requesting to remove the event loop hook.
@@ -930,45 +932,63 @@ class TerminalInteractiveShell(InteractiveShell):
                 self.active_eventloop = self._inputhook = None
                 if PTK3:
                     import asyncio
+
                     self.pt_loop = asyncio.new_event_loop()
                 print(msg)
                 return
         else:
             # Requesting an event loop hook.
             import asyncio
+
             if self._inputhook is None:
                 # No event loop hook currently installed.
                 if gui in {"inline", "webagg"}:
                     # There's no actual hook for these.
                     return
                 else:
-                    self.active_eventloop, self._inputhook = get_inputhook_name_and_func(gui)
+                    (
+                        self.active_eventloop,
+                        self._inputhook,
+                    ) = get_inputhook_name_and_func(gui)
                     if PTK3:
-                        from prompt_toolkit.eventloop import new_eventloop_with_inputhook
+                        from prompt_toolkit.eventloop import (
+                            new_eventloop_with_inputhook,
+                        )
+
                         self.pt_loop = new_eventloop_with_inputhook(self._inputhook)
                     print(f"Installed {self.active_eventloop} event loop hook.")
             else:
+
                 def cannot_change_hook_msg():
-                    print(f"Shell is already running a gui event loop for {self.active_eventloop}. "
-                          "Call with no arguments to disable the current loop.")
+                    print(
+                        f"Shell is already running a gui event loop for {self.active_eventloop}. "
+                        "Call with no arguments to disable the current loop."
+                    )
+
                 # An event loop hook is already installed.
                 if self.active_eventloop == gui:
                     # already installed; nothing to do.
                     return
-                elif self.active_eventloop.startswith('qt'):
-                    if gui == 'qt':
+                elif self.active_eventloop.startswith("qt"):
+                    if gui == "qt":
                         # This means "requesting latest version". But you can't switch versions once
                         # you've chosen one, so we just accept this if the event loop hook is
                         # already *any* Qt version.
                         return
-                    elif gui.startswith('qt'):
+                    elif gui.startswith("qt"):
                         # Requesting a specific version of qt, but not the same version as the one
                         # installed last time. We run this code, which will let the Qt importing
                         # logic tell the user that the version cannot be switched. Effectively, we
                         # are re-hooking the same hook.
-                        self.active_eventloop, self._inputhook = get_inputhook_name_and_func(gui)
+                        (
+                            self.active_eventloop,
+                            self._inputhook,
+                        ) = get_inputhook_name_and_func(gui)
                         if PTK3:
-                            from prompt_toolkit.eventloop import new_eventloop_with_inputhook
+                            from prompt_toolkit.eventloop import (
+                                new_eventloop_with_inputhook,
+                            )
+
                             self.pt_loop = new_eventloop_with_inputhook(self._inputhook)
                         # Still print this so it's clear what's happening.
                         print(f"Installed {self.active_eventloop} event loop hook.")

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -947,6 +947,9 @@ class TerminalInteractiveShell(InteractiveShell):
                         self.pt_loop = new_eventloop_with_inputhook(self._inputhook)
                     print(f"Installed {self.active_eventloop} event loop hook.")
             else:
+                def cannot_change_hook_msg():
+                    print(f"Shell is already running a gui event loop for {self.active_eventloop}. "
+                          "Call with no arguments to disable the current loop.")
                 # An event loop hook is already installed.
                 if self.active_eventloop == gui:
                     # already installed; nothing to do.
@@ -968,10 +971,12 @@ class TerminalInteractiveShell(InteractiveShell):
                             self.pt_loop = new_eventloop_with_inputhook(self._inputhook)
                         # Still print this so it's clear what's happening.
                         print(f"Installed {self.active_eventloop} event loop hook.")
+                    else:
+                        # A hook is already installed, and the user is requesting a different one.
+                        cannot_change_hook_msg()
+                        return
                 else:
-                    # A hook is already installed, and the user is requesting a different one.
-                    print(f"Shell is already running a gui event loop for {self.active_eventloop}. "
-                          "Call with no arguments to disable the current loop.")
+                    cannot_change_hook_msg()
                     return
 
     # Run !system commands directly, not through pipes, so terminal programs

--- a/shaperilio-reqs.txt
+++ b/shaperilio-reqs.txt
@@ -1,0 +1,3 @@
+-e .
+matplotlib
+pyqt5


### PR DESCRIPTION
Addresses the annoying extra messages as detailed in #14006.

# Behavior
The intent is to:
- Communicate when the user installs a hook
- Communicate when the user tries to install a different hook and cannot.
- Communicate when the user uninstalls a hook
- *Not* communicate when the user tries to install the same hook multiple times, with special care for the "latest version" `'qt'` hook request.

Take a system with both `PyQt5` and `pyside6` installed:
```
(venv) > ipython
Python 3.10.5 (tags/v3.10.5:f377153, Jun  6 2022, 16:14:13) [MSC v.1929 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.14.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: %gui qt
Installed qt6 event loop hook.

In [2]: %gui qt5
Cannot switch Qt versions for this session; will use qt6.
Installed qt6 event loop hook.

In [3]: %gui qt

In [4]: %gui qt6

In [5]: %gui tk
Shell is already running a gui event loop for qt6. Call with no arguments to disable the current loop.

In [6]: %gui
GUI event loop hook for tk removed.

In [7]: %gui tk
Installed tk event loop hook.

In [8]: %gui qt
Shell is already running a gui event loop for tk. Call with no arguments to disable the current loop.

In [9]: %gui qt6
Shell is already running a gui event loop for tk. Call with no arguments to disable the current loop.

In [10]: %gui qt5
Shell is already running a gui event loop for tk. Call with no arguments to disable the current loop.

In [11]: %gui
GUI event loop hook for qt5 removed.

In [12]: %gui tk
Installed tk event loop hook.

In [13]: %gui
GUI event loop hook for tk removed.

In [14]: %gui qt5
Cannot switch Qt versions for this session; will use qt6.
Installed qt6 event loop hook.

In [15]: 
```

This means when you run `ipython --matplotlib=tk`, for example, you'll see this:
```
Python 3.10.5 (tags/v3.10.5:f377153, Jun  6 2022, 16:14:13) [MSC v.1929 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.14.0.dev -- An enhanced Interactive Python. Type '?' for help.
Installed tk event loop hook.

In [1]:
```

# Notes
Working on this has uncovered some interesting dynamics; `qt` is taken to mean "the latest Qt available" and the current code appears to force, in some cases, what is effectively a `%gui qt` command before command line or config args are processed (see [this issue](https://github.com/ipython/matplotlib-inline/issues/25)), so that executing

```
ipython --matplotlib=qt5
```

effectively runs
```
%gui qt
%gui qt5
```

and if both `pyside6` and `PyQt5` are installed, the `%gui qt5` will trigger a message about not being able to change Qt versions in the session.