### PR TITLE
Remove unused dependency `appnope`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ packages = find:
 python_requires = >=3.9
 zip_safe = False
 install_requires =
-    appnope; sys_platform == "darwin"
     colorama; sys_platform == "win32"
     decorator
     exceptiongroup; python_version<'3.11'


### PR DESCRIPTION
Remove the dependency `appnope` as it is no longer being used, but still being installed on macOS.

Last seen in version `3.2.3`.
Removed in https://github.com/ipython/ipython/pull/6662.

`IPython/external/appnope` exists in `3.2.3`:
https://github.com/ipython/ipython/tree/3.2.3/IPython/external

Gone in the next version (`4.0.0`):
https://github.com/ipython/ipython/tree/4.0.0/IPython/external