### PR TITLE
Improve inference from return type annotations in completer

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -14,10 +14,6 @@ from typing import (
     get_args,
     get_origin,
 )
-from typing_extensions import (
-    Self,  # Python >=3.10
-    TypeAliasType,  # Python >=3.12
-)
 import ast
 import builtins
 import collections
@@ -27,8 +23,18 @@ from functools import cached_property
 from dataclasses import dataclass, field
 from types import MethodDescriptorType, ModuleType
 
-
 from IPython.utils.decorators import undoc
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
+if sys.version_info < (3, 12):
+    from typing_extensions import TypeAliasType
+else:
+    from typing import TypeAliasType
 
 
 @undoc

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -1,18 +1,23 @@
 from inspect import isclass, signature, Signature
 from typing import (
+    Annotated,
+    AnyStr,
     Callable,
     Dict,
     Literal,
     NamedTuple,
     NewType,
+    Optional,
+    Protocol,
     Set,
     Sequence,
     Tuple,
     Type,
-    Protocol,
+    TypeGuard,
     Union,
     get_args,
     get_origin,
+    is_typeddict,
 )
 import ast
 import builtins
@@ -27,9 +32,9 @@ from IPython.utils.decorators import undoc
 
 
 if sys.version_info < (3, 11):
-    from typing_extensions import Self
+    from typing_extensions import Self, LiteralString
 else:
-    from typing import Self
+    from typing import Self, LiteralString
 
 if sys.version_info < (3, 12):
     from typing_extensions import TypeAliasType
@@ -423,8 +428,36 @@ UNARY_OP_DUNDERS: Dict[Type[ast.unaryop], Tuple[str, ...]] = {
 }
 
 
-class Duck:
+class ImpersonatingDuck:
     """A dummy class used to create objects of other classes without calling their ``__init__``"""
+
+    # no-op: override __class__ to impersonate
+
+
+class _Duck:
+    """A dummy class used to create objects pretending to have given attributes"""
+
+    def __init__(self, attributes: Optional[dict] = None, items: Optional[dict] = None):
+        self.attributes = attributes or {}
+        self.items = items or {}
+
+    def __getattr__(self, attr: str):
+        return self.attributes[attr]
+
+    def __hasattr__(self, attr: str):
+        return attr in self.attributes
+
+    def __dir__(self):
+        return [*dir(super), *self.attributes]
+
+    def __getitem__(self, key: str):
+        return self.items[key]
+
+    def __hasitem__(self, key: str):
+        return self.items[key]
+
+    def _ipython_key_completions_(self):
+        return self.items.keys()
 
 
 def _find_dunder(node_op, dunders) -> Union[Tuple[str, ...], None]:
@@ -617,26 +650,69 @@ def _eval_return_type(func: Callable, node: ast.Call, context: EvaluationContext
     # if annotation was not stringized, or it was stringized
     # but resolved by signature call we know the return type
     not_empty = sig.return_annotation is not Signature.empty
-    stringized = isinstance(sig.return_annotation, str)
     if not_empty:
-        return_type = (
-            _eval_node_name(sig.return_annotation, context)
-            if stringized
-            else sig.return_annotation
-        )
-        if return_type is Self and hasattr(func, "__self__"):
-            return func.__self__
-        elif get_origin(return_type) is Literal:
-            type_args = get_args(return_type)
-            if len(type_args) == 1:
-                return type_args[0]
-        elif isinstance(return_type, NewType):
-            return _eval_or_create_duck(return_type.__supertype__, node, context)
-        elif isinstance(return_type, TypeAliasType):
-            return _eval_or_create_duck(return_type.__value__, node, context)
-        else:
-            return _eval_or_create_duck(return_type, node, context)
+        return _resolve_annotation(sig.return_annotation, sig, func, node, context)
     return NOT_EVALUATED
+
+
+def _resolve_annotation(
+    annotation,
+    sig: Signature,
+    func: Callable,
+    node: ast.Call,
+    context: EvaluationContext,
+):
+    """Resolve annotation created by user with `typing` module and custom objects."""
+    annotation = (
+        _eval_node_name(annotation, context)
+        if isinstance(annotation, str)
+        else annotation
+    )
+    origin = get_origin(annotation)
+    if annotation is Self and hasattr(func, "__self__"):
+        return func.__self__
+    elif origin is Literal:
+        type_args = get_args(annotation)
+        if len(type_args) == 1:
+            return type_args[0]
+    elif annotation is LiteralString:
+        return ""
+    elif annotation is AnyStr:
+        index = None
+        for i, (key, value) in enumerate(sig.parameters.items()):
+            if value.annotation is AnyStr:
+                index = i
+                break
+        if index is not None and index < len(node.args):
+            return eval_node(node.args[index], context)
+    elif origin is TypeGuard:
+        return bool()
+    elif origin is Union:
+        attributes = [
+            attr
+            for type_arg in get_args(annotation)
+            for attr in dir(_resolve_annotation(type_arg, sig, func, node, context))
+        ]
+        return _Duck(attributes=dict.fromkeys(attributes))
+    elif is_typeddict(annotation):
+        return _Duck(
+            attributes=dict.fromkeys(dir(dict())),
+            items={
+                k: _resolve_annotation(v, sig, func, node, context)
+                for k, v in annotation.__annotations__.items()
+            },
+        )
+    elif hasattr(annotation, "_is_protocol"):
+        return _Duck(attributes=dict.fromkeys(dir(annotation)))
+    elif origin is Annotated:
+        type_arg = get_args(annotation)[0]
+        return _resolve_annotation(type_arg, sig, func, node, context)
+    elif isinstance(annotation, NewType):
+        return _eval_or_create_duck(annotation.__supertype__, node, context)
+    elif isinstance(annotation, TypeAliasType):
+        return _eval_or_create_duck(annotation.__value__, node, context)
+    else:
+        return _eval_or_create_duck(annotation, node, context)
 
 
 def _eval_node_name(node_id: str, context: EvaluationContext):
@@ -671,7 +747,7 @@ def _create_duck_for_heap_type(duck_type):
 
     Returns the duck or NOT_EVALUATED sentinel if duck could not be created.
     """
-    duck = Duck()
+    duck = ImpersonatingDuck()
     try:
         # this only works for heap types, not builtins
         duck.__class__ = duck_type

--- a/IPython/core/tests/test_guarded_eval.py
+++ b/IPython/core/tests/test_guarded_eval.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import contextmanager
 from typing import NamedTuple, Literal, NewType
 from functools import partial
@@ -7,12 +8,19 @@ from IPython.core.guarded_eval import (
     guarded_eval,
     _unbind_method,
 )
-from typing_extensions import (
-    Self,  # Python >=3.10
-    TypeAliasType,  # Python >=3.12
-)
 from IPython.testing import decorators as dec
 import pytest
+
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
+if sys.version_info < (3, 12):
+    from typing_extensions import TypeAliasType
+else:
+    from typing import TypeAliasType
 
 
 def create_context(evaluation: str, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pygments>=2.4.0",
     "stack_data",
     "traitlets>=5.13.0",
-    "typing_extensions; python_version<'3.10'",
+    "typing_extensions; python_version<'3.12'",
 ]
 dynamic = ["authors", "license", "version"]
 


### PR DESCRIPTION
Addresses the issue of non-jedi completer not picking type annotations for `__init__()` brought up in https://github.com/ipython/ipython/issues/14336

![completion_works](https://github.com/ipython/ipython/assets/5832902/73d44e26-123e-4691-87a6-e4d92c6f5061)

Follow-up to https://github.com/ipython/ipython/pull/14185

Supports:
- [x] `Annotated`
- [x] `AnyStr`
- [x] `Literal`
- [x] `LiteralString`
- [x] `NewType`
- [x] `Optional`
- [x] `Protocol`
- [x] `Self`
- [x] `TypeAliasType` (`type` keyword in Python 3.12+)
- [x] `TypedDict`
- [x] `TypeGuard`
- [x] `Union`

Limitations:
- no type narrowing: ambiguous return types from `Union`, and `Optional` will always return all possible values
- generics (`TypeVar` and `Generic`) are not support (except for `AnyStr`)
- old style `TypeAlias` (deprecated in Python 3.12) is not supported