### PR TITLE
Fix compatibility with pytest 8

### DIFF
--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -165,7 +165,7 @@ class TestPylabSwitch(object):
         def enable_gui(self, gui):
             pass
 
-    def setup(self):
+    def setup_method(self):
         import matplotlib
         def act_mpl(backend):
             matplotlib.rcParams['backend'] = backend
@@ -184,7 +184,7 @@ class TestPylabSwitch(object):
         self._save_cis = backend_inline.configure_inline_support
         backend_inline.configure_inline_support = lambda *a, **kw: None
 
-    def teardown(self):
+    def teardown_method(self):
         pt.activate_matplotlib = self._save_am
         pt.import_pylab = self._save_ip
         backend_inline.configure_inline_support = self._save_cis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ qtconsole = [
 ]
 terminal = []
 test = [
-    "pytest<8",
+    "pytest",
     "pytest-asyncio<0.22",
     "testpath",
     "pickleshare",


### PR DESCRIPTION
setup/teardown nose methods are no longer supported by pytest 8. https://docs.pytest.org/en/latest/deprecations.html#setup-teardown