### PR TITLE
fall back to native when printing an ExceptionGroup

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -112,6 +112,8 @@ try:
 except ImportError:
     sphinxify = None
 
+if sys.version_info[:2] < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 class ProvisionalWarning(DeprecationWarning):
     """
@@ -2095,25 +2097,38 @@ class InteractiveShell(SingletonConfigurable):
                     stb.extend(self.InteractiveTB.get_exception_only(etype,
                                                                      value))
                 else:
-                    try:
-                        # Exception classes can customise their traceback - we
-                        # use this in IPython.parallel for exceptions occurring
-                        # in the engines. This should return a list of strings.
-                        if hasattr(value, "_render_traceback_"):
-                            stb = value._render_traceback_()
-                        else:
-                            stb = self.InteractiveTB.structured_traceback(
-                                etype, value, tb, tb_offset=tb_offset
-                            )
 
-                    except Exception:
-                        print(
-                            "Unexpected exception formatting exception. Falling back to standard exception"
-                        )
+                    def contains_exceptiongroup(val):
+                        if val is None:
+                            return False
+                        return isinstance(
+                            val, BaseExceptionGroup
+                        ) or contains_exceptiongroup(val.__context__)
+
+                    if contains_exceptiongroup(value):
+                        # fall back to native exception formatting until ultratb
+                        # supports exception groups
                         traceback.print_exc()
-                        return None
+                    else:
+                        try:
+                            # Exception classes can customise their traceback - we
+                            # use this in IPython.parallel for exceptions occurring
+                            # in the engines. This should return a list of strings.
+                            if hasattr(value, "_render_traceback_"):
+                                stb = value._render_traceback_()
+                            else:
+                                stb = self.InteractiveTB.structured_traceback(
+                                    etype, value, tb, tb_offset=tb_offset
+                                )
 
-                    self._showtraceback(etype, value, stb)
+                        except Exception:
+                            print(
+                                "Unexpected exception formatting exception. Falling back to standard exception"
+                            )
+                            traceback.print_exc()
+                            return None
+
+                        self._showtraceback(etype, value, stb)
                     if self.call_pdb:
                         # drop into debugger
                         self.debugger(force=True)

--- a/IPython/core/tests/test_exceptiongroup_tb.py
+++ b/IPython/core/tests/test_exceptiongroup_tb.py
@@ -6,6 +6,7 @@ import pytest
 from tempfile import TemporaryDirectory
 from IPython.testing import tools as tt
 
+
 def _exceptiongroup_common(
     outer_chain: str,
     inner_chain: str,
@@ -60,7 +61,7 @@ def _exceptiongroup_common(
         match_lines += [
             "During handling of the above exception, another exception occurred:",
         ]
-    elif inner_chain == 'from':
+    elif inner_chain == "from":
         match_lines += [
             "The above exception was the direct cause of the following exception:",
         ]
@@ -87,20 +88,22 @@ def _exceptiongroup_common(
 
     err_index = match_index = 0
     for expected in match_lines:
-        for i,actual in enumerate(error_lines):
+        for i, actual in enumerate(error_lines):
             if actual == expected:
-                error_lines = error_lines[i+1:]
+                error_lines = error_lines[i + 1 :]
                 break
         else:
-            assert False, f'{expected} not found in cap.stderr'
+            assert False, f"{expected} not found in cap.stderr"
+
 
 @pytest.mark.skipif(
-        sys.version_info < (3, 11), reason="Native ExceptionGroup not implemented"
-        )
+    sys.version_info < (3, 11), reason="Native ExceptionGroup not implemented"
+)
 @pytest.mark.parametrize("outer_chain", ["none", "from", "another"])
 @pytest.mark.parametrize("inner_chain", ["none", "from", "another"])
 def test_native_exceptiongroup(outer_chain, inner_chain) -> None:
     _exceptiongroup_common(outer_chain, inner_chain, native=True)
+
 
 @pytest.mark.parametrize("outer_chain", ["none", "from", "another"])
 @pytest.mark.parametrize("inner_chain", ["none", "from", "another"])

--- a/IPython/core/tests/test_exceptiongroup_tb.py
+++ b/IPython/core/tests/test_exceptiongroup_tb.py
@@ -1,0 +1,109 @@
+import unittest
+import re
+from IPython.utils.capture import capture_output
+import sys
+import pytest
+from tempfile import TemporaryDirectory
+from IPython.testing import tools as tt
+
+def _exceptiongroup_common(
+    outer_chain: str,
+    inner_chain: str,
+    native: bool,
+) -> None:
+    pre_raise = "exceptiongroup." if not native else ""
+    pre_catch = pre_raise if sys.version_info < (3, 11) else ""
+    filestr = f"""
+    {"import exceptiongroup" if not native else ""}
+    import pytest
+
+    def f(): raise ValueError("From f()")
+    def g(): raise BaseException("From g()")
+
+    def inner(inner_chain):
+        excs = []
+        for callback in [f, g]:
+            try:
+                callback()
+            except BaseException as err:
+                excs.append(err)
+        if excs:
+            if inner_chain == "none":
+                raise {pre_raise}BaseExceptionGroup("Oops", excs)
+            try:
+                raise SyntaxError()
+            except SyntaxError as e:
+                if inner_chain == "from":
+                    raise {pre_raise}BaseExceptionGroup("Oops", excs) from e
+                else:
+                    raise {pre_raise}BaseExceptionGroup("Oops", excs)
+
+    def outer(outer_chain, inner_chain):
+        try:
+            inner(inner_chain)
+        except {pre_catch}BaseExceptionGroup as e:
+            if outer_chain == "none":
+                raise
+            if outer_chain == "from":
+                raise IndexError() from e
+            else:
+                raise IndexError
+
+
+    outer("{outer_chain}", "{inner_chain}")
+    """
+    with capture_output() as cap:
+        ip.run_cell(filestr)
+
+    match_lines = []
+    if inner_chain == "another":
+        match_lines += [
+            "During handling of the above exception, another exception occurred:",
+        ]
+    elif inner_chain == 'from':
+        match_lines += [
+            "The above exception was the direct cause of the following exception:",
+        ]
+
+    match_lines += [
+        "  + Exception Group Traceback (most recent call last):",
+        f"  | {pre_catch}BaseExceptionGroup: Oops (2 sub-exceptions)",
+        "    | ValueError: From f()",
+        "    | BaseException: From g()",
+    ]
+
+    if outer_chain == "another":
+        match_lines += [
+            "During handling of the above exception, another exception occurred:",
+            "IndexError",
+        ]
+    elif outer_chain == "from":
+        match_lines += [
+            "The above exception was the direct cause of the following exception:",
+            "IndexError",
+        ]
+
+    error_lines = cap.stderr.split("\n")
+
+    err_index = match_index = 0
+    for expected in match_lines:
+        for i,actual in enumerate(error_lines):
+            if actual == expected:
+                error_lines = error_lines[i+1:]
+                break
+        else:
+            assert False, f'{expected} not found in cap.stderr'
+
+@pytest.mark.skipif(
+        sys.version_info < (3, 11), reason="Native ExceptionGroup not implemented"
+        )
+@pytest.mark.parametrize("outer_chain", ["none", "from", "another"])
+@pytest.mark.parametrize("inner_chain", ["none", "from", "another"])
+def test_native_exceptiongroup(outer_chain, inner_chain) -> None:
+    _exceptiongroup_common(outer_chain, inner_chain, native=True)
+
+@pytest.mark.parametrize("outer_chain", ["none", "from", "another"])
+@pytest.mark.parametrize("inner_chain", ["none", "from", "another"])
+def test_native_exceptiongroup(outer_chain, inner_chain) -> None:
+    pytest.importorskip("exceptiongroup")
+    _exceptiongroup_common(outer_chain, inner_chain, native=False)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - sphinx>=4.2
   - sphinx_rtd_theme
   - numpy
+  - exceptiongroup
   - testpath
   - matplotlib
   - pip

--- a/docs/source/whatsnew/pr/native_fallback_exceptiongroup.rst
+++ b/docs/source/whatsnew/pr/native_fallback_exceptiongroup.rst
@@ -1,3 +1,3 @@
 Native fallback for displaying ExceptionGroup
---------------------------
+---------------------------------------------
 ExceptionGroups are now displayed with `traceback.print_exc`, as a temporary fix until UltraTB properly supports displaying child exceptions.

--- a/docs/source/whatsnew/pr/native_fallback_exceptiongroup.rst
+++ b/docs/source/whatsnew/pr/native_fallback_exceptiongroup.rst
@@ -1,0 +1,3 @@
+Native fallback for displaying ExceptionGroup
+--------------------------
+ExceptionGroups are now displayed with `traceback.print_exc`, as a temporary fix until UltraTB properly supports displaying child exceptions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     backcall
     colorama; sys_platform == "win32"
     decorator
-    exceptiongroup; python_version<'3.10'
+    exceptiongroup; python_version<'3.11'
     jedi>=0.16
     matplotlib-inline
     pexpect>4.3; sys_platform != "win32"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     backcall
     colorama; sys_platform == "win32"
     decorator
+    exceptiongroup; python_version<'3.10'
     jedi>=0.16
     matplotlib-inline
     pexpect>4.3; sys_platform != "win32"

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ doc =
     stack_data
     pytest<7
     typing_extensions
+    exceptiongroup
     %(test)s
 kernel =
     ipykernel


### PR DESCRIPTION
Fixes #13753 

I started looking into delving deeper into ultratb to add support for Exception Groups, but felt that this would be enough of an improvement over the status quo that it'd probably be worth implementing on it's own.
I also looked quite a bit at ipyparallel's `CompositeError` https://github.com/ipython/ipyparallel/blob/main/ipyparallel/error.py#L169, which seems like the equivalent of exception groups.

Remaining TODO:
- [x] add tests
- [x] add documentation

Will go ahead with those if the basic approach is deemed acceptable