### PR TITLE
Disable scheduled CI runs on forks

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    # Disable scheduled CI runs on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'ipython'
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/nightly-wheel-build.yml
+++ b/.github/workflows/nightly-wheel-build.yml
@@ -9,8 +9,8 @@ jobs:
   upload_anaconda:
     name: Upload to Anaconda
     runs-on: ubuntu-latest
-    # The artifacts cannot be uploaded on PRs
-    if: github.event_name != 'pull_request'
+    # The artifacts cannot be uploaded on PRs, also disable scheduled CI runs on forks
+    if: github.event_name != 'pull_request' && (github.event_name != 'schedule' || github.repository_owner == 'ipython')
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    # Disable scheduled CI runs on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'ipython'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The three scheduled CI runs are running on forks of the main repo, e.g. https://github.com/ianthomas23/ipython/actions. They can be disabled by each fork owner, but this PR disables them for all forks.