### PR TITLE
Refuse to install event loop hooks when not using `prompt_toolkit`

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -915,10 +915,14 @@ class TerminalInteractiveShell(InteractiveShell):
     active_eventloop = None
     def enable_gui(self, gui=None):
         if self.simple_prompt is True and gui is not None:
-            print(f"Cannot install event loop hook for \"{gui}\" when running with `--simple-prompt`.")
-            print("NOTE: Tk is supported natively; use Tk apps and Tk backends with `--simple-prompt`.")
+            print(
+                f'Cannot install event loop hook for "{gui}" when running with `--simple-prompt`.'
+            )
+            print(
+                "NOTE: Tk is supported natively; use Tk apps and Tk backends with `--simple-prompt`."
+            )
             return
-        
+
         if self._inputhook is None and gui is None:
             print("No event loop hook running.")
             return

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -914,6 +914,11 @@ class TerminalInteractiveShell(InteractiveShell):
 
     active_eventloop = None
     def enable_gui(self, gui=None):
+        if self.simple_prompt is True and gui is not None:
+            print(f"Cannot install event loop hook for \"{gui}\" when running with `--simple-prompt`.")
+            print("NOTE: Tk is supported natively; use Tk apps and Tk backends with `--simple-prompt`.")
+            return
+        
         if self._inputhook is None and gui is None:
             print("No event loop hook running.")
             return


### PR DESCRIPTION
Without this, `%gui` is effectively a no-op but the user thinks it works.

For example. If running `ipython`:

```
In [1]: import matplotlib; matplotlib.use('QtAgg'); from matplotlib import pyplot; pyplot.ion(); pyplot.plot([1, 2, 3, 4])        
Installed qt6 event loop hook.
Out[1]: [<matplotlib.lines.Line2D at 0x1ba2f59d2a0>]
```
The window appears and responds as expected.

If running `ipython --simple-prompt`, the user would see the same output, when in fact no event loop hook was installed since it's not supported without `prompt_toolkit`. The resulting Qt window is unresponsive because the event loop is not running, i.e. with `--simple-prompt`, Qt windows should block (but `pyplot` doesn't/can't know to do that)

With this PR, the user will see:
```
In [1]: import matplotlib; matplotlib.use('QtAgg'); from matplotlib import pyplot; pyplot.ion(); pyplot.plot([1, 2, 3, 4])
Cannot install event loop hook for "qt" when running with `--simple-prompt`.
NOTE: Tk is supported natively; use Tk apps and Tk backends with `--simple-prompt`.
Out[1]: [<matplotlib.lines.Line2D at 0x170be0c0310>]
```
They'll still get an unresponsive Qt window, but they'll at least be told this can't work (while anything using Tk will work just fine).