### PR TITLE
Feature/add line numbers to prompt

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -747,7 +747,7 @@ class TerminalInteractiveShell(InteractiveShell):
         def get_message():
             return PygmentsTokens(self.prompts.in_prompt_tokens())
 
-        if self.editing_mode == 'emacs' and self.prompt_line_number_format == '':
+        if self.editing_mode == "emacs" and self.prompt_line_number_format == "":
             # with emacs mode the prompt is (usually) static, so we call only
             # the function once. With VI mode it can toggle between [ins] and
             # [nor] so we can't precompute.

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -747,7 +747,7 @@ class TerminalInteractiveShell(InteractiveShell):
         def get_message():
             return PygmentsTokens(self.prompts.in_prompt_tokens())
 
-        if self.editing_mode == 'emacs':
+        if self.editing_mode == 'emacs' and self.prompt_line_number_format == '':
             # with emacs mode the prompt is (usually) static, so we call only
             # the function once. With VI mode it can toggle between [ins] and
             # [nor] so we can't precompute.

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -753,7 +753,7 @@ class TerminalInteractiveShell(InteractiveShell):
             "message": get_message,
             "prompt_continuation": (
                 lambda width, lineno, is_soft_wrap: PygmentsTokens(
-                    self.prompts.continuation_prompt_tokens(width)
+                    self.prompts.continuation_prompt_tokens(width, lineno=lineno)
                 )
             ),
             "multiline": True,

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -588,6 +588,17 @@ class TerminalInteractiveShell(InteractiveShell):
         help="Display the current vi mode (when using vi editing mode)."
     ).tag(config=True)
 
+    prompt_line_number_format = Unicode(
+        "",
+        help="The format for line numbering, will be passed `line` (int, 1 based)"
+        " the current line number and `rel_line` the relative line number."
+        " for example to display both you can use the following template string :"
+        " c.TerminalInteractiveShell.prompt_line_number_format='{line: 4d}/{rel_line:+03d} | '"
+        " This will display the current line number, with leading space and a width of at least 4"
+        " character, as well as the relative line number 0 padded and always with a + or - sign."
+        " Note that when using Emacs mode the prompt of the first line may not update.",
+    ).tag(config=True)
+
     @observe('term_title')
     def init_term_title(self, change=None):
         # Enable or disable the terminal title.

--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -25,11 +25,20 @@ class Prompts(object):
             return '['+mode+'] '
         return ''
 
+    def current_line(self) -> int:
+        if self.shell.pt_app is not None:
+            return self.shell.pt_app.default_buffer.document.cursor_position_row or 0
+        return 0
 
     def in_prompt_tokens(self):
         return [
             (Token.Prompt, self.vi_mode()),
-            (Token.Prompt, "1 | "),
+            (
+                Token.Prompt,
+                self.shell.prompt_line_number_format.format(
+                    line=1, rel_line=-self.current_line()
+                ),
+            ),
             (Token.Prompt, "In ["),
             (Token.PromptNum, str(self.shell.execution_count)),
             (Token.Prompt, ']: '),
@@ -41,7 +50,12 @@ class Prompts(object):
     def continuation_prompt_tokens(self, width=None, *, lineno=None):
         if width is None:
             width = self._width()
-        prefix = " " * len(self.vi_mode()) + str(lineno + 1) + " | "
+        line = lineno + 1 if lineno is not None else 0
+        prefix = " " * len(
+            self.vi_mode()
+        ) + self.shell.prompt_line_number_format.format(
+            line=line, rel_line=line - self.current_line() - 1
+        )
         return [
             (
                 Token.Prompt,

--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -28,8 +28,9 @@ class Prompts(object):
 
     def in_prompt_tokens(self):
         return [
-            (Token.Prompt, self.vi_mode() ),
-            (Token.Prompt, 'In ['),
+            (Token.Prompt, self.vi_mode()),
+            (Token.Prompt, "1 | "),
+            (Token.Prompt, "In ["),
             (Token.PromptNum, str(self.shell.execution_count)),
             (Token.Prompt, ']: '),
         ]
@@ -37,11 +38,15 @@ class Prompts(object):
     def _width(self):
         return fragment_list_width(self.in_prompt_tokens())
 
-    def continuation_prompt_tokens(self, width=None):
+    def continuation_prompt_tokens(self, width=None, *, lineno=None):
         if width is None:
             width = self._width()
+        prefix = " " * len(self.vi_mode()) + str(lineno + 1) + " | "
         return [
-            (Token.Prompt, (' ' * (width - 5)) + '...: '),
+            (
+                Token.Prompt,
+                prefix + (" " * (width - len(prefix) - 5)) + "...: ",
+            ),
         ]
 
     def rewrite_prompt_tokens(self):

--- a/docs/source/whatsnew/pr/incompat-line-numbers.rst
+++ b/docs/source/whatsnew/pr/incompat-line-numbers.rst
@@ -1,0 +1,4 @@
+Line Numbers
+============
+
+This PR add line numbers to the default prompt.


### PR DESCRIPTION
This PR adds line numbers to the default prompt (#13965).

Emacs mode preview:

![image](https://github.com/ipython/ipython/assets/62400541/c347c3a1-8d90-450a-b52c-ad12f257fa1e)

Vim mode preview:

![image](https://github.com/ipython/ipython/assets/62400541/db5cde79-ab7d-4875-90be-7e791c300bb6)

**Note:** These changes are untested for now. I am struggling to run the existing tests in my dev environment. Are there any instructions on how to get everything set up for testing purposes?