### PR TITLE
Fix inputhook integration - Pass inputhook as an argument to Promptsesion.run().

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -631,7 +631,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
         editing_mode = getattr(EditingMode, self.editing_mode.upper())
 
-        self.pt_loop = asyncio.new_event_loop()
+        self._use_asyncio_inputhook = False
         self.pt_app = PromptSession(
             auto_suggest=self.auto_suggest,
             editing_mode=editing_mode,
@@ -798,24 +798,23 @@ class TerminalInteractiveShell(InteractiveShell):
         # If we don't do this, people could spawn coroutine with a
         # while/true inside which will freeze the prompt.
 
-        policy = asyncio.get_event_loop_policy()
-        old_loop = get_asyncio_loop()
-
-        # FIXME: prompt_toolkit is using the deprecated `asyncio.get_event_loop`
-        # to get the current event loop.
-        # This will probably be replaced by an attribute or input argument,
-        # at which point we can stop calling the soon-to-be-deprecated `set_event_loop` here.
-        if old_loop is not self.pt_loop:
-            policy.set_event_loop(self.pt_loop)
-        try:
-            with patch_stdout(raw=True):
+        with patch_stdout(raw=True):
+            if self._use_asyncio_inputhook:
+                # When we integrate the asyncio event loop, run the UI in the
+                # same event loop as the rest of the code. don't use an actual
+                # input hook. (Asyncio is not made for nesting event loops.)
+                asyncio_loop = get_asyncio_loop()
+                text = asyncio_loop.run_until_complete(
+                    self.pt_app.prompt_async(
+                        default=default, **self._extra_prompt_options()
+                    )
+                )
+            else:
                 text = self.pt_app.prompt(
                     default=default,
-                    **self._extra_prompt_options())
-        finally:
-            # Restore the original event loop.
-            if old_loop is not None and old_loop is not self.pt_loop:
-                policy.set_event_loop(old_loop)
+                    inputhook=self._inputhook,
+                    **self._extra_prompt_options(),
+                )
 
         return text
 
@@ -950,29 +949,7 @@ class TerminalInteractiveShell(InteractiveShell):
         else:
             self.active_eventloop = self._inputhook = None
 
-        # For prompt_toolkit 3.0. We have to create an asyncio event loop with
-        # this inputhook.
-        if PTK3:
-            import asyncio
-            from prompt_toolkit.eventloop import new_eventloop_with_inputhook
-
-            if gui == 'asyncio':
-                # When we integrate the asyncio event loop, run the UI in the
-                # same event loop as the rest of the code. don't use an actual
-                # input hook. (Asyncio is not made for nesting event loops.)
-                self.pt_loop = get_asyncio_loop()
-                print("Installed asyncio event loop hook.")
-
-            elif self._inputhook:
-                # If an inputhook was set, create a new asyncio event loop with
-                # this inputhook for the prompt.
-                self.pt_loop = new_eventloop_with_inputhook(self._inputhook)
-                print(f"Installed {self.active_eventloop} event loop hook.")
-            else:
-                # When there's no inputhook, run the prompt in a separate
-                # asyncio event loop.
-                self.pt_loop = asyncio.new_event_loop()
-                print("GUI event loop hook disabled.")
+        self._use_asyncio_inputhook = gui == "asyncio"
 
     # Run !system commands directly, not through pipes, so terminal programs
     # work correctly.


### PR DESCRIPTION
See: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1809

To summarize:
- In prompt_toolkit, some changes were done to get rid of a deprecation warning related to the usage of `set_event_loop()` on Python 3.12. It looks like IPython did had a workaround for the deprecation warning, but Xonsh for instance did not. Now, the code that was fixed in prompt_toolkit breaks input hooks in IPython.
- The right thing to do would be to accept the input hook as an argument in prompt_toolkit, which is what this PR does: https://github.com/prompt-toolkit/python-prompt-toolkit/pull/1810
- For IPython, we have to do a similar change to pass it as an argument (this PR).

It's not well tested (I'm not using IPython with inputhooks myself). I'm also not very familiar myself with IPython's code base.

I think it requires some coordination. I'm not sure if there's a way to be backward compatible. I guess if I push a new prompt_toolkit version with the fix on my side, nothing will break, but input hooks will for sure not work on any Python version until this is merged.

We should probably set the minimum prompt_toolkit version after merging this.
