### PR TITLE
Drop 3.9

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         include:
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         deps: [test_extra]
         # Test all on ubuntu, test ends on macos
         include:
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.10"
             deps: test_extra
           - os: macos-latest
             python-version: "3.11"
@@ -35,17 +35,17 @@ jobs:
             deps: test
           # Tests latest development Python version
           - os: ubuntu-latest
-            python-version: "3.12-dev"
+            python-version: "3.13-dev"
             deps: test
           # Installing optional dependencies stuff takes ages on PyPy
           - os: ubuntu-latest
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
             deps: test
           - os: windows-latest
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
             deps: test
           - os: macos-latest
-            python-version: "pypy-3.9"
+            python-version: "pypy-3.10"
             deps: test
 
     steps:

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -26,9 +26,10 @@ import sys
 #-----------------------------------------------------------------------------
 
 # Don't forget to also update setup.py when this changes!
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 10):
     raise ImportError(
         """
+IPython 8.19+ supports Python 3.10 and above, following SPEC0.
 IPython 8.13+ supports Python 3.9 and above, following NEP 29.
 IPython 8.0-8.12 supports Python 3.8 and above, following NEP 29.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -28,10 +28,7 @@ import warnings
 
 from typing import Any, Optional, Dict, Union, List, Tuple
 
-if sys.version_info <= (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias
+from typing import TypeAlias
 
 # IPython's own
 from IPython.core import page

--- a/IPython/core/tests/test_async_helpers.py
+++ b/IPython/core/tests/test_async_helpers.py
@@ -3,13 +3,15 @@ Test for async helpers.
 
 Should only trigger on python 3.5+ or will have syntax errors.
 """
-import platform
 from itertools import chain, repeat
 from textwrap import dedent, indent
-from unittest import TestCase
-from IPython.testing.decorators import skip_without
-import sys
 from typing import TYPE_CHECKING
+from unittest import TestCase
+
+import pytest
+
+from IPython.core.async_helpers import _should_be_async
+from IPython.testing.decorators import skip_without
 
 if TYPE_CHECKING:
     from IPython import get_ipython
@@ -17,10 +19,13 @@ if TYPE_CHECKING:
     ip = get_ipython()
 
 
-iprc = lambda x: ip.run_cell(dedent(x)).raise_error()
-iprc_nr = lambda x: ip.run_cell(dedent(x))
+def iprc(x):
+    return ip.run_cell(dedent(x)).raise_error()
 
-from IPython.core.async_helpers import _should_be_async
+
+def iprc_nr(x):
+    return ip.run_cell(dedent(x))
+
 
 class AsyncTest(TestCase):
     def test_should_be_async(self):
@@ -283,7 +288,11 @@ class AsyncTest(TestCase):
 
         iprc("(" * 200 + ")" * 200)
 
-    @skip_without('curio')
+    @pytest.mark.xfail(reason="fail on curio 1.6 and before on Python 3.12")
+    @pytest.mark.skip(
+        reason="skip_without(curio) fails on 3.12 for now even with other skip so must uncond skip"
+    )
+    # @skip_without("curio")
     def test_autoawait_curio(self):
         iprc("%autoawait curio")
 

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -322,7 +322,7 @@ class InputSplitterTestCase(unittest.TestCase):
 
     @pytest.mark.xfail(
         reason="Bug in python 3.9.8 – bpo 45738",
-        condition=sys.version_info in [(3, 9, 8, "final", 0), (3, 11, 0, "alpha", 2)],
+        condition=sys.version_info in [(3, 11, 0, "alpha", 2)],
         raises=SystemError,
         strict=True,
     )

--- a/IPython/core/tests/test_inputtransformer2.py
+++ b/IPython/core/tests/test_inputtransformer2.py
@@ -319,8 +319,7 @@ examples = [
         None,
         marks=pytest.mark.xfail(
             reason="Bug in python 3.9.8 – bpo 45738",
-            condition=sys.version_info
-            in [(3, 9, 8, "final", 0), (3, 11, 0, "alpha", 2)],
+            condition=sys.version_info in [(3, 11, 0, "alpha", 2)],
             raises=SystemError,
             strict=True,
         ),
@@ -338,7 +337,7 @@ def test_check_complete_param(code, expected, number):
 @pytest.mark.xfail(platform.python_implementation() == "PyPy", reason="fail on pypy")
 @pytest.mark.xfail(
     reason="Bug in python 3.9.8 – bpo 45738",
-    condition=sys.version_info in [(3, 9, 8, "final", 0), (3, 11, 0, "alpha", 2)],
+    condition=sys.version_info in [(3, 11, 0, "alpha", 2)],
     raises=SystemError,
     strict=True,
 )

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -64,7 +64,7 @@ def test_inspect_getfile_raises_exception():
     """Check oinspect.find_file/getsource/find_source_lines expectations"""
     with pytest.raises(TypeError):
         inspect.getfile(type)
-    with pytest.raises(OSError if sys.version_info >= (3, 10) else TypeError):
+    with pytest.raises(OSError):
         inspect.getfile(SourceModuleMainTest)
 
 

--- a/IPython/lib/tests/test_pretty.py
+++ b/IPython/lib/tests/test_pretty.py
@@ -140,7 +140,7 @@ def test_pprint_heap_allocated_type():
     """
     Test that pprint works for heap allocated types.
     """
-    module_name = "xxlimited" if sys.version_info < (3, 10) else "xxlimited_35"
+    module_name = "xxlimited_35"
     expected_output = (
         "xxlimited.Null" if sys.version_info < (3, 10, 6) else "xxlimited_35.Null"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 51.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]
-python_version = 3.9
+python_version = 3.10
 ignore_missing_imports = true
 follow_imports = 'silent'
 exclude = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 zip_safe = False
 install_requires =
     colorama; sys_platform == "win32"
@@ -80,7 +80,7 @@ test_extra =
     curio
     matplotlib!=3.2.0
     nbformat
-    numpy>=1.22
+    numpy>=1.23
     pandas
     trio
 all =

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ import sys
 #
 # This check is also made in IPython/__init__, don't forget to update both when
 # changing Python version requirements.
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 10):
     pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
     try:
         import pip
@@ -39,6 +39,7 @@ if sys.version_info < (3, 9):
 
 
     error = """
+IPython 8.19+ supports Python 3.10 and above, following SPEC0
 IPython 8.13+ supports Python 3.9 and above, following NEP 29.
 IPython 8.0-8.12 supports Python 3.8 and above, following NEP 29.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.


### PR DESCRIPTION
According to SPEC-0 this is about time,
we thus bump minimal python, shift CI to test from 3.10 to 3.12, mark a
curio test as x-fail as curio is not yet compatible with 3.12 but the
fix in in trio main.

Remove all conditionals that will never execute on 3.10+