### PR TITLE
feat(debugger): support . (dot) as an argument of the l(ist) command in ipdb

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -640,7 +640,7 @@ class Pdb(OldPdb):
         """
         self.lastcmd = 'list'
         last = None
-        if arg:
+        if arg and arg != '.':
             try:
                 x = eval(arg, {}, {})
                 if type(x) == type(()):
@@ -655,7 +655,7 @@ class Pdb(OldPdb):
             except:
                 print('*** Error in argument:', repr(arg), file=self.stdout)
                 return
-        elif self.lineno is None:
+        elif self.lineno is None or arg == '.':
             first = max(1, self.curframe.f_lineno - 5)
         else:
             first = self.lineno + 1

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -640,7 +640,7 @@ class Pdb(OldPdb):
         """
         self.lastcmd = 'list'
         last = None
-        if arg and arg != '.':
+        if arg and arg != ".":
             try:
                 x = eval(arg, {}, {})
                 if type(x) == type(()):
@@ -655,7 +655,7 @@ class Pdb(OldPdb):
             except:
                 print('*** Error in argument:', repr(arg), file=self.stdout)
                 return
-        elif self.lineno is None or arg == '.':
+        elif self.lineno is None or arg == ".":
             first = max(1, self.curframe.f_lineno - 5)
         else:
             first = self.lineno + 1


### PR DESCRIPTION
Support `.` as an argument of the `l(ist)` command in the debugger.  This works in pdb but not work in ipdb right now (see [the relevant issue](https://github.com/gotcha/ipdb/issues/203)).