### PR TITLE
Move Matplotlib backend mapping to Matplotlib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,11 @@ jobs:
           - os: macos-latest
             python-version: "pypy-3.10"
             deps: test
+          # Temporary CI run to use entry point compatible code in matplotlib-inline.
+          - os: ubuntu-latest
+            python-version: "3.12"
+            deps: test_extra
+            want-latest-entry-point-code: true
 
     steps:
     - uses: actions/checkout@v3
@@ -82,6 +87,16 @@ jobs:
     - name: Check manifest
       if: runner.os != 'Windows'  # setup.py does not support sdist on Windows
       run: check-manifest
+
+    - name: Install entry point compatible code (TEMPORARY)
+      if: matrix.want-latest-entry-point-code
+      run: |
+        python -m pip list
+        # Not installing matplotlib's entry point code as building matplotlib from source is complex.
+        # Rely upon matplotlib to test all the latest entry point branches together.
+        python -m pip install --upgrade git+https://github.com/ipython/matplotlib-inline.git@main
+        python -m pip list
+
     - name: pytest
       env:
         COLUMNS: 120

--- a/IPython/core/display_functions.py
+++ b/IPython/core/display_functions.py
@@ -111,7 +111,7 @@ def display(
     display_id=None,
     raw=False,
     clear=False,
-    **kwargs
+    **kwargs,
 ):
     """Display a Python object in all frontends.
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3657,7 +3657,7 @@ class InteractiveShell(SingletonConfigurable):
         from IPython.core import pylabtools as pt
         gui, backend = pt.find_gui_and_backend(gui, self.pylab_gui_select)
 
-        if gui != 'inline':
+        if gui != None:
             # If we have our first gui selection, store it
             if self.pylab_gui_select is None:
                 self.pylab_gui_select = gui

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -93,17 +93,12 @@ class PylabMagics(Magics):
         """
         args = magic_arguments.parse_argstring(self.matplotlib, line)
         if args.list:
-            from IPython.core.pylabtools import _matplotlib_manages_backends
+            from IPython.core.pylabtools import _list_matplotlib_backends_and_gui_loops
 
-            if _matplotlib_manages_backends():
-                from matplotlib.backends.registry import backend_registry
-
-                backends_list = backend_registry.list_all()
-            else:
-                from IPython.core.pylabtools import backends
-
-                backends_list = list(backends.keys())
-            print("Available matplotlib backends: %s" % backends_list)
+            print(
+                "Available matplotlib backends: %s"
+                % _list_matplotlib_backends_and_gui_loops()
+            )
         else:
             gui, backend = self.shell.enable_matplotlib(args.gui.lower() if isinstance(args.gui, str) else args.gui)
             self._show_matplotlib_backend(args.gui, backend)

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -24,12 +24,13 @@ from warnings import warn
 #-----------------------------------------------------------------------------
 
 magic_gui_arg = magic_arguments.argument(
-        'gui', nargs='?',
-        help="""Name of the matplotlib backend to use such as 'qt' or 'widget'.
+    "gui",
+    nargs="?",
+    help="""Name of the matplotlib backend to use such as 'qt' or 'widget'.
         If given, the corresponding matplotlib backend is used,
         otherwise it will be matplotlib's default
         (which you can set in your matplotlib config file).
-        """
+        """,
 )
 
 
@@ -93,11 +94,14 @@ class PylabMagics(Magics):
         args = magic_arguments.parse_argstring(self.matplotlib, line)
         if args.list:
             from IPython.core.pylabtools import _matplotlib_manages_backends
+
             if _matplotlib_manages_backends():
                 from matplotlib.backends.registry import backend_registry
+
                 backends_list = backend_registry.list_all()
             else:
                 from IPython.core.pylabtools import backends
+
                 backends_list = list(backends.keys())
             print("Available matplotlib backends: %s" % backends_list)
         else:

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -18,7 +18,6 @@ from IPython.core import magic_arguments
 from IPython.core.magic import Magics, magics_class, line_magic
 from IPython.testing.skipdoctest import skip_doctest
 from warnings import warn
-from IPython.core.pylabtools import backends
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -26,11 +25,11 @@ from IPython.core.pylabtools import backends
 
 magic_gui_arg = magic_arguments.argument(
         'gui', nargs='?',
-        help="""Name of the matplotlib backend to use %s.
+        help="""Name of the matplotlib backend to use such as 'qt' or 'widget'.
         If given, the corresponding matplotlib backend is used,
         otherwise it will be matplotlib's default
         (which you can set in your matplotlib config file).
-        """ % str(tuple(sorted(backends.keys())))
+        """
 )
 
 
@@ -93,7 +92,13 @@ class PylabMagics(Magics):
         """
         args = magic_arguments.parse_argstring(self.matplotlib, line)
         if args.list:
-            backends_list = list(backends.keys())
+            from IPython.core.pylabtools import _matplotlib_manages_backends
+            if _matplotlib_manages_backends():
+                from matplotlib.backends.registry import backend_registry
+                backends_list = backend_registry.list_all()
+            else:
+                from IPython.core.pylabtools import backends
+                backends_list = list(backends.keys())
             print("Available matplotlib backends: %s" % backends_list)
         else:
             gui, backend = self.shell.enable_matplotlib(args.gui.lower() if isinstance(args.gui, str) else args.gui)

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -44,7 +44,9 @@ _deprecated_backends = {
 # GUI support to activate based on the desired matplotlib backend.  For the
 # most part it's just a reverse of the above dict, but we also need to add a
 # few others that map to the same GUI manually:
-_deprecated_backend2gui = dict(zip(_deprecated_backends.values(), _deprecated_backends.keys()))
+_deprecated_backend2gui = dict(
+    zip(_deprecated_backends.values(), _deprecated_backends.keys())
+)
 # In the reverse mapping, there are a few extra valid matplotlib backends that
 # map to the same GUI support
 _deprecated_backend2gui["GTK"] = _deprecated_backend2gui["GTKCairo"] = "gtk"
@@ -279,7 +281,7 @@ def select_figure_formats(shell, formats, **kwargs):
 
     [ f.pop(Figure, None) for f in shell.display_formatter.formatters.values() ]
     mplbackend = matplotlib.get_backend().lower()
-    if mplbackend in ('nbagg', 'ipympl', 'widget', 'module://ipympl.backend_nbagg'):
+    if mplbackend in ("nbagg", "ipympl", "widget", "module://ipympl.backend_nbagg"):
         formatter = shell.display_formatter.ipython_display_formatter
         formatter.for_type(Figure, _reshow_nbagg_figure)
 
@@ -330,15 +332,16 @@ def find_gui_and_backend(gui=None, gui_select=None):
     """
 
     import matplotlib
+
     if _matplotlib_manages_backends():
         backend_registry = matplotlib.backends.registry.backend_registry
 
         # gui argument may be a gui event loop or may be a backend name.
         if gui in ("auto", None):
-            backend = matplotlib.rcParamsOrig['backend']
+            backend = matplotlib.rcParamsOrig["backend"]
             backend, gui = backend_registry.resolve_backend(backend)
         else:
-             backend, gui = backend_registry.resolve_gui_or_backend(gui)
+            backend, gui = backend_registry.resolve_gui_or_backend(gui)
 
         return gui, backend
 
@@ -347,6 +350,7 @@ def find_gui_and_backend(gui=None, gui_select=None):
     has_unified_qt_backend = mpl_version_info >= (3, 5)
 
     from IPython.core.pylabtools import backends
+
     backends_ = dict(backends)
     if not has_unified_qt_backend:
         backends_["qt"] = "qt5agg"
@@ -466,5 +470,6 @@ def configure_inline_support(shell, backend):
 
 def _matplotlib_manages_backends():
     import matplotlib
+
     mpl_version_info = getattr(matplotlib, "__version_info__", (0, 0))
     return mpl_version_info >= (3, 9)

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -483,7 +483,8 @@ def _matplotlib_manages_backends() -> bool:
 
     If it returns True, the caller can be sure that
     matplotlib.backends.registry.backend_registry is available along with
-    member functions resolve_gui_or_backend, resolve_backend and list_all.
+    member functions resolve_gui_or_backend, resolve_backend, list_all, and
+    list_gui_frameworks.
     """
     global _matplotlib_manages_backends_value
     if _matplotlib_manages_backends_value is None:
@@ -497,3 +498,21 @@ def _matplotlib_manages_backends() -> bool:
             _matplotlib_manages_backends_value = False
 
     return _matplotlib_manages_backends_value
+
+
+def _list_matplotlib_backends_and_gui_loops() -> list[str]:
+    """Return list of all Matplotlib backends and GUI event loops.
+
+    This is the list returned by
+        %matplotlib --list
+    """
+    if _matplotlib_manages_backends():
+        from matplotlib.backends.registry import backend_registry
+
+        ret = backend_registry.list_all() + backend_registry.list_gui_frameworks()
+    else:
+        from IPython.core import pylabtools
+
+        ret = list(pylabtools.backends.keys())
+
+    return sorted(["auto"] + ret)

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -77,7 +77,8 @@ def __getattr__(name):
         warnings.warn(
             f"{name} is deprecated since IPython 8.24, backends are managed "
             "in matplotlib and can be externally registered.",
-            DeprecationWarning)
+            DeprecationWarning,
+        )
         return globals()[f"_deprecated_{name}"]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -14,7 +14,7 @@ from IPython.utils.decorators import flag_calls
 
 
 # Matplotlib backend resolution functionality moved from IPython to Matplotlib
-# in IPython 8.23 and Matplotlib 3.9. Need to keep `backends` and `backend2gui`
+# in IPython 8.24 and Matplotlib 3.9.1. Need to keep `backends` and `backend2gui`
 # here for earlier Matplotlib and for external backend libraries such as
 # mplcairo that might rely upon it.
 _deprecated_backends = {
@@ -74,7 +74,10 @@ del _deprecated_backend2gui["module://ipympl.backend_nbagg"]
 # Deprecated attributes backends and backend2gui mostly following PEP 562.
 def __getattr__(name):
     if name in ("backends", "backend2gui"):
-        warnings.warn(f"{name} is deprecated", DeprecationWarning)
+        warnings.warn(
+            f"{name} is deprecated since IPython 8.24, backends are managed "
+            "in matplotlib and can be externally registered.",
+            DeprecationWarning)
         return globals()[f"_deprecated_{name}"]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
@@ -377,7 +380,8 @@ def find_gui_and_backend(gui=None, gui_select=None):
             gui = gui_select
             backend = backends_[gui]
 
-    # Since IPython 8.23.0 use None for no gui event loop rather than "inline".
+    # Matplotlib before _matplotlib_manages_backends() can return "inline" for
+    # no gui event loop rather than the None that IPython >= 8.24.0 expects.
     if gui == "inline":
         gui = None
 

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -31,8 +31,7 @@ from IPython.terminal import pt_inputhooks
 
 gui_keys = tuple(sorted(pt_inputhooks.backends) + sorted(pt_inputhooks.aliases))
 
-backend_keys = sorted(pylabtools.backends.keys())
-backend_keys.insert(0, 'auto')
+backend_keys = []
 
 shell_flags = {}
 

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -31,7 +31,7 @@ from IPython.terminal import pt_inputhooks
 
 gui_keys = tuple(sorted(pt_inputhooks.backends) + sorted(pt_inputhooks.aliases))
 
-backend_keys = []
+backend_keys: list[str] = []
 
 shell_flags = {}
 

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -11,36 +11,45 @@ import glob
 from itertools import chain
 import os
 import sys
+import typing as t
 
 from traitlets.config.application import boolean_flag
 from traitlets.config.configurable import Configurable
 from traitlets.config.loader import Config
 from IPython.core.application import SYSTEM_CONFIG_DIRS, ENV_CONFIG_DIRS
-from IPython.core import pylabtools
 from IPython.utils.contexts import preserve_keys
 from IPython.utils.path import filefind
 from traitlets import (
-    Unicode, Instance, List, Bool, CaselessStrEnum, observe,
+    Unicode,
+    Instance,
+    List,
+    Bool,
+    CaselessStrEnum,
+    observe,
     DottedObjectName,
+    Undefined,
 )
 from IPython.terminal import pt_inputhooks
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Aliases and Flags
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 gui_keys = tuple(sorted(pt_inputhooks.backends) + sorted(pt_inputhooks.aliases))
-
-backend_keys: list[str] = []
 
 shell_flags = {}
 
 addflag = lambda *args: shell_flags.update(boolean_flag(*args))
-addflag('autoindent', 'InteractiveShell.autoindent',
-        'Turn on autoindenting.', 'Turn off autoindenting.'
+addflag(
+    "autoindent",
+    "InteractiveShell.autoindent",
+    "Turn on autoindenting.",
+    "Turn off autoindenting.",
 )
-addflag('automagic', 'InteractiveShell.automagic',
-        """Turn on the auto calling of magic commands. Type %%magic at the
+addflag(
+    "automagic",
+    "InteractiveShell.automagic",
+    """Turn on the auto calling of magic commands. Type %%magic at the
         IPython  prompt  for  more information.""",
         'Turn off the auto calling of magic commands.'
 )
@@ -95,6 +104,37 @@ shell_aliases = dict(
     matplotlib='InteractiveShellApp.matplotlib',
 )
 shell_aliases['cache-size'] = 'InteractiveShell.cache_size'
+
+
+# -----------------------------------------------------------------------------
+# Traitlets
+# -----------------------------------------------------------------------------
+
+
+class MatplotlibBackendCaselessStrEnum(CaselessStrEnum):
+    """An enum of Matplotlib backend strings where the case should be ignored.
+
+    Prior to Matplotlib 3.9.1 the list of valid backends is hardcoded in
+    pylabtools.backends. After that, Matplotlib manages backends.
+
+    The list of valid backends is determined when it is first needed to avoid
+    wasting unnecessary initialisation time.
+    """
+
+    def __init__(
+        self: CaselessStrEnum[t.Any],
+        default_value: t.Any = Undefined,
+        **kwargs: t.Any,
+    ) -> None:
+        super().__init__(None, default_value=default_value, **kwargs)
+
+    def __getattribute__(self, name):
+        if name == "values" and object.__getattribute__(self, name) is None:
+            from IPython.core.pylabtools import _list_matplotlib_backends_and_gui_loops
+
+            self.values = _list_matplotlib_backends_and_gui_loops()
+        return object.__getattribute__(self, name)
+
 
 #-----------------------------------------------------------------------------
 # Main classes and functions
@@ -155,30 +195,31 @@ class InteractiveShellApp(Configurable):
     exec_lines = List(Unicode(),
         help="""lines of code to run at IPython startup."""
     ).tag(config=True)
-    code_to_run = Unicode('',
-        help="Execute the given command string."
+    code_to_run = Unicode("", help="Execute the given command string.").tag(config=True)
+    module_to_run = Unicode("", help="Run the module as a script.").tag(config=True)
+    gui = CaselessStrEnum(
+        gui_keys,
+        allow_none=True,
+        help="Enable GUI event loop integration with any of {0}.".format(gui_keys),
     ).tag(config=True)
-    module_to_run = Unicode('',
-        help="Run the module as a script."
-    ).tag(config=True)
-    gui = CaselessStrEnum(gui_keys, allow_none=True,
-        help="Enable GUI event loop integration with any of {0}.".format(gui_keys)
-    ).tag(config=True)
-    matplotlib = CaselessStrEnum(backend_keys, allow_none=True,
+    matplotlib = MatplotlibBackendCaselessStrEnum(
+        allow_none=True,
         help="""Configure matplotlib for interactive use with
-        the default matplotlib backend."""
+        the default matplotlib backend.""",
     ).tag(config=True)
-    pylab = CaselessStrEnum(backend_keys, allow_none=True,
+    pylab = MatplotlibBackendCaselessStrEnum(
+        allow_none=True,
         help="""Pre-load matplotlib and numpy for interactive use,
         selecting a particular matplotlib backend and loop integration.
-        """
+        """,
     ).tag(config=True)
-    pylab_import_all = Bool(True,
+    pylab_import_all = Bool(
+        True,
         help="""If true, IPython will populate the user namespace with numpy, pylab, etc.
         and an ``import *`` is done from numpy and pylab, when using pylab mode.
 
         When False, pylab mode should not import any names into the user namespace.
-        """
+        """,
     ).tag(config=True)
     ignore_cwd = Bool(
         False,

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -199,7 +199,7 @@ class TestPylabSwitch(object):
         assert s.pylab_gui_select == "qt"
 
         gui, backend = s.enable_matplotlib("inline")
-        assert gui == "inline"
+        assert gui is None
         assert s.pylab_gui_select == "qt"
 
         gui, backend = s.enable_matplotlib("qt")
@@ -207,7 +207,7 @@ class TestPylabSwitch(object):
         assert s.pylab_gui_select == "qt"
 
         gui, backend = s.enable_matplotlib("inline")
-        assert gui == "inline"
+        assert gui is None
         assert s.pylab_gui_select == "qt"
 
         gui, backend = s.enable_matplotlib()
@@ -217,11 +217,11 @@ class TestPylabSwitch(object):
     def test_inline(self):
         s = self.Shell()
         gui, backend = s.enable_matplotlib("inline")
-        assert gui == "inline"
+        assert gui is None
         assert s.pylab_gui_select == None
 
         gui, backend = s.enable_matplotlib("inline")
-        assert gui == "inline"
+        assert gui is None
         assert s.pylab_gui_select == None
 
         gui, backend = s.enable_matplotlib("qt")
@@ -233,14 +233,14 @@ class TestPylabSwitch(object):
 
         ip = self.Shell()
         gui, backend = ip.enable_matplotlib("inline")
-        assert gui == "inline"
+        assert gui is None
 
         fmts =  {'png'}
         active_mimes = {_fmt_mime_map[fmt] for fmt in fmts}
         pt.select_figure_formats(ip, fmts)
 
         gui, backend = ip.enable_matplotlib("inline")
-        assert gui == "inline"
+        assert gui is None
 
         for mime, f in ip.display_formatter.formatters.items():
             if mime in active_mimes:
@@ -254,7 +254,7 @@ class TestPylabSwitch(object):
         assert gui == "qt"
         assert s.pylab_gui_select == "qt"
 
-        gui, backend = s.enable_matplotlib("gtk")
+        gui, backend = s.enable_matplotlib("gtk3")
         assert gui == "qt"
         assert s.pylab_gui_select == "qt"
 

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -197,7 +197,7 @@ class InteractiveShellEmbed(TerminalInteractiveShell):
         dummy=None,
         stack_depth=1,
         compile_flags=None,
-        **kw
+        **kw,
     ):
         """Activate the interactive interpreter.
 

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -966,7 +966,7 @@ class TerminalInteractiveShell(InteractiveShell):
         if self._inputhook is not None and gui is None:
             self.active_eventloop = self._inputhook = None
 
-        if gui and (gui not in {"inline", "webagg"}):
+        if gui and (gui not in {None, "webagg"}):
             # This hook runs with each cycle of the `prompt_toolkit`'s event loop.
             self.active_eventloop, self._inputhook = get_inputhook_name_and_func(gui)
         else:


### PR DESCRIPTION
This is WIP to move IPython's backend mapping into Matplotlib and extends it to allow backends to register themselves via [entry points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins). It is a coordinated effort across Matplotlib, IPython, matplotlib-inline and ipympl. Closes #14311. Most of the work is in Matplotlib (matplotlib/matplotlib#27948) but I will repeat the relevant points here.

When using a Matplotlib magic command of the form `%matplotlib something` the identification of the Matplotlib backend and GUI loop are now performed in Matplotlib not IPython. This supports:

1. Matplotlib backends that IPython already supports such as `qtagg` and `tkagg`.
2. Other built-in Matplotlib backends such as `qtcairo`.
3. Backends that use `module://something` syntax such as `module://mplcairo.qt`.
4. Backends that self-register using entry points, currently `inline` and `widget`/`ipympl`.

Implementation details:

1. The magic command is now explicitly `%matplotlib gui_or_backend` rather than `%matplotlib gui`. This is already effectively the case as e.g. `%matplotlib ipympl` is really a backend not GUI name. Within Matplotlib the `gui_or_backend` is checked first to see if it is a GUI name and then falls back to checking if it is a backend name.
2. If you select the `inline` backend the corresponding GUI is now `None` not `inline`. All backends which do not have a GUI loop return `None`, otherwise we have to keep explicit checks within IPython for particular backends.
3. `backends` and `backend2gui` are now deprecated but are still exposed, with a deprecation warning, if required. If using Matplotlib, ipympl, etc releases that include the corresponding changes to this PR then they are not needed as Matplotlib deals with it all. But for backward compatibility they must still be available for a while along with the remainder of the existing backend-handling code.
4. I haven't yet updated the documentation but we need to keep information about valid GUI frameworks and I propose that we should remove all lists of valid Matplotlib backends, replacing them with instructions on how to obtain the current list (pointing to the Matplotlib docs and using `%matplotlib --list`). If we keep any lists then they will inevitably become out of date. This extends to the `backend_keys` in IPython/core/shellapp.py.

Because the four related projects are loosely coupled without direct dependencies on each other (except for `ipython` and `matplotlib-inline`), backward compatibility requires all possible combinations of projects before and after the new functionality (I will call these "old" and "new" from now on) to continue to work. I have tested these all locally, and the CI of this PR will test new IPython against old Matplotlib for example, but I need to add one or more new temporary CI runs to test new IPython against new Matplotlib etc. The identification of new versus old depends on version checks on the other libraries, so here is a table that I will update showing the current status of progress in the 4 projects:

| Project | Relevant PRs | Possible release version |
| --- | --- | --- |
| matplotlib-inline | ipython/matplotlib-inline#34, ipython/matplotlib-inline#35 | 0.1.7 |
| ipympl | matplotlib/ipympl#549 | 0.9.4 |
| Matplotlib | matplotlib/matplotlib#27948 | 3.9.0 |
| IPython | #14371 (this) | 8.24.0 |

The two widget projects can be released soon, once we are happy with the entry point approach. The other two projects' PRs will have to be synchronised as each includes version checks on each other.

To do

- [ ] Add CI runs against the new PR branches of the other projects.
- [ ] Add comments for conditions required for backward-compatibility code blocks to be removed.
- [ ] Update documentation, including removal of lists of valid backends.
- [ ] Update version checks before merging.