### PR TITLE
.github/workflows/downstream.yml: Test with sagemath-repl

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -44,9 +44,23 @@ jobs:
         # we must install IPython after ipykernel to get the right versions.
         python -m pip install --upgrade --upgrade-strategy eager flaky ipyparallel
         python -m pip install --upgrade 'pytest<7'  'pytest_asyncio<0.21'
-    - name: pytest
+    - name: pytest ipykernel
       env:
         COLUMNS: 120
       run: |
         cd ../ipykernel
         pytest
+    - name: Install sagemath-repl
+      run: |
+        cd ..
+        git clone --depth 1 https://github.com/sagemath/sage
+        cd sage
+        # We cloned it for the tests, but for simplicity we install the
+        # wheels from PyPI.
+        pip install --pre sagemath-repl
+        pip install tox
+        cd ..
+    - name: tox sagemath-repl
+      run: |
+        cd ../sage/pkgs/sagemath-repl
+        tox -v -v --skip-pkg-install --sitepackages -e norequirements

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -58,7 +58,7 @@ jobs:
         # We cloned it for the tests, but for simplicity we install the
         # wheels from PyPI.
         # (Avoid 10.3b6 because of https://github.com/sagemath/sage/pull/37178)
-        pip install --pre "sagemath-repl<10.3b5"
+        pip install --pre "sagemath-repl<10.3b6" "sagemath-environment<10.3b6"
         cd ..
     - name: Test sagemath-repl
       run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -57,11 +57,11 @@ jobs:
         cd sage
         # We cloned it for the tests, but for simplicity we install the
         # wheels from PyPI.
-        # (Avoid 10.3b5-10.3b6 because of https://github.com/sagemath/sage/pull/37178)
+        # (Avoid 10.3b6 because of https://github.com/sagemath/sage/pull/37178)
         pip install --pre "sagemath-repl<10.3b5"
-        pip install tox
         cd ..
-    - name: tox sagemath-repl
+    - name: Test sagemath-repl
       run: |
-        cd ../sage/pkgs/sagemath-repl
-        tox -v -v --skip-pkg-install --sitepackages -e norequirements
+        cd ../sage/
+        # From https://github.com/sagemath/sage/blob/develop/pkgs/sagemath-repl/tox.ini
+        sage-runtests -p --environment=sage.all__sagemath_repl --baseline-stats-path=pkgs/sagemath-repl/known-test-failures.json --initial --optional=sage src/sage/repl src/sage/doctest src/sage/misc/sage_input.py src/sage/misc/sage_eval.py

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -57,7 +57,8 @@ jobs:
         cd sage
         # We cloned it for the tests, but for simplicity we install the
         # wheels from PyPI.
-        pip install --pre sagemath-repl
+        # (Avoid 10.3b5-10.3b6 because of https://github.com/sagemath/sage/pull/37178)
+        pip install --pre "sagemath-repl<10.3b5"
         pip install tox
         cd ..
     - name: tox sagemath-repl

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -59,6 +59,8 @@ jobs:
         # wheels from PyPI.
         # (Avoid 10.3b6 because of https://github.com/sagemath/sage/pull/37178)
         pip install --pre "sagemath-repl<10.3b6" "sagemath-environment<10.3b6"
+        # Install optionals that make more tests pass
+        pip install sagemath-categories pillow
         cd ..
     - name: Test sagemath-repl
       run: |


### PR DESCRIPTION
Adding a lightweight test with SageMath using the modularized distribution https://pypi.org/project/sagemath-repl/ of the Sage library. 

Motivated by https://github.com/sagemath/sage/issues/36975, https://github.com/ipython/ipython/pull/14223#issuecomment-1870467577, https://github.com/sagemath/sage/issues/36993, https://github.com/sagemath/sage/issues/37031 @Carreau