### PR TITLE
pyproject.toml, setup.py: Declare backend-path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include COPYING.rst
 include LICENSE
 include setupbase.py
+include _build_meta.py
 include MANIFEST.in
 include py.typed
 include .mailmap

--- a/_build_meta.py
+++ b/_build_meta.py
@@ -1,0 +1,2 @@
+# See https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks
+from setuptools.build_meta import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools >= 51.0.0"]
-build-backend = "setuptools.build_meta"
+# We need access to the 'setupbase' module at build time.
+# Hence we declare a custom build backend.
+build-backend = "_build_meta"  # just re-exports setuptools.build_meta definitions
+backend-path = ["."]
 
 [tool.mypy]
 python_version = "3.10"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ Python {py} detected.
 from setuptools import setup
 
 # Our own imports
-sys.path.insert(0, ".")
 
 from setupbase import target_update, find_entry_points
 


### PR DESCRIPTION
Replacing `sys.path.insert(0, ".")` in `setup.py` by declaring a custom PEP-517 build system.
