### PR TITLE
Make `ipapp.py` unrunnable as one py file, due to relative import

### DIFF
--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # encoding: utf-8
 """
 The :class:`~traitlets.config.application.Application` object for the command
@@ -337,7 +336,3 @@ def load_default_config(ipython_dir=None):
     return app.config
 
 launch_new_instance = TerminalIPythonApp.launch_instance
-
-
-if __name__ == '__main__':
-    launch_new_instance()


### PR DESCRIPTION
fixes #14159