### PR TITLE
Fix: change parso logging level

### DIFF
--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -15,9 +15,14 @@
 # Python standard modules
 import glob
 import io
+import logging
 import os
 import time
 
+
+
+# prevent jedi/parso's debug messages pipe into interactiveshell
+logging.getLogger("parso").setLevel(logging.WARNING)
 
 #****************************************************************************
 # FIXME: This class isn't a mixin anymore, but it still needs attributes from


### PR DESCRIPTION
This PR closes #10946.

I was wondering where to put this line.
I think the logger module is the best place.

The issue won't break the interactive shell now.