### PR TITLE
Fix wrong u-prefix for strings in magics docs.

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -122,7 +122,7 @@ class BasicMagics(Magics):
           Created `%whereami` as an alias for `%pwd`.
 
           In [6]: %whereami
-          Out[6]: u'/home/testuser'
+          Out[6]: '/home/testuser'
 
           In [7]: %alias_magic h history "-p -l 30" --line
           Created `%h` as an alias for `%history -l 30`.
@@ -537,25 +537,25 @@ Currently the magic system has the following functions:""",
             In [1]: from math import pi
 
             In [2]: %precision 3
-            Out[2]: u'%.3f'
+            Out[2]: '%.3f'
 
             In [3]: pi
             Out[3]: 3.142
 
             In [4]: %precision %i
-            Out[4]: u'%i'
+            Out[4]: '%i'
 
             In [5]: pi
             Out[5]: 3
 
             In [6]: %precision %e
-            Out[6]: u'%e'
+            Out[6]: '%e'
 
             In [7]: pi**10
             Out[7]: 9.364805e+04
 
             In [8]: %precision
-            Out[8]: u'%r'
+            Out[8]: '%r'
 
             In [9]: pi**10
             Out[9]: 93648.047476082982


### PR DESCRIPTION
`%precision` doesn't output `u'%r'` on Python 3, but `'%r'`.

(Note that the point of this PR is explicitly not to remove u-prefixes on all strings -- something that would likely be better done by automated tooling anyways -- but only on those occurring within some docstrings that end up in the rendered docs, which would more likely not have been found by tooling.)