### PR TITLE
Deprecate utils tz

### DIFF
--- a/IPython/utils/tz.py
+++ b/IPython/utils/tz.py
@@ -5,24 +5,25 @@ Timezone utilities
 Just UTC-awareness right now
 """
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Copyright (C) 2013 The IPython Development Team
 #
 #  Distributed under the terms of the BSD License.  The full license is in
 #  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Imports
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 from datetime import tzinfo, timedelta, datetime
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Code
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # constant for zero offset
 ZERO = timedelta(0)
+
 
 class tzUTC(tzinfo):
     """tzinfo object for UTC (zero offset)"""
@@ -39,10 +40,13 @@ UTC = tzUTC()  # type: ignore[abstract]
 
 def utc_aware(unaware):
     """decorator for adding UTC tzinfo to datetime's utcfoo methods"""
+
     def utc_method(*args, **kwargs):
         dt = unaware(*args, **kwargs)
         return dt.replace(tzinfo=UTC)
+
     return utc_method
+
 
 utcfromtimestamp = utc_aware(datetime.utcfromtimestamp)
 utcnow = utc_aware(datetime.utcnow)

--- a/IPython/utils/tz.py
+++ b/IPython/utils/tz.py
@@ -24,8 +24,10 @@ from datetime import tzinfo, timedelta, datetime
 # -----------------------------------------------------------------------------
 # Code
 # -----------------------------------------------------------------------------
-
 __all__ = ["tzUTC", "utc_aware", "utcfromtimestamp", "utcnow"]
+
+# Enable display of DeprecrationWarning for this module explicitly.
+warnings.filterwarnings("default", category=DeprecationWarning, module=__name__)
 
 # constant for zero offset
 ZERO = timedelta(0)
@@ -36,10 +38,14 @@ def __getattr__(name):
         err = f"IPython.utils.tz is deprecated and has no attribute {name}"
         raise AttributeError(err)
 
-    msg = "The module `IPython.utils.tz` is deprecated and will be completely removed."
-    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+    _warn_deprecated()
 
     return getattr(name)
+
+
+def _warn_deprecated():
+    msg = "The module `IPython.utils.tz` is deprecated and will be completely removed."
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
 
 class tzUTC(tzinfo):
@@ -47,6 +53,8 @@ class tzUTC(tzinfo):
 
     Deprecated since IPython 8.19.0.
     """
+
+    _warn_deprecated()
 
     def utcoffset(self, d):
         return ZERO
@@ -65,6 +73,7 @@ def utc_aware(unaware):
     """
 
     def utc_method(*args, **kwargs):
+        _warn_deprecated()
         dt = unaware(*args, **kwargs)
         return dt.replace(tzinfo=UTC)
 

--- a/IPython/utils/tz.py
+++ b/IPython/utils/tz.py
@@ -3,6 +3,8 @@
 Timezone utilities
 
 Just UTC-awareness right now
+
+Deprecated since IPython 8.19.0.
 """
 
 # -----------------------------------------------------------------------------
@@ -16,17 +18,35 @@ Just UTC-awareness right now
 # Imports
 # -----------------------------------------------------------------------------
 
+import warnings
 from datetime import tzinfo, timedelta, datetime
 
 # -----------------------------------------------------------------------------
 # Code
 # -----------------------------------------------------------------------------
+
+__all__ = ["tzUTC", "utc_aware", "utcfromtimestamp", "utcnow"]
+
 # constant for zero offset
 ZERO = timedelta(0)
 
 
+def __getattr__(name):
+    if name not in __all__:
+        err = f"IPython.utils.tz is deprecated and has no attribute {name}"
+        raise AttributeError(err)
+
+    msg = "The module `IPython.utils.tz` is deprecated and will be completely removed."
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+
+    return getattr(name)
+
+
 class tzUTC(tzinfo):
-    """tzinfo object for UTC (zero offset)"""
+    """tzinfo object for UTC (zero offset)
+
+    Deprecated since IPython 8.19.0.
+    """
 
     def utcoffset(self, d):
         return ZERO
@@ -39,7 +59,10 @@ UTC = tzUTC()  # type: ignore[abstract]
 
 
 def utc_aware(unaware):
-    """decorator for adding UTC tzinfo to datetime's utcfoo methods"""
+    """decorator for adding UTC tzinfo to datetime's utcfoo methods
+
+    Deprecated since IPython 8.19.0.
+    """
 
     def utc_method(*args, **kwargs):
         dt = unaware(*args, **kwargs)

--- a/IPython/utils/tz.py
+++ b/IPython/utils/tz.py
@@ -26,8 +26,6 @@ from datetime import tzinfo, timedelta, datetime
 # -----------------------------------------------------------------------------
 __all__ = ["tzUTC", "utc_aware", "utcfromtimestamp", "utcnow"]
 
-# Enable display of DeprecrationWarning for this module explicitly.
-warnings.filterwarnings("default", category=DeprecationWarning, module=__name__)
 
 # constant for zero offset
 ZERO = timedelta(0)


### PR DESCRIPTION
Closes #14249

1. Apply `black` to module.
2. Add docstrings mentioning deprecation as of IPython 8.19.0.
3. Implement and add `_warn_deprecated()` function.
4. Explicitly enable display of `DeprecationWarning` for this module.