### PR TITLE
Fix #14230 (missing param for autoreload)

### DIFF
--- a/IPython/core/events.py
+++ b/IPython/core/events.py
@@ -82,7 +82,11 @@ class EventManager(object):
                 func(*args, **kwargs)
             except (Exception, KeyboardInterrupt):
                 if self.print_on_error:
-                    print("Error in callback {} (for {}):".format(func, event))
+                    print(
+                        "Error in callback {} (for {}), with arguments args {},kwargs {}:".format(
+                            func, event, args, kwargs
+                        )
+                    )
                 self.shell.showtraceback()
 
 # event_name -> prototype mapping

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -701,7 +701,7 @@ class AutoreloadMagics(Magics):
                     # Inject module to user namespace
                     self.shell.push({top_name: top_module})
 
-    def pre_run_cell(self):
+    def pre_run_cell(self, info):
         if self._reloader.enabled:
             try:
                 self._reloader.check()

--- a/IPython/extensions/tests/test_autoreload.py
+++ b/IPython/extensions/tests/test_autoreload.py
@@ -21,6 +21,7 @@ import textwrap
 import shutil
 import random
 import time
+import traceback
 from io import StringIO
 from dataclasses import dataclass
 
@@ -31,6 +32,7 @@ from unittest import TestCase
 from IPython.extensions.autoreload import AutoreloadMagics
 from IPython.core.events import EventManager, pre_run_cell
 from IPython.testing.decorators import skipif_not_numpy
+from IPython.core.interactiveshell import ExecutionInfo
 
 if platform.python_implementation() == "PyPy":
     pytest.skip(
@@ -56,8 +58,27 @@ class FakeShell:
 
     register_magics = set_hook = noop
 
+    def showtraceback(
+        self,
+        exc_tuple=None,
+        filename=None,
+        tb_offset=None,
+        exception_only=False,
+        running_compiled_code=False,
+    ):
+        traceback.print_exc()
+
     def run_code(self, code):
-        self.events.trigger("pre_run_cell")
+        self.events.trigger(
+            "pre_run_cell",
+            ExecutionInfo(
+                raw_cell="",
+                store_history=False,
+                silent=False,
+                shell_futures=False,
+                cell_id=None,
+            ),
+        )
         exec(code, self.user_ns)
         self.auto_magics.post_execute_hook()
 
@@ -279,6 +300,7 @@ class TestAutoreload(Fixture):
     @skipif_not_numpy
     def test_comparing_numpy_structures(self):
         self.shell.magic_autoreload("2")
+        self.shell.run_code("1+1")
         mod_name, mod_fn = self.new_module(
             textwrap.dedent(
                 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ qtconsole =
 terminal =
 test =
     pytest<7.1
-    pytest-asyncio
+    pytest-asyncio<0.22
     testpath
     pickleshare
 test_extra =


### PR DESCRIPTION
This extend the tests to actually trigger the same event as what the shell is doing, and updating the auto reload callback to accept more parameters.

It also improve both the logging and test  mock to log more informations on failure.