### PR TITLE
Fix missing jQuery in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,19 +71,19 @@ exec(
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.doctest',
-    'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.graphviz',
-    'sphinxcontrib.jquery',
-    'IPython.sphinxext.ipython_console_highlighting',
-    'IPython.sphinxext.ipython_directive',
-    'sphinx.ext.napoleon',  # to preprocess docstrings
-    'github',  # for easy GitHub links
-    'magics',
-    'configtraits',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "sphinx.ext.inheritance_diagram",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.graphviz",
+    "sphinxcontrib.jquery",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "IPython.sphinxext.ipython_directive",
+    "sphinx.ext.napoleon",  # to preprocess docstrings
+    "github",  # for easy GitHub links
+    "magics",
+    "configtraits",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,7 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.graphviz',
+    'sphinxcontrib.jquery',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
     'sphinx.ext.napoleon',  # to preprocess docstrings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ doc = [
     "setuptools>=18.5",
     "sphinx>=1.3",
     "sphinx-rtd-theme",
+    "sphinxcontrib-jquery",
     "docrepr",
     "matplotlib",
     "stack_data",


### PR DESCRIPTION
It's been 8 years since I last updated my IPython fork... 😄 

![Screenshot 2024-02-19 at 17-29-31 astrojuanlu_ipython Official repository for IPython itself  Other repos in the IPython organization contain things like the website documentation builds etc](https://github.com/ipython/ipython/assets/316517/a5143264-6188-4389-bc37-914019b2be2b)

Fix #14213 by adding https://pypi.org/project/sphinxcontrib-jquery/ to the Sphinx extensions, see https://github.com/sphinx-doc/sphinx/issues/10070 and https://github.com/sphinx-doc/sphinx/issues/7405 for extra context.

Also fix #14264.