### PR TITLE
Remove link to non-existent ipyparallel docs.

### DIFF
--- a/docs/source/development/parallel_messages.rst
+++ b/docs/source/development/parallel_messages.rst
@@ -1,8 +1,0 @@
-:orphan:
-
-================================
-Messaging for Parallel Computing
-================================
-
-IPython parallel has moved to ipyparallel -
-see :ref:`ipyparallel:/reference/messages.md` for the documentation.

--- a/docs/source/whatsnew/version0.11.rst
+++ b/docs/source/whatsnew/version0.11.rst
@@ -309,7 +309,7 @@ be started by calling ``ipython qtconsole``. The protocol is :ref:`documented
 <messaging>`.
 
 The parallel computing framework has also been rewritten using ZMQ. The
-protocol is described :ref:`here <ipyparallel:/reference/messages.md>`, and the code is in the
+protocol is described in the ipyparallel documentation, and the code is in the
 new :mod:`IPython.parallel` module.
 
 .. _python3_011:


### PR DESCRIPTION
Those were likely recently removed.