### PR TITLE
Uncomment app.document_config_options() for adding IPython options pages to Configuring IPython section

### DIFF
--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -109,7 +109,7 @@ def write_doc(name, title, app, preamble=None):
         f.write("\n")
         if preamble is not None:
             f.write(preamble + '\n\n')
-        #f.write(app.document_config_options())
+        f.write(app.document_config_options())
 
         for c in app._classes_inc_parents():
             f.write(class_config_rst_doc(c, trait_aliases))


### PR DESCRIPTION
This change, discussed at #14364, adds `IPython options` pages to the `Configuring IPython` section, which lists available options for the classes.