### PR TITLE
Depend upon traitlets >5.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "prompt_toolkit>=3.0.41,<3.1.0",
     "pygments>=2.4.0",
     "stack_data",
-    "traitlets>=5",
+    "traitlets>=5.10.0",
     "typing_extensions; python_version<'3.10'",
 ]
 dynamic = ["authors", "license", "version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "prompt_toolkit>=3.0.41,<3.1.0",
     "pygments>=2.4.0",
     "stack_data",
-    "traitlets>=5.10.0",
+    "traitlets>=5.13.0",
     "typing_extensions; python_version<'3.10'",
 ]
 dynamic = ["authors", "license", "version"]


### PR DESCRIPTION
In previous versions, `traitlets.List` does not inherit from `typing.Generic` which means it does not implement `__class_getitem__` which means [`List[ast.NodeTransformer]`](https://github.com/ipython/ipython/blob/8.22.0/IPython/core/interactiveshell.py#L331) raises at runtime.