### PR TITLE
ipdb: accept header= argument

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -1111,10 +1111,13 @@ class InterruptiblePdb(Pdb):
                 raise
 
 
-def set_trace(frame=None):
+def set_trace(frame=None, header=None):
     """
     Start debugging from `frame`.
 
     If frame is not specified, debugging starts from caller's frame.
     """
-    Pdb().set_trace(frame or sys._getframe().f_back)
+    pdb = Pdb()
+    if header is not None:
+        pdb.message(header)
+    pdb.set_trace(frame or sys._getframe().f_back)


### PR DESCRIPTION
This improves symmetry between Ipdb and vanilla old Pdb.

The `header` argument to `pdb.set_trace()` [has been added in Python 3.7](https://docs.python.org/3.9/whatsnew/3.7.html#pdb).

_(This still requires changes in [gotcha/ipdb](https://github.com/gotcha/ipdb) to be fully useful - I'll get to that later :wink:)_