### PR TITLE
Fix diagrams by reinstating graphiz

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
copying https://github.com/jupyter/jupyter/pull/714

resolves part of #14213

Check my work! I haven't worked with readthedocs myself, I'm just blindly copying what worked for Jupyter.