### PR TITLE
[perf] optimize object inspect

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -416,6 +416,8 @@ class Inspector(Colorable):
 
         If any exception is generated, None is returned instead and the
         exception is suppressed."""
+        if not callable(obj):
+            return None        
         try:
             return _render_signature(signature(obj), oname)
         except:

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -417,7 +417,7 @@ class Inspector(Colorable):
         If any exception is generated, None is returned instead and the
         exception is suppressed."""
         if not callable(obj):
-            return None        
+            return None
         try:
             return _render_signature(signature(obj), oname)
         except:


### PR DESCRIPTION
Do not call signature(obj) for non-callables. Signature, will check and raise a exception where the message will contain `obj.__repr__` and that can be very expensive (take minutes) on certain objects. 