### PR TITLE
displayhook - get reference to the actual executed cell

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -13,7 +13,7 @@ import io as _io
 import tokenize
 
 from traitlets.config.configurable import Configurable
-from traitlets import Instance, Float
+from traitlets import Instance, Unicode, Float
 from warnings import warn
 
 # TODO: Move the various attributes (cache_size, [others now moved]). Some
@@ -31,6 +31,7 @@ class DisplayHook(Configurable):
                      allow_none=True)
     exec_result = Instance('IPython.core.interactiveshell.ExecutionResult',
                            allow_none=True)
+    exec_cell = Unicode(allow_none=True)
     cull_fraction = Float(0.2)
 
     def __init__(self, shell=None, cache_size=1000, **kwargs):
@@ -83,8 +84,8 @@ class DisplayHook(Configurable):
 
     def quiet(self):
         """Should we silence the display hook because of ';'?"""
-        if self.exec_result is not None:
-            return self.semicolon_at_end_of_expression(self.exec_result.info.raw_cell)
+        if self.exec_result is not None and self.exec_result.cell is not None:
+            return self.semicolon_at_end_of_expression(self.exec_result.cell)
         return False
 
     @staticmethod

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -255,6 +255,7 @@ class ExecutionResult(object):
     error_in_exec: Optional[BaseException] = None
     info = None
     result = None
+    cell = None
 
     def __init__(self, info):
         self.info = info
@@ -3223,6 +3224,8 @@ class InteractiveShell(SingletonConfigurable):
                 cell = transformed_cell
             else:
                 cell = raw_cell
+
+        result.cell = cell
 
         # Do NOT store paste/cpaste magic history
         if "get_ipython().run_line_magic(" in cell and "paste" in cell:

--- a/IPython/core/tests/test_magic.py
+++ b/IPython/core/tests/test_magic.py
@@ -1546,3 +1546,31 @@ def test_run_module_from_import_hook():
         assert output == captured.stdout
 
         sys.meta_path.pop(0)
+
+
+def doctest_magic_output_can_be_silenced():
+    """Test ...
+    In [1]: from IPython.core.magic import register_line_magic, output_can_be_silenced
+
+    In [2]: @register_line_magic
+       ...: def echo_magic(line):
+       ...:     return line
+       ...:
+
+    In [3]: @register_line_magic
+       ...: @output_can_be_silenced
+       ...: def echo_magic_can_be_silenced(line):
+       ...:     return line
+       ...:
+
+    In [4]: %echo_magic hello
+    Out[4]: 'hello'
+
+    In [5]: %echo_magic hello;
+    Out[5]: 'hello;'
+
+    In [6]: %echo_magic_can_be_silenced hello;
+
+    In [7]: %echo_magic_can_be_silenced hello
+    Out[7]: 'hello'
+    """


### PR DESCRIPTION
raw_cell might need transformation and cannot be tokenized.
Fixes #7256