### PR TITLE
Attempt to remove backcall.

### DIFF
--- a/IPython/core/events.py
+++ b/IPython/core/events.py
@@ -89,9 +89,8 @@ class EventManager(object):
 available_events = {}
 
 def _define_event(callback_function):
-    callback_proto = callback_prototype(callback_function)
-    available_events[callback_function.__name__] = callback_proto
-    return callback_proto
+    available_events[callback_function.__name__] = callback_function
+    return callback_function
 
 # ------------------------------------------------------------------------------
 # Callback prototypes

--- a/IPython/core/events.py
+++ b/IPython/core/events.py
@@ -13,8 +13,6 @@ events and the arguments which will be passed to them.
    This API is experimental in IPython 2.0, and may be revised in future versions.
 """
 
-from backcall import callback_prototype
-
 
 class EventManager(object):
     """Manage a collection of events and a sequence of callbacks for each.
@@ -63,22 +61,13 @@ class EventManager(object):
         """
         if not callable(function):
             raise TypeError('Need a callable, got %r' % function)
-        callback_proto = available_events.get(event)
         if function not in self.callbacks[event]:
-            self.callbacks[event].append(callback_proto.adapt(function))
+            self.callbacks[event].append(function)
     
     def unregister(self, event, function):
         """Remove a callback from the given event."""
         if function in self.callbacks[event]:
             return self.callbacks[event].remove(function)
-
-        # Remove callback in case ``function`` was adapted by `backcall`.
-        for callback in self.callbacks[event]:
-            try:
-                if callback.__wrapped__ is function:
-                    return self.callbacks[event].remove(callback)
-            except AttributeError:
-                pass
 
         raise ValueError('Function {!r} is not registered as a {} callback'.format(function, event))
 

--- a/IPython/core/tests/test_events.py
+++ b/IPython/core/tests/test_events.py
@@ -76,16 +76,3 @@ class CallbackTests(unittest.TestCase):
         self.em.trigger('ping_received')
         self.assertEqual([True, True, False], invoked)
         self.assertEqual([func3], self.em.callbacks['ping_received'])
-    
-    def test_ignore_event_arguments_if_no_argument_required(self):
-        call_count = [0]
-        def event_with_no_argument():
-            call_count[0] += 1
-
-        self.em.register('event_with_argument', event_with_no_argument)
-        self.em.trigger('event_with_argument', 'the argument')
-        self.assertEqual(call_count[0], 1)
-        
-        self.em.unregister('event_with_argument', event_with_no_argument)
-        self.em.trigger('ping_received')
-        self.assertEqual(call_count[0], 1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ python_requires = >=3.9
 zip_safe = False
 install_requires =
     appnope; sys_platform == "darwin"
-    backcall
     colorama; sys_platform == "win32"
     decorator
     exceptiongroup; python_version<'3.11'


### PR DESCRIPTION
This was meant to allow this API to evolve, but I have the impression was not use much.

This will reduce our dependencies and reliance on older packages.