### PR TITLE
IPython/utils/path.py: Deprecate unused `target_outdated`, `target_update`

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -12,6 +12,7 @@ import errno
 import shutil
 import random
 import glob
+import warnings
 
 from IPython.utils.process import system
 
@@ -295,6 +296,11 @@ def target_outdated(target,deps):
 
     .. deprecated:: 8.22
     """
+    warnings.warn(
+        "`target_outdated` is deprecated since IPython 8.22 and will be removed in future versions",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         target_time = os.path.getmtime(target)
     except os.error:
@@ -319,7 +325,12 @@ def target_update(target,deps,cmd):
     .. deprecated:: 8.22
     """
 
-    if target_outdated(target,deps):
+    warnings.warn(
+        "`target_update` is deprecated since IPython 8.22 and will be removed in future versions",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if target_outdated(target, deps):
         system(cmd)
 
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -292,6 +292,8 @@ def target_outdated(target,deps):
 
     If target doesn't exist or is older than any file listed in deps, return
     true, otherwise return false.
+
+    .. deprecated:: 8.22
     """
     try:
         target_time = os.path.getmtime(target)
@@ -312,7 +314,10 @@ def target_update(target,deps,cmd):
     target_update(target,deps,cmd) -> runs cmd if target is outdated.
 
     This is just a wrapper around target_outdated() which calls the given
-    command if target is outdated."""
+    command if target is outdated.
+
+    .. deprecated:: 8.22
+    """
 
     if target_outdated(target,deps):
         system(cmd)


### PR DESCRIPTION
These functions are unused. I propose to deprecate them

(`setupbase.py` brings its own copy of these functions.)
