### PR TITLE
Fix clearing output references with `%reset out`

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -297,8 +297,11 @@ class DisplayHook(Configurable):
         for n in range(1,self.prompt_count + 1):
             key = '_'+repr(n)
             try:
+                del self.shell.user_ns_hidden[key]
+            except KeyError: pass
+            try:
                 del self.shell.user_ns[key]
-            except: pass
+            except KeyError: pass
         # In some embedded circumstances, the user_ns doesn't have the
         # '_oh' key set up.
         oh = self.shell.user_ns.get('_oh', None)

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -298,10 +298,12 @@ class DisplayHook(Configurable):
             key = '_'+repr(n)
             try:
                 del self.shell.user_ns_hidden[key]
-            except KeyError: pass
+            except KeyError:
+                pass
             try:
                 del self.shell.user_ns[key]
-            except KeyError: pass
+            except KeyError:
+                pass
         # In some embedded circumstances, the user_ns doesn't have the
         # '_oh' key set up.
         oh = self.shell.user_ns.get('_oh', None)


### PR DESCRIPTION
This should fix #14129. Namely the second reference to the output is stored in `user_ns_hidden`. That was already cleared during hard `%reset` but was not cleared when using `%reset out`. Manual `gc.collect()` is still required.