### PR TITLE
Update example for %alias_magic

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -124,7 +124,7 @@ class BasicMagics(Magics):
           In [6]: %whereami
           Out[6]: '/home/testuser'
 
-          In [7]: %alias_magic h history "-p -l 30" --line
+          In [7]: %alias_magic h history -p "-l 30" --line
           Created `%h` as an alias for `%history -l 30`.
         """
 


### PR DESCRIPTION
Fix example for creating `%alias_magic`