### PR TITLE
Update release script to use git switch in place of checkout

### DIFF
--- a/tools/release_helper.sh
+++ b/tools/release_helper.sh
@@ -1,5 +1,5 @@
 # Simple tool to help for release
-# when releasing with bash, simple source it to get asked questions. 
+# when releasing with bash, simple source it to get asked questions.
 
 # misc check before starting
 BLACK=$(tput setaf 1)
@@ -62,7 +62,7 @@ ask_section(){
 
 maybe_edit(){
     echo
-    echo $BLUE"$1"$NOR 
+    echo $BLUE"$1"$NOR
     echo -n $GREEN"Press ${BLUE}e$GREEN to Edit ${BLUE}$1$GREEN, any other keys to skip: "$NOR
     if [ "$ZSH_NAME" = "zsh" ] ; then
         read -k1 value
@@ -71,7 +71,7 @@ maybe_edit(){
        read -n1 value
     fi
 
-    echo 
+    echo
     if [ $value = 'e' ]  ; then
         $=EDITOR $1
     fi
@@ -79,7 +79,7 @@ maybe_edit(){
 
 
 
-echo 
+echo
 if ask_section "Updating what's new with information from docs/source/whatsnew/pr"
 then
     python tools/update_whatsnew.py
@@ -93,11 +93,11 @@ fi
 if ask_section "Gen Stats, and authors"
 then
 
-    echo 
+    echo
     echo $BLUE"here are all the authors that contributed to this release:"$NOR
     git log --format="%aN <%aE>" $PREV_RELEASE... | sort -u -f
 
-    echo 
+    echo
     echo $BLUE"If you see any duplicates cancel (Ctrl-C), then edit .mailmap."
     echo $GREEN"Press enter to continue:"$NOR
     read
@@ -115,12 +115,12 @@ fi
 if ask_section "Generate API difference (using frapuccino)"
 then
     echo $BLUE"Checking out $PREV_RELEASE"$NOR
-    git checkout $PREV_RELEASE
+    git switch $PREV_RELEASE
     sleep 1
     echo $BLUE"Saving API to file $PREV_RELEASE"$NOR
     frappuccino IPython IPython.kernel IPython.lib IPython.qt IPython.lib.kernel IPython.html IPython.frontend IPython.external --save IPython-$PREV_RELEASE.json
     echo $BLUE"coming back to $BRANCH"$NOR
-    git checkout $BRANCH
+    git switch $BRANCH
     sleep 1
     echo $BLUE"comparing ..."$NOR
     frappuccino IPython IPython.kernel IPython.lib --compare IPython-$PREV_RELEASE.json
@@ -145,7 +145,7 @@ read
 if ask_section "Build the documentation ?"
 then
     make html -C docs
-    echo 
+    echo
     echo $GREEN"Check the docs, press enter to continue"$NOR
     read
 
@@ -158,27 +158,27 @@ then
    echo $GREEN"Press enter to commit"$NOR
    read
    git commit -am "release $VERSION" -S
-   
+
    echo
    echo $BLUE"git push origin \$BRANCH ($BRANCH)?"$NOR
    echo $GREEN"Make sure you can push"$NOR
    echo $GREEN"Press enter to continue"$NOR
    read
    git push origin $BRANCH
-   
+
    echo
    echo "Let's tag : git tag -am \"release $VERSION\" \"$VERSION\" -s"
    echo $GREEN"Press enter to tag commit"$NOR
    read
    git tag -am "release $VERSION" "$VERSION" -s
-   
+
    echo
    echo $BLUE"And push the tag: git push origin \$VERSION ?"$NOR
    echo $GREEN"Press enter to continue"$NOR
    read
    git push origin $VERSION
-   
-   
+
+
    echo $GREEN"please update version number and back to .dev in ${RED}IPython/core/release.py"
    echo $GREEN"I tried ${RED}sed -i bkp -e '/Uncomment/s/^/# /g' IPython/core/release.py${NOR}"
    sed -i bkp -e '/Uncomment/s/^/# /g' IPython/core/release.py
@@ -188,10 +188,10 @@ then
    maybe_edit IPython/core/release.py
    echo ${BLUE}"Do not commit yet – we'll do it later."$NOR
 
-   
+
    echo $GREEN"Press enter to continue"$NOR
    read
-   
+
    echo
    echo "Let's commit : "$BLUE"git commit -am \"back to dev\""$NOR
    echo $GREEN"Press enter to commit"$NOR
@@ -204,17 +204,17 @@ then
    read
    git push origin $BRANCH
 
-   
+
    echo
-   echo $BLUE"let's : git checkout $VERSION"$NOR
+   echo $BLUE"let's : git switch $VERSION"$NOR
    echo $GREEN"Press enter to continue"$NOR
    read
-   git checkout $VERSION
+   git switch $VERSION
 fi
 
 if ask_section "Should we build and release ?"
 then
-    
+
     echo $BLUE"going to set SOURCE_DATE_EPOCH"$NOR
     echo $BLUE'export SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)'$NOR
     echo $GREEN"Press enter to continue"$NOR
@@ -253,7 +253,7 @@ then
     echo $NOR
 
     if ask_section "upload packages ?"
-    then 
+    then
        tools/release upload
     fi
 fi


### PR DESCRIPTION
Git checkout has been deprecated in favor of git switch.

The switch sub command is dedicated to branch handling while checkout did several different unrelated things which made it error prone.

Fixes #13910 