### PR TITLE
Fix auto_create not recognized by TerminalIPythonApp, and please linter.

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -213,7 +213,9 @@ class BaseIPythonApplication(Application):
         return d
     
     _in_init_profile_dir = False
+
     profile_dir = Instance(ProfileDir, allow_none=True)
+
     @default('profile_dir')
     def _profile_dir_default(self):
         # avoid recursion
@@ -226,11 +228,13 @@ class BaseIPythonApplication(Application):
     overwrite = Bool(False,
         help="""Whether to overwrite existing config files when copying"""
     ).tag(config=True)
+
     auto_create = Bool(False,
         help="""Whether to create profile dir if it doesn't exist"""
     ).tag(config=True)
 
     config_files = List(Unicode())
+
     @default('config_files')
     def _config_files_default(self):
         return [self.config_file_name]

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -209,7 +209,7 @@ class ProfileCreate(BaseIPythonApplication):
     name = u'ipython-profile'
     description = create_help
     examples = _create_examples
-    auto_create = Bool(True)
+    auto_create = Bool(True).tag(config=True)
     def _log_format_default(self):
         return "[%(name)s] %(message)s"
 

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -177,7 +177,7 @@ class LocateIPythonApp(BaseIPythonApplication):
 
 
 class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
-    name = u'ipython'
+    name = "ipython"
     description = usage.cl_usage
     crash_handler_class = IPAppCrashHandler  # typing: ignore[assignment]
     examples = _examples
@@ -196,7 +196,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
     def _classes_default(self):
         """This has to be in a method, for TerminalIPythonApp to be available."""
         return [
-            InteractiveShellApp, # ShellApp comes before TerminalApp, because
+            InteractiveShellApp,  # ShellApp comes before TerminalApp, because
             self.__class__,      # it will also affect subclasses (e.g. QtConsole)
             TerminalInteractiveShell,
             HistoryManager,
@@ -224,9 +224,9 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         ),
     )
 
-
     # *do* autocreate requested profile, but don't create the config file.
-    auto_create=Bool(True)
+    auto_create = Bool(True).tag(config=True)
+
     # configurables
     quick = Bool(False,
         help="""Start IPython quickly by skipping the loading of config files."""


### PR DESCRIPTION
Config option auto_create not recognized by TerminalIPythonApp, as the config overwirte id not add `.tag(config=True)`

closes #14282