### PR TITLE
Change "Non Expected" to "Unexpected" in exception messages.

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -581,7 +581,9 @@ class EmbeddedSphinxShell(object):
             s += "<<<" + ("-" * 73)
             logger.warning(s)
             if self.warning_is_error:
-                raise RuntimeError('Non Expected exception in `{}` line {}'.format(filename, lineno))
+                raise RuntimeError(
+                    "Unexpected exception in `{}` line {}".format(filename, lineno)
+                )
 
         # output any warning raised during execution to stdout
         # unless :okwarning: has been specified.
@@ -597,7 +599,9 @@ class EmbeddedSphinxShell(object):
                 s += "<<<" + ("-" * 73)
                 logger.warning(s)
                 if self.warning_is_error:
-                    raise RuntimeError('Non Expected warning in `{}` line {}'.format(filename, lineno))
+                    raise RuntimeError(
+                        "Unexpected warning in `{}` line {}".format(filename, lineno)
+                    )
 
         self.clear_cout()
         return (ret, input_lines, processed_output,


### PR DESCRIPTION
Hope this minor fix isn't considered noise.

The contents of this message do not seem to be depended upon in other parts of the codebase; can't speak for downstream applications, though.