### PR TITLE
Fix docstring leading space.

### DIFF
--- a/IPython/core/tests/test_magic_arguments.py
+++ b/IPython/core/tests/test_magic_arguments.py
@@ -12,6 +12,8 @@ import sys
 from IPython.core.magic_arguments import (argument, argument_group, kwds,
     magic_arguments, parse_argstring, real_name)
 
+LEADING_SPACE = "" if sys.version_info > (3, 13) else " "
+
 
 @magic_arguments()
 @argument('-f', '--foo', help="an argument")
@@ -81,14 +83,14 @@ def test_magic_arguments():
 
     assert (
         magic_foo1.__doc__
-        == f"::\n\n  %foo1 [-f FOO]\n\n A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
+        == f"::\n\n  %foo1 [-f FOO]\n\n{LEADING_SPACE}A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
     )
     assert getattr(magic_foo1, "argcmd_name", None) == None
     assert real_name(magic_foo1) == "foo1"
     assert magic_foo1(None, "") == argparse.Namespace(foo=None)
     assert hasattr(magic_foo1, "has_arguments")
 
-    assert magic_foo2.__doc__ == "::\n\n  %foo2\n\n A docstring.\n"
+    assert magic_foo2.__doc__ == f"::\n\n  %foo2\n\n{LEADING_SPACE}A docstring.\n"
     assert getattr(magic_foo2, "argcmd_name", None) == None
     assert real_name(magic_foo2) == "foo2"
     assert magic_foo2(None, "") == argparse.Namespace()
@@ -96,7 +98,7 @@ def test_magic_arguments():
 
     assert (
         magic_foo3.__doc__
-        == f"::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n"
+        == f"::\n\n  %foo3 [-f FOO] [-b BAR] [-z BAZ]\n\n{LEADING_SPACE}A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n\nGroup:\n  -b BAR, --bar BAR  a grouped argument\n\nSecond Group:\n  -z BAZ, --baz BAZ  another grouped argument\n"
     )
     assert getattr(magic_foo3, "argcmd_name", None) == None
     assert real_name(magic_foo3) == "foo3"
@@ -105,7 +107,7 @@ def test_magic_arguments():
 
     assert (
         magic_foo4.__doc__
-        == f"::\n\n  %foo4 [-f FOO]\n\n A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
+        == f"::\n\n  %foo4 [-f FOO]\n\n{LEADING_SPACE}A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
     )
     assert getattr(magic_foo4, "argcmd_name", None) == None
     assert real_name(magic_foo4) == "foo4"
@@ -114,7 +116,7 @@ def test_magic_arguments():
 
     assert (
         magic_foo5.__doc__
-        == f"::\n\n  %frobnicate [-f FOO]\n\n A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
+        == f"::\n\n  %frobnicate [-f FOO]\n\n{LEADING_SPACE}A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
     )
     assert getattr(magic_foo5, "argcmd_name", None) == "frobnicate"
     assert real_name(magic_foo5) == "frobnicate"
@@ -123,7 +125,7 @@ def test_magic_arguments():
 
     assert (
         magic_magic_foo.__doc__
-        == f"::\n\n  %magic_foo [-f FOO]\n\n A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
+        == f"::\n\n  %magic_foo [-f FOO]\n\n{LEADING_SPACE}A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
     )
     assert getattr(magic_magic_foo, "argcmd_name", None) == None
     assert real_name(magic_magic_foo) == "magic_foo"
@@ -132,7 +134,7 @@ def test_magic_arguments():
 
     assert (
         foo.__doc__
-        == f"::\n\n  %foo [-f FOO]\n\n A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
+        == f"::\n\n  %foo [-f FOO]\n\n{LEADING_SPACE}A docstring.\n\n{options}:\n  -f FOO, --foo FOO  an argument\n"
     )
     assert getattr(foo, "argcmd_name", None) == None
     assert real_name(foo) == "foo"

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -17,7 +17,7 @@ import warnings
 from string import Formatter
 from pathlib import Path
 
-from typing import List, Union, Optional, Dict, Tuple
+from typing import List, Dict, Tuple
 
 
 class LSString(str):
@@ -357,7 +357,7 @@ def format_screen(strng):
     return strng
 
 
-def dedent(text):
+def dedent(text: str) -> str:
     """Equivalent of textwrap.dedent that ignores unindented first line.
 
     This means it will still dedent strings like:


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/106411, it look like cpython is removing leading space and indent.

We therefore need conditional check, until we decide Wether this is a problem we want to deal with or not.