### PR TITLE
refactor: Use pathlib in tools/

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -7,28 +7,29 @@ from __future__ import print_function
 
 import os
 from glob import glob
+from pathlib import Path
 from subprocess import call
 import sys
 
-from toollib import (get_ipdir, pjoin, cd, execfile, sh, archive,
+from toollib import (get_ipdir, cd, execfile, sh, archive,
          archive_user, archive_dir)
 
 # Get main ipython dir, this will raise if it doesn't pass some checks
 ipdir = get_ipdir()
-tooldir = pjoin(ipdir, 'tools')
-distdir = pjoin(ipdir, 'dist')
+tooldir = ipdir / 'tools'
+distdir = ipdir / 'dist'
 
 # Where I keep static backups of each release
-ipbackupdir = os.path.expanduser('~/ipython/backup')
-if not os.path.exists(ipbackupdir):
-    os.makedirs(ipbackupdir)
+ipbackupdir = Path('~/ipython/backup').expanduser()
+if not ipbackupdir.exists():
+    ipbackupdir.mkdir(parents=True, exist_ok=True)
 
 # Start in main IPython dir
 cd(ipdir)
 
 # Load release info
 version = None
-execfile(pjoin('IPython','core','release.py'), globals())
+execfile(Path('IPython','core','release.py'), globals())
 
 # Build site addresses for file uploads
 release_site = '%s/release/%s' % (archive, version)

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -5,8 +5,9 @@
 import os
 import sys
 
+from pathlib import Path
+
 # Useful shorthands
-pjoin = os.path.join
 cd = os.chdir
 
 # Constants
@@ -34,13 +35,12 @@ def get_ipdir():
     """Get IPython directory from command line, or assume it's the one above."""
 
     # Initialize arguments and check location
-    ipdir = pjoin(os.path.dirname(__file__), os.pardir)
-
-    ipdir = os.path.abspath(ipdir)
+    ipdir = Path(__file__).parent / os.pardir
+    ipdir = ipdir.resolve()
 
     cd(ipdir)
-    if not os.path.isdir('IPython') and os.path.isfile('setup.py'):
-        raise SystemExit('Invalid ipython directory: %s' % ipdir)
+    if not Path("IPython").is_dir() and Path("setup.py").is_file():
+        raise SystemExit("Invalid ipython directory: %s" % ipdir)
     return ipdir
 
 def execfile(fname, globs, locs=None):


### PR DESCRIPTION
Since script `release` is meant to be run only when doing the actual release of ipython, I could not easily verify it works correctly.
So please double check if it still works the same way as before.

Related to: #12515 