### PR TITLE
Delay import from matplotlib_inline.backend_inline

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3667,6 +3667,7 @@ class InteractiveShell(SingletonConfigurable):
         pt.activate_matplotlib(backend)
 
         from matplotlib_inline.backend_inline import configure_inline_support
+
         configure_inline_support(self, backend)
 
         # Now we must activate the gui pylab wants to use, and fix %run to take

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3651,8 +3651,6 @@ class InteractiveShell(SingletonConfigurable):
             make sense in all contexts, for example a terminal ipython can't
             display figures inline.
         """
-        from matplotlib_inline.backend_inline import configure_inline_support
-
         from IPython.core import pylabtools as pt
         gui, backend = pt.find_gui_and_backend(gui, self.pylab_gui_select)
 
@@ -3667,6 +3665,8 @@ class InteractiveShell(SingletonConfigurable):
                 gui, backend = pt.find_gui_and_backend(self.pylab_gui_select)
 
         pt.activate_matplotlib(backend)
+
+        from matplotlib_inline.backend_inline import configure_inline_support
         configure_inline_support(self, backend)
 
         # Now we must activate the gui pylab wants to use, and fix %run to take


### PR DESCRIPTION
Possible fix for #14329.

With this change, the reproducers from the issue become:
```python
$ ipython
<snip>

In [1]: import matplotlib.pyplot as plt; plt.set_loglevel("debug")

In [2]: %matplotlib tk
DEBUG:matplotlib.pyplot:Loaded backend TkAgg version 8.6.
```
and
![Screenshot from 2024-02-12 12-44-30](https://github.com/ipython/ipython/assets/580326/7fab93cb-9696-4945-8e14-6a57daba8139)

It is still possible to call `matplotlib.pyplot.switch_backend` twice but only if you request `%matplotlib inline`, and the `switch_backend` is called with same correct backend twice. This isn't ideal but it doesn't cause any problems apart from being a little slower than necessary.