### PR TITLE
pyproject.toml (project.entrypoints, project.scripts): Define here

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,16 @@ dependencies = [
     "traitlets>=5",
     "typing_extensions; python_version<'3.10'",
 ]
-dynamic = ["authors", "entry-points", "license", "scripts", "version"]
+dynamic = ["authors", "license", "version"]
+
+[project.entry-points."pygments.lexers"]
+ipythonconsole = "IPython.lib.lexers:IPythonConsoleLexer"
+ipython = "IPython.lib.lexers:IPythonLexer"
+ipython3 = "IPython.lib.lexers:IPython3Lexer"
+
+[project.scripts]
+ipython = "IPython:start_ipython"
+ipython3 = "IPython:start_ipython"
 
 [project.readme]
 file = "long_description.rst"

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ from setuptools import setup
 
 # Our own imports
 
-from setupbase import target_update, find_entry_points
+from setupbase import target_update
 
 from setupbase import (
     setup_args,
@@ -131,15 +131,6 @@ setup_args['cmdclass'] = {
     'build_py': \
             check_package_data_first(git_prebuild('IPython')),
     'sdist' : git_prebuild('IPython', sdist),
-}
-
-setup_args["entry_points"] = {
-    "console_scripts": find_entry_points(),
-    "pygments.lexers": [
-        "ipythonconsole = IPython.lib.lexers:IPythonConsoleLexer",
-        "ipython = IPython.lib.lexers:IPythonLexer",
-        "ipython3 = IPython.lib.lexers:IPython3Lexer",
-    ],
 }
 
 #---------------------------------------------------------------------------

--- a/setupbase.py
+++ b/setupbase.py
@@ -162,26 +162,6 @@ def target_update(target,deps,cmd):
         os.system(cmd)
 
 #---------------------------------------------------------------------------
-# Find scripts
-#---------------------------------------------------------------------------
-
-def find_entry_points():
-    """Defines the command line entry points for IPython
-
-    This always uses setuptools-style entry points. When setuptools is not in
-    use, our own build_scripts_entrypt class below parses these and builds
-    command line scripts.
-
-    Each of our entry points gets a plain name, e.g. ipython, and a name
-    suffixed with the Python major version number, e.g. ipython3.
-    """
-    ep = [
-            'ipython%s = IPython:start_ipython',
-        ]
-    major_suffix = str(sys.version_info[0])
-    return [e % "" for e in ep] + [e % major_suffix for e in ep]
-
-#---------------------------------------------------------------------------
 # VCS related
 #---------------------------------------------------------------------------
 


### PR DESCRIPTION
... instead of in setup.py, setupbase.py

Another step toward removing setup.py, as requested by @Carreau in https://github.com/ipython/ipython/pull/14327#pullrequestreview-1884755776
