### PR TITLE
Fix downstream ipykernel tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10"]
         include:
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.10"
 
     steps:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -59,10 +59,10 @@ jobs:
         # We cloned it for the tests, but for simplicity we install the
         # wheels from PyPI.
         # (Avoid 10.3b6 because of https://github.com/sagemath/sage/pull/37178)
-        pip install --pre "sagemath-repl<10.3b6" "sagemath-environment<10.3b6"
+        pip install --pre sagemath-repl sagemath-environment
         # Install optionals that make more tests pass
         pip install pillow
-        pip install --pre "sagemath-categories<10.3b6"
+        pip install --pre sagemath-categories
         cd ..
     - name: Test sagemath-repl
       run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -61,7 +61,8 @@ jobs:
         # (Avoid 10.3b6 because of https://github.com/sagemath/sage/pull/37178)
         pip install --pre "sagemath-repl<10.3b6" "sagemath-environment<10.3b6"
         # Install optionals that make more tests pass
-        pip install sagemath-categories pillow
+        pip install pillow
+        pip install --pre "sagemath-categories<10.3b6"
         cd ..
     - name: Test sagemath-repl
       run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -35,17 +35,16 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
     - name: Install ipykernel
       run: |
-        cd .. 
+        cd ..
         git clone https://github.com/ipython/ipykernel
         cd ipykernel
-        pip install -e .[test] 
+        pip install -e .[test]
         cd ..
     - name: Install and update Python dependencies
       run: |
         python -m pip install --upgrade -e file://$PWD#egg=ipython[test]
         # we must install IPython after ipykernel to get the right versions.
         python -m pip install --upgrade --upgrade-strategy eager flaky ipyparallel
-        python -m pip install --upgrade 'pytest<7'  'pytest_asyncio<0.21'
     - name: pytest ipykernel
       env:
         COLUMNS: 120


### PR DESCRIPTION
Locally I can get the downstream `ipykernel` tests to pass just by removing the explicit downgrade of `pytest` and `pytest_asyncio`, so here trying it in CI.