### PR TITLE
Adding more pre-commit arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
     rev: 1.7.2
     hooks:
     -   id: darker
+        additional_dependencies: [isort, mypy, flake8]


### PR DESCRIPTION
This will add `isort`, `mypy`, `flake8` as pre-commit arguments in `.pre-commit-config.yaml`. 

See: #14192 
