### PR TITLE
Fix memory leak in Qt event loop integration (#14240)

### DIFF
--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -84,3 +84,5 @@ def inputhook(context):
                 _exec(event_loop)
         finally:
             notifier.setEnabled(False)
+    # make sure that the QObject is being deleted
+    event_loop.setParent(None)

--- a/IPython/terminal/pt_inputhooks/qt.py
+++ b/IPython/terminal/pt_inputhooks/qt.py
@@ -84,5 +84,7 @@ def inputhook(context):
                 _exec(event_loop)
         finally:
             notifier.setEnabled(False)
-    # make sure that the QObject is being deleted
+
+    # This makes sure that the event loop is garbage collected.
+    # See issue 14240.
     event_loop.setParent(None)


### PR DESCRIPTION
The QEventLoop object, `event_loop`, created in `IPython/terminal/pt_intputhooks/qt.py` L58 is not deleted when exiting the scope as passing `app` to the constructor parents the object to `app`. This creates a memory leak as QEventLoop objects are being accumulated.

The issue was originally reported by @pag who also suggested the fix.

`pytest IPython/terminal/tests/` runs through without errors. I have tested the changes and see no more accumulation of `QEventLoop` objects.

This fixes #14240
