### PR TITLE
add __repr__ to MagicsDisplay

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         darker -r 60625f241f298b5039cb2debc365db38aa7bb522 --check --diff . || (
         echo "Changes need auto-formatting. Run:"
-        echo "    darker -r 60625f241f298b5039cb2debc365db38aa7bb522"
+        echo "    darker -r 60625f241f298b5039cb2debc365db38aa7bb522 ."
         echo "then commit and push changes to fix."
         exit 1
         )

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -40,6 +40,9 @@ class MagicsDisplay(object):
     def _repr_pretty_(self, p, cycle):
         p.text(self._lsmagic())
     
+    def __repr__(self):
+        return self.__str__()
+    
     def __str__(self):
         return self._lsmagic()
     

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -42,7 +42,7 @@ class MagicsDisplay(object):
     
     def __repr__(self):
         return self.__str__()
-    
+
     def __str__(self):
         return self._lsmagic()
     


### PR DESCRIPTION
Here's more details on the `rich` side:

https://github.com/Textualize/rich/issues/3317

I don't see a good reason not to overload `__repr__` in this use case
