### PR TITLE
Add hack to change traceback syntax highlighting

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -809,6 +809,7 @@ class VerboseTB(TBTools):
     would appear in the traceback)."""
 
     _tb_highlight = "bg:ansiyellow"
+    _tb_highlight_style = "default"
 
     def __init__(
         self,
@@ -1110,7 +1111,7 @@ class VerboseTB(TBTools):
         after = context // 2
         before = context - after
         if self.has_colors:
-            style = get_style_by_name("default")
+            style = get_style_by_name(self._tb_highlight_style)
             style = stack_data.style_with_executing_node(style, self._tb_highlight)
             formatter = Terminal256Formatter(style=style)
         else:


### PR DESCRIPTION
Similar to #13756, add a hack to configure the Pygments style for syntax highlighting of tracebacks.

This does not change default behavior.

To use the hack, add to ipython_config.py:

    from IPython.core.ultratb import VerboseTB
    VerboseTB._tb_highlight_style = "pastie"

Mitigates #13953.