### PR TITLE
Fix use of --pylab=auto and --matplotlib=auto

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3654,6 +3654,13 @@ class InteractiveShell(SingletonConfigurable):
             make sense in all contexts, for example a terminal ipython can't
             display figures inline.
         """
+        from .pylabtools import _matplotlib_manages_backends
+
+        if not _matplotlib_manages_backends() and gui in (None, "auto"):
+            # Early import of backend_inline required for its side effect of
+            # calling _enable_matplotlib_integration()
+            import matplotlib_inline.backend_inline
+
         from IPython.core import pylabtools as pt
         gui, backend = pt.find_gui_and_backend(gui, self.pylab_gui_select)
 


### PR DESCRIPTION
Fixes #14401 which has been a bug in the 8.22.x and 8.23.x releases.

When I removed the multiple initialisation of Matplotlib backends in #14330 it broke use of the following:
```bash
ipython --matplotlib
ipython --matplotlib=auto
ipython --pylab
ipython --pylab=auto
```
by failing to display Matplotlib plot. If you specify a particular GUI event loop such as using
```bash
ipython --pylab=qt
```
then it was and is fine. So for anyone finding this, the workaround until the next release is to specify a GUI loop rather than relying on the auto selection.

I didn't notice this as I've been concentrating on moving the Matplotlib backend logic from IPython to Matplotlib, and with those changes (matplotlib/matplotlib#27948) the above use cases all work OK.

The fix is to reintroduce the early import of `matplotlib-inline` but only if both the gui loop is not specified and the Matplotlib version is before the movement of the backend logic across to it.

There are no explicit tests for this. In the future I will try to think of some tests for some of this IPython-Matplotlib functionality that don't involve installing complicated backend dependencies or adding image comparison tests. 