### PR TITLE
Wrong variable name in Python 3.13

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -454,7 +454,7 @@ class Pdb(OldPdb):
                 with self._hold_exceptions(_chained_exceptions):
                     OldPdb.interaction(self, frame, tb)
             else:
-                OldPdb.interaction(self, frame, traceback)
+                OldPdb.interaction(self, frame, tb_or_exc)
 
         except KeyboardInterrupt:
             self.stdout.write("\n" + self.shell.get_exception_only())


### PR DESCRIPTION
This should fix some of the issues on 3.13 testing but not sufficient as we'll get issues with stack_data  and executing