### PR TITLE
Fix DeprecationWarning on 3.12 with a datetime adapter for sqlite3

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -9,7 +9,6 @@ import datetime
 from pathlib import Path
 import re
 import sqlite3
-import sys
 import threading
 
 from traitlets.config.configurable import LoggingConfigurable
@@ -29,14 +28,6 @@ from traitlets import (
     default,
     observe,
 )
-
-
-if sys.version_info >= (3, 12):
-
-    def _adapt_datetime(val):
-        return val.isoformat(" ")
-
-    sqlite3.register_adapter(datetime.datetime, _adapt_datetime)
 
 #-----------------------------------------------------------------------------
 # Classes and functions
@@ -583,7 +574,7 @@ class HistoryManager(HistoryAccessor):
             cur = conn.execute(
                 """INSERT INTO sessions VALUES (NULL, ?, NULL,
                             NULL, '') """,
-                (datetime.datetime.now(),),
+                (datetime.datetime.now().isoformat(" "),),
             )
             self.session_number = cur.lastrowid
 
@@ -591,9 +582,15 @@ class HistoryManager(HistoryAccessor):
         """Close the database session, filling in the end time and line count."""
         self.writeout_cache()
         with self.db:
-            self.db.execute("""UPDATE sessions SET end=?, num_cmds=? WHERE
-                            session==?""", (datetime.datetime.now(),
-                            len(self.input_hist_parsed)-1, self.session_number))
+            self.db.execute(
+                """UPDATE sessions SET end=?, num_cmds=? WHERE
+                            session==?""",
+                (
+                    datetime.datetime.now().isoformat(" "),
+                    len(self.input_hist_parsed) - 1,
+                    self.session_number,
+                ),
+            )
         self.session_number = 0
 
     def name_session(self, name):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -9,6 +9,7 @@ import datetime
 from pathlib import Path
 import re
 import sqlite3
+import sys
 import threading
 
 from traitlets.config.configurable import LoggingConfigurable
@@ -28,6 +29,14 @@ from traitlets import (
     default,
     observe,
 )
+
+
+if sys.version_info >= (3, 12):
+
+    def _adapt_datetime(val):
+        return val.isoformat(" ")
+
+    sqlite3.register_adapter(datetime.datetime, _adapt_datetime)
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -20,7 +20,6 @@ import os
 import time
 
 
-
 # prevent jedi/parso's debug messages pipe into interactiveshell
 logging.getLogger("parso").setLevel(logging.WARNING)
 


### PR DESCRIPTION
After python/cpython#90016, default adapters and converters are deprecated.  See also
https://docs.python.org/3.12/library/sqlite3.html#sqlite3-adapter-converter-recipes