### PR TITLE
Cache debugger skip frame predicate

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -100,6 +100,8 @@ All the changes since then are under the same license as IPython.
 #
 #*****************************************************************************
 
+from __future__ import annotations
+
 import inspect
 import linecache
 import os
@@ -111,6 +113,12 @@ from functools import lru_cache
 from IPython import get_ipython
 from IPython.core.excolors import exception_colors
 from IPython.utils import PyColorize, coloransi, py3compat
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # otherwise circular import
+    from IPython.core.interactiveshell import InteractiveShell
 
 # skip module docstests
 __skip_doctest__ = True
@@ -189,6 +197,8 @@ class Pdb(OldPdb):
     See the `skip_predicates` commands.
 
     """
+
+    shell: InteractiveShell
 
     if CHAIN_EXCEPTIONS:
         MAX_CHAINED_EXCEPTION_DEPTH = 999
@@ -470,23 +480,10 @@ class Pdb(OldPdb):
 
         return line
 
-    def new_do_frame(self, arg):
-        OldPdb.do_frame(self, arg)
-
     def new_do_quit(self, arg):
-
-        if hasattr(self, 'old_all_completions'):
-            self.shell.Completer.all_completions = self.old_all_completions
-
         return OldPdb.do_quit(self, arg)
 
     do_q = do_quit = decorate_fn_with_doc(new_do_quit, OldPdb.do_quit)
-
-    def new_do_restart(self, arg):
-        """Restart command. In the context of ipython this is exactly the same
-        thing as 'quit'."""
-        self.msg("Restart doesn't make sense here. Using 'quit' instead.")
-        return self.do_quit(arg)
 
     def print_stack_trace(self, context=None):
         Colors = self.color_scheme_table.active_colors

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Pdb debugger class.
 
@@ -103,15 +102,15 @@ All the changes since then are under the same license as IPython.
 
 import inspect
 import linecache
-import sys
-import re
 import os
+import re
+import sys
+from contextlib import contextmanager
+from functools import lru_cache
 
 from IPython import get_ipython
-from contextlib import contextmanager
-from IPython.utils import PyColorize
-from IPython.utils import coloransi, py3compat
 from IPython.core.excolors import exception_colors
+from IPython.utils import PyColorize, coloransi, py3compat
 
 # skip module docstests
 __skip_doctest__ = True
@@ -941,11 +940,14 @@ class Pdb(OldPdb):
         Utility to tell us whether we are in a decorator internal and should stop.
 
         """
-
         # if we are disabled don't skip
         if not self._predicates["debuggerskip"]:
             return False
 
+        return self._cachable_skip(frame)
+
+    @lru_cache
+    def _cachable_skip(self, frame):
         # if frame is tagged, skip by default.
         if DEBUGGERSKIP in frame.f_code.co_varnames:
             return True

--- a/docs/source/development/parallel_messages.rst
+++ b/docs/source/development/parallel_messages.rst
@@ -1,8 +1,0 @@
-:orphan:
-
-================================
-Messaging for Parallel Computing
-================================
-
-IPython parallel has moved to ipyparallel -
-see :ref:`ipyparallel:/reference/messages.md` for the documentation.

--- a/docs/source/whatsnew/version0.11.rst
+++ b/docs/source/whatsnew/version0.11.rst
@@ -309,7 +309,7 @@ be started by calling ``ipython qtconsole``. The protocol is :ref:`documented
 <messaging>`.
 
 The parallel computing framework has also been rewritten using ZMQ. The
-protocol is described :ref:`here <ipyparallel:/reference/messages.md>`, and the code is in the
+protocol is described in the ipyparallel documentation, and the code is in the
 new :mod:`IPython.parallel` module.
 
 .. _python3_011:


### PR DESCRIPTION


I'm not 100% sure this is correct as technically the value of
__debugger_skip__ could change in the current frame while we are
stepping into it, but that is likely super rare, and the slowdown
that this create is problematic.

There is still a small overhead for me, but this should make the
experience much better.

See https://github.com/spyder-ide/spyder-kernels/pull/458, https://github.com/ipython/ipython/issues/13972, https://github.com/spyder-ide/spyder/issues/20571, https://github.com/ipython/ipython/issues/14382