### PR TITLE
IPDB: Fix case where some Exceptions have no traceback.

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -419,7 +419,12 @@ class Pdb(OldPdb):
                     rep = repr(exc)
                     if len(rep) > 80:
                         rep = rep[:77] + "..."
-                    self.message(f"{prompt} {ix:>3} {rep}")
+                    indicator = (
+                        "  -"
+                        if self._chained_exceptions[ix].__traceback__ is None
+                        else f"{ix:>3}"
+                    )
+                    self.message(f"{prompt} {indicator} {rep}")
             else:
                 try:
                     number = int(arg)
@@ -427,6 +432,12 @@ class Pdb(OldPdb):
                     self.error("Argument must be an integer")
                     return
                 if 0 <= number < len(self._chained_exceptions):
+                    if self._chained_exceptions[number].__traceback__ is None:
+                        self.error(
+                            "This exception does not have a traceback, cannot jump to it"
+                        )
+                        return
+
                     self._chained_exception_index = number
                     self.setup(None, self._chained_exceptions[number].__traceback__)
                     self.print_stack_entry(self.stack[self.curindex])
@@ -438,6 +449,8 @@ class Pdb(OldPdb):
             if CHAIN_EXCEPTIONS:
                 # this context manager is part of interaction in 3.13
                 _chained_exceptions, tb = self._get_tb_and_exceptions(tb_or_exc)
+                if isinstance(tb_or_exc, BaseException):
+                    assert tb is not None, "main exception must have a traceback"
                 with self._hold_exceptions(_chained_exceptions):
                     OldPdb.interaction(self, frame, tb)
             else:


### PR DESCRIPTION
In chained exception if some exceptions does not have tracebacks, prevent jumping to them.

We also add the assert that the main exception does have a traceback.

This is a partial port of python/cpython commit 5f3433f210d25d366fcebfb40adf444c8f46cd59