### PR TITLE
Fix temporary folder cleanup on exit

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -21,6 +21,7 @@ import inspect
 import os
 import re
 import runpy
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -3902,7 +3903,7 @@ class InteractiveShell(SingletonConfigurable):
         del self.tempfiles
         for tdir in self.tempdirs:
             try:
-                tdir.rmdir()
+                shutil.rmtree(tdir)
                 self.tempdirs.remove(tdir)
             except FileNotFoundError:
                 pass


### PR DESCRIPTION
When using mkdtemp, the folder content cleanup must be done by the user.

The current call to `rmdir` fails in case additional files are generated while editing the code. For example vim with undofile activated does this.

Fixes #14099 