### PR TITLE
Autobalance

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -241,8 +241,9 @@ class AutoBalancer:
 
     has_side_effects: bool = True
 
-    def __init__(self, shell):
+    def __init__(self, shell=None, default=False):
         self._shell = shell
+        self._default = default
 
     def __call__(self, lines):
         """For single line cell, add necessary [{( and )}] to balance."""
@@ -251,12 +252,16 @@ class AutoBalancer:
             # apply only for single line cell
             return lines
 
-        if self._shell is None or not self._shell.autobalance:
+        if self._shell is None:
+            if not self._default:
+                return lines
+        elif not self._shell.autobalance:
             return lines
 
         modified, new_line = _autobalance_line(lines[0])
         if modified:
-            self._shell.auto_rewrite_input(new_line)
+            if self._shell is not None:
+                self._shell.auto_rewrite_input(new_line)
             return [new_line]
         return lines
 

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -14,13 +14,11 @@ import ast
 from codeop import CommandCompiler, Compile
 import re
 import tokenize
-from typing import List, Tuple, Optional, Any
+from typing import List, Tuple, Optional, Any, TYPE_CHECKING
 import warnings
 import io
 
-# only for type checking, do not import this, it lead to a circular
-# import
-if False:
+if TYPE_CHECKING:
     from IPython.core.interactiveshell import InteractiveShell
 
 _indent_re = re.compile(r'^[ \t]+')

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -17,6 +17,11 @@ import tokenize
 from typing import List, Tuple, Optional, Any
 import warnings
 
+# only for type checking, do not import this, it lead to a circular
+# import
+if False:
+    from IPython.core.interactiveshell import InteractiveShell
+
 _indent_re = re.compile(r'^[ \t]+')
 
 def leading_empty_lines(lines):
@@ -570,7 +575,11 @@ class TransformerManager:
     The key methods for external use are ``transform_cell()``
     and ``check_complete()``.
     """
-    def __init__(self):
+
+    shell: Optional["InteractiveShell"]
+
+    def __init__(self, shell=None):
+        self.shell = shell
         self.cleanup_transforms = [
             leading_empty_lines,
             leading_indent,

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -306,6 +306,16 @@ class InteractiveShell(SingletonConfigurable):
         """
     ).tag(config=True)
 
+    autobalance = Bool(
+        False,
+        help="""
+        Add automatically opening and closing parenthesis, braces and brackets
+        at the begin matching respectively closing and opening ones. Opening
+        symbols are added in the begin of the expression, and closings symbols
+        at the end of the line. E.g. `1+2)/2]*(2+3` becomes `[(1+2)/2]*(2+3)`.
+        """,
+    ).tag(config=True)
+
     autoindent = Bool(True, help=
         """
         Autoindent IPython code entered interactively.
@@ -485,9 +495,8 @@ class InteractiveShell(SingletonConfigurable):
         will be displayed as regular output instead."""
     ).tag(config=True)
 
-
-    show_rewritten_input = Bool(True,
-        help="Show rewritten input, e.g. for autocall."
+    show_rewritten_input = Bool(
+        True, help="Show rewritten input, e.g. for autocall and autobalance."
     ).tag(config=True)
 
     quiet = Bool(False).tag(config=True)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -71,7 +71,7 @@ from IPython.core.events import EventManager, available_events
 from IPython.core.extensions import ExtensionManager
 from IPython.core.formatters import DisplayFormatter
 from IPython.core.history import HistoryManager
-from IPython.core.inputtransformer2 import ESC_MAGIC, ESC_MAGIC2
+from IPython.core.inputtransformer2 import ESC_MAGIC, ESC_MAGIC2, TransformerManager
 from IPython.core.logger import Logger
 from IPython.core.macro import Macro
 from IPython.core.payload import PayloadManager
@@ -430,8 +430,9 @@ class InteractiveShell(SingletonConfigurable):
     ipython_dir= Unicode('').tag(config=True) # Set to get_ipython_dir() in __init__
 
     # Used to transform cells before running them, and check whether code is complete
-    input_transformer_manager = Instance('IPython.core.inputtransformer2.TransformerManager',
-                                         ())
+    input_transformer_manager = Instance(
+        "IPython.core.inputtransformer2.TransformerManager", allow_none=True
+    )
 
     @property
     def input_transformers_cleanup(self):
@@ -593,6 +594,7 @@ class InteractiveShell(SingletonConfigurable):
         self.init_history()
         self.init_encoding()
         self.init_prefilter()
+        self.init_input_transformer_manager()
 
         self.init_syntax_highlighting()
         self.init_hooks()
@@ -2740,6 +2742,13 @@ class InteractiveShell(SingletonConfigurable):
         print("------> " + cmd)
 
     #-------------------------------------------------------------------------
+    # Things related to input_transformer_manager
+    # -------------------------------------------------------------------------
+
+    def init_input_transformer_manager(self):
+        self.input_transformer_manager = TransformerManager(shell=self)
+
+    # -------------------------------------------------------------------------
     # Things related to extracting values/expressions from kernel and user_ns
     #-------------------------------------------------------------------------
 

--- a/IPython/core/magics/auto.py
+++ b/IPython/core/magics/auto.py
@@ -142,3 +142,32 @@ class AutoMagics(Magics):
                     self.shell.autocall = self._magic_state.autocall_save = 1
 
         print("Automatic calling is:", list(valid_modes.values())[self.shell.autocall])
+
+    @line_magic
+    def autobalance(self, parameter_s=""):
+        """Automatically balance parenthesis, braces and brackets.
+
+        On single line cell, this mode add automatically needed symbol at the
+        begin of the expression and the end of the line. If symbols need to
+        be added at other place, there exists a ambiguity, and this
+        transformation is not applied.
+
+        Without arguments toggles on/off. With arguments it sets the value, and
+        you can use any of (case insensitive):
+
+         - on, 1, True: to activate
+
+         - off, 0, False: to deactivate.
+
+        When symbols are added, the rewritten line is displayed. See
+        shell configuration `show_rewritten_input` to change this behavior.
+        """
+
+        arg = parameter_s.lower()
+        if arg in ("on", "1", "true"):
+            self.shell.autobalance = True
+        elif arg in ("off", "0", "false"):
+            self.shell.autobalance = False
+        else:
+            self.shell.autobalance = not self.shell.autobalance
+        print("Autobalance " + ("enabled" if self.shell.autobalance else "disabled"))

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -160,7 +160,7 @@ HELP_UNICODE = (
 )
 
 
-def null_cleanup_transformer(lines, **kwargs):
+def null_cleanup_transformer(lines):
     """
     A cleanup transform that returns an empty list.
     """

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -160,7 +160,7 @@ HELP_UNICODE = (
 )
 
 
-def null_cleanup_transformer(lines):
+def null_cleanup_transformer(lines, **kwargs):
     """
     A cleanup transform that returns an empty list.
     """

--- a/IPython/core/tests/test_inputtransformer2_line.py
+++ b/IPython/core/tests/test_inputtransformer2_line.py
@@ -93,6 +93,13 @@ def a():
 """,
 )
 
+AUTOBALANCE = (
+    ("(1+1)/2", "(1+1)/2"),
+    ("1+1)/2", "(1+1)/2"),
+    ("1+1/(2+3", "1+1/(2+3)"),
+    ("i+1)/2 for i in range(10)]", "[(i+1)/2 for i in range(10)]"),
+)
+
 
 def test_ipython_prompt():
     for sample, expected in [
@@ -165,3 +172,15 @@ CRLF_MAGIC = ([
 def test_crlf_magic():
     for sample, expected in [CRLF_MAGIC]:
         assert ipt2.cell_magic(sample) == expected
+
+
+def test_autobalance_no_changes():
+    autobalance = ipt2.AutoBalancer(default=False)
+    for sample, _ in AUTOBALANCE:
+        assert autobalance([sample]) == [sample]
+
+
+def test_autobalance_changes():
+    autobalance = ipt2.AutoBalancer(default=True)
+    for sample, expected in AUTOBALANCE:
+        assert autobalance([sample]) == [expected]

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -792,12 +792,12 @@ class TestMiscTransform(unittest.TestCase):
         cleanup = 0
         line_t = 0
 
-        def count_cleanup(lines, **kwargs):
+        def count_cleanup(lines):
             nonlocal cleanup
             cleanup += 1
             return lines
 
-        def count_line_t(lines, **kwargs):
+        def count_line_t(lines):
             nonlocal line_t
             line_t += 1
             return lines

--- a/IPython/core/tests/test_interactiveshell.py
+++ b/IPython/core/tests/test_interactiveshell.py
@@ -791,12 +791,13 @@ class TestMiscTransform(unittest.TestCase):
     def test_transform_only_once(self):
         cleanup = 0
         line_t = 0
-        def count_cleanup(lines):
+
+        def count_cleanup(lines, **kwargs):
             nonlocal cleanup
             cleanup += 1
             return lines
 
-        def count_line_t(lines):
+        def count_line_t(lines, **kwargs):
             nonlocal line_t
             line_t += 1
             return lines


### PR DESCRIPTION
This PR adds a mode for automatic opening of brackets, braces and braces.

This follows a strange idea that appeared on Saturday the 13th, following the other strange idea in #14077.

The logic used is as follows:

 - if the mode is enabled
 - and if the cell is only one line long
 - and if there are unmatched `[{()}]`
 - and if it is enough to add opening symbols at the beginning and/or closing symbols at the end

then the line is modified.

Technical points:

 - I chose not to use prefilters, but input transformers for this, because prefilters work with the check/handle logic, which does not allow to have at the same time the addition of symbols and the use of a magic (like `%time` for example).
 - the TransformerManager didn't have a member allowing to come back to the shell, and it's essential for me to access the shell config and to be able to display the modified line (when there is a modification)
 - the transformations had no way to have additional arguments and only received the lines. I had to add kwargs to be able to add arguments that transformations are free to use or not.

Demo:
```
Python 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.14.0.dev -- An enhanced Interactive Python. Type '?' for help.

In [1]: 1+1)/2
  Cell In[1], line 1
    1+1)/2
       ^
SyntaxError: unmatched ')'


In [2]: %autobalance
Autobalance enabled

In [3]: 1+1)/2
------> (1+1)/2
Out[3]: 1.0

In [4]: 1+1)/(3+4
------> (1+1)/(3+4)
Out[4]: 0.2857142857142857

In [5]: i+1)/2 for i in range(5)]+[1,2
------> [(i+1)/2 for i in range(5)]+[1,2]
Out[5]: [0.5, 1.0, 1.5, 2.0, 2.5, 1, 2]

In [6]: my_values = i+1)/2 for i in range(5)]+[1,2
------> my_values = [(i+1)/2 for i in range(5)]+[1,2]

In [7]: %config TerminalInteractiveShell.show_rewritten_input = False

In [8]: 1+1)/(3+4
Out[8]: 0.2857142857142857
```

This is my first time diving into IPython code (and contributing to it), I may have missed a lot things. I place this PR in draft for two reasons:

 - the changes made to the TransformerManager logic (with shell passing and kwargs on transformations) seem a bit intrusive to me, and discussing them seems like the best option.
 - I have not yet written the specific tests for this new behavior.

Finally, I think it is important to mention the [adapted xkcd](https://xkcd.com/859/).