### PR TITLE
solving the type error in line 331 in ipython/core/interactiveshell.py

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -328,7 +328,7 @@ class InteractiveShell(SingletonConfigurable):
 
     _instance = None
 
-    ast_transformers: List[ast.NodeTransformer] = List(
+    ast_transformers: List = List(
         [],
         help="""
         A list of ast.NodeTransformer subclass instances, which will be applied


### PR DESCRIPTION
List isn't subscriptable and line 331 in interactiveshell.py defines list as: 
>List[ast.NodeTransformer]
 
which causes a 

> TypeError: 'type' object is not subscriptable. 

To solve it change the line 331 to: 

> ast_transformers: List = List(