### PR TITLE
Fix listing of subcommands for "ipython profile" and "ipython history".

### DIFF
--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -146,9 +146,11 @@ class HistoryApp(Application):
 
     def start(self):
         if self.subapp is None:
-            print("No subcommand specified. Must specify one of: %s" % \
-                                                    (self.subcommands.keys()))
-            print()
+            print(
+                "No subcommand specified. Must specify one of: "
+                + ", ".join(map(repr, self.subcommands))
+                + ".\n"
+            )
             self.print_description()
             self.print_subcommands()
             self.exit(1)

--- a/IPython/core/profileapp.py
+++ b/IPython/core/profileapp.py
@@ -303,8 +303,11 @@ class ProfileApp(Application):
 
     def start(self):
         if self.subapp is None:
-            print("No subcommand specified. Must specify one of: %s"%(self.subcommands.keys()))
-            print()
+            print(
+                "No subcommand specified. Must specify one of: "
+                + ", ".join(map(repr, self.subcommands))
+                + ".\n"
+            )
             self.print_description()
             self.print_subcommands()
             self.exit(1)


### PR DESCRIPTION
The previous code (likely going back to Py2) would print

    Must specify one of: dict_keys(['create', 'list', 'locate'])

This PR fixes it to

    Must specify one of: 'create', 'list', 'locate'.