### PR TITLE
Fix many py2-style prints in docs and commented code.

### DIFF
--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -19,7 +19,7 @@ example, you could use a startup file like this::
 
     def calljed(self,filename, linenum):
         "My editor hook calls the jed editor directly."
-        print "Calling my own editor, jed ..."
+        print("Calling my own editor, jed ...")
         if os.system('jed +%d %s' % (linenum,filename)) != 0:
             raise TryNext()
 
@@ -111,7 +111,7 @@ class CommandChainDispatcher:
         TryNext"""
         last_exc = TryNext()
         for prio,cmd in self.chain:
-            #print "prio",prio,"cmd",cmd #dbg
+            # print("prio",prio,"cmd",cmd)  # dbg
             try:
                 return cmd(*args, **kw)
             except TryNext as exc:

--- a/IPython/core/inputsplitter.py
+++ b/IPython/core/inputsplitter.py
@@ -320,7 +320,7 @@ class InputSplitter(object):
             prompt = '>>> ' + indent
             line = indent + raw_input(prompt)
             isp.push(line)
-        print 'Input source was:\n', isp.source_reset(),
+        print('Input source was:\n', isp.source_reset())
     """
     # A cache for storing the current indentation
     # The first value stores the most recently processed source input

--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -191,7 +191,7 @@ which already exists. But you must first start the logging process with
     def log_write(self, data, kind='input'):
         """Write data to the log file, if active"""
 
-        #print 'data: %r' % data # dbg
+        # print('data: %r' % data)  # dbg
         if self.log_active and data:
             write = self.logfile.write
             if kind=='input':

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -452,7 +452,7 @@ class CodeMagics(Magics):
                     # Load the parameter given as a variable. If not a string,
                     # process it as an object instead (below)
 
-                    #print '*** args',args,'type',type(args)  # dbg
+                    # print('*** args',args,'type',type(args))  # dbg
                     data = eval(args, shell.user_ns)
                     if not isinstance(data, str):
                         raise DataIsObject
@@ -636,8 +636,8 @@ class CodeMagics(Magics):
 
           In [1]: edit
           Editing... done. Executing edited code...
-          Out[1]: 'def foo():\\n    print "foo() was defined in an editing
-          session"\\n'
+          Out[1]: 'def foo():\\n    print("foo() was defined in an editing
+          session")\\n'
 
         We can then call the function foo()::
 
@@ -661,21 +661,21 @@ class CodeMagics(Magics):
           In [5]: edit
           Editing... done. Executing edited code...
           hello
-          Out[5]: "print 'hello'\\n"
+          Out[5]: "print('hello')\\n"
 
         Now we call it again with the previous output (stored in _)::
 
           In [6]: edit _
           Editing... done. Executing edited code...
           hello world
-          Out[6]: "print 'hello world'\\n"
+          Out[6]: "print('hello world')\\n"
 
         Now we call it with the output #8 (stored in _8, also as Out[8])::
 
           In [7]: edit _8
           Editing... done. Executing edited code...
           hello again
-          Out[7]: "print 'hello again'\\n"
+          Out[7]: "print('hello again')\\n"
 
 
         Changing the default editor hook:

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1256,7 +1256,7 @@ class ExecutionMagics(Magics):
           Wall time: 1.37
           Out[3]: 499999500000L
 
-          In [4]: %time print 'hello world'
+          In [4]: %time print('hello world')
           hello world
           CPU times: user 0.00 s, sys: 0.00 s, total: 0.00 s
           Wall time: 0.00
@@ -1406,9 +1406,9 @@ class ExecutionMagics(Magics):
           44: x=1
           45: y=3
           46: z=x+y
-          47: print x
+          47: print(x)
           48: a=5
-          49: print 'x',x,'y',y
+          49: print('x',x,'y',y)
 
         you can create a macro with lines 44 through 47 (included) and line 49
         called my_macro with::
@@ -1428,7 +1428,7 @@ class ExecutionMagics(Magics):
 
         You can view a macro's contents by explicitly printing it with::
 
-          print macro_name
+          print(macro_name)
 
         """
         opts,args = self.parse_options(parameter_s,'rq',mode='list')
@@ -1439,7 +1439,7 @@ class ExecutionMagics(Magics):
                 "%macro insufficient args; usage '%macro name n1-n2 n3-4...")
         name, codefrom = args[0], " ".join(args[1:])
 
-        #print 'rng',ranges  # dbg
+        # print('rng',ranges)  # dbg
         try:
             lines = self.shell.find_user_code(codefrom, 'r' in opts)
         except (ValueError, TypeError) as e:

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -128,7 +128,7 @@ class HistoryMagics(Magics):
 
           In [6]: %history -n 4-6
           4:a = 12
-          5:print a**2
+          5:print(a**2)
           6:%history -n 4-6
 
         """

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -43,7 +43,7 @@ class NamespaceMagics(Magics):
 
         '%pinfo object' is just a synonym for object? or ?object."""
 
-        #print 'pinfo par: <%s>' % parameter_s  # dbg
+        # print('pinfo par: <%s>' % parameter_s)  # dbg
         # detail_level: 0 -> obj? , 1 -> obj??
         detail_level = 0
         # We need to detect if we got called as 'pinfo pinfo foo', which can

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -1196,7 +1196,7 @@ class Inspector(Colorable):
 
           - list_types(False): list all available object types for object matching.
         """
-        #print 'ps pattern:<%r>' % pattern # dbg
+        # print('ps pattern:<%r>' % pattern)  # dbg
 
         # defaults
         type_pattern = 'all'
@@ -1225,7 +1225,7 @@ class Inspector(Colorable):
                 raise ValueError('invalid namespace <%s>. Valid names: %s' %
                                  (name,ns_table.keys()))
 
-        #print 'type_pattern:',type_pattern # dbg
+        # print('type_pattern:',type_pattern)  # dbg
         search_result, namespaces_seen = set(), set()
         for ns_name in ns_search:
             ns = ns_table[ns_name]

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -122,8 +122,8 @@ def _detect_screen_size(screen_lines_def):
     termios.tcsetattr(sys.stdout,termios.TCSANOW,term_flags)
     # Now we have what we needed: the screen size in rows/columns
     return screen_lines_real
-    #print '***Screen size:',screen_lines_real,'lines x',\
-    #screen_cols,'columns.' # dbg
+    # print('***Screen size:',screen_lines_real,'lines x',
+    #       screen_cols,'columns.')  # dbg
 
 def pager_page(strng, start=0, screen_lines=0, pager_cmd=None):
     """Display a string, piping through a pager after a certain length.
@@ -179,9 +179,9 @@ def pager_page(strng, start=0, screen_lines=0, pager_cmd=None):
             print(str_toprint)
             return
 
-    #print 'numlines',numlines,'screenlines',screen_lines  # dbg
+    # print('numlines',numlines,'screenlines',screen_lines)  # dbg
     if numlines <= screen_lines :
-        #print '*** normal print'  # dbg
+        # print('*** normal print')  # dbg
         print(str_toprint)
     else:
         # Try to open pager and default to internal one if that fails.

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -240,7 +240,7 @@ class PrefilterManager(Configurable):
 
         This implements the checker/handler part of the prefilter pipe.
         """
-        # print "prefilter_line_info: ", line_info
+        # print("prefilter_line_info: ", line_info)
         handler = self.find_handler(line_info)
         return handler.handle(line_info)
 
@@ -267,7 +267,7 @@ class PrefilterManager(Configurable):
         transformers and then the checkers/handlers.
         """
 
-        # print "prefilter_line: ", line, continue_prompt
+        # print("prefilter_line: ", line, continue_prompt)
         # All handlers *must* return a value, even if it's blank ('').
 
         # save the line away in case we crash, so the post-mortem handler can
@@ -300,7 +300,7 @@ class PrefilterManager(Configurable):
             return normal_handler.handle(line_info)
 
         prefiltered = self.prefilter_line_info(line_info)
-        # print "prefiltered line: %r" % prefiltered
+        # print("prefiltered line: %r" % prefiltered)
         return prefiltered
 
     def prefilter_lines(self, lines, continue_prompt=False):
@@ -544,7 +544,7 @@ class PrefilterHandler(Configurable):
         )
 
     def handle(self, line_info):
-        # print "normal: ", line_info
+        # print("normal: ", line_info)
         """Handle normal input lines. Use as a template for handlers."""
 
         # With autoindent on, we need some way to exit the input loop, and I

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -224,7 +224,7 @@ def mpl_runner(safe_execfile):
         import matplotlib
         import matplotlib.pyplot as plt
 
-        #print '*** Matplotlib runner ***' # dbg
+        # print('*** Matplotlib runner ***')  # dbg
         # turn off rendering until end of script
         with matplotlib.rc_context({"interactive": False}):
             safe_execfile(fname, *where, **kw)

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -63,19 +63,19 @@ def split_user_input(line, pattern=None):
         pattern = line_split
     match = pattern.match(line)
     if not match:
-        # print "match failed for line '%s'" % line
+        # print("match failed for line '%s'" % line)
         try:
             ifun, the_rest = line.split(None,1)
         except ValueError:
-            # print "split failed for line '%s'" % line
+            # print("split failed for line '%s'" % line)
             ifun, the_rest = line, u''
         pre = re.match(r'^(\s*)(.*)',line).groups()[0]
         esc = ""
     else:
         pre, esc, ifun, the_rest = match.groups()
 
-    #print 'line:<%s>' % line # dbg
-    #print 'pre <%s> ifun <%s> rest <%s>' % (pre,ifun.strip(),the_rest) # dbg
+    # print('line:<%s>' % line)  # dbg
+    # print('pre <%s> ifun <%s> rest <%s>' % (pre,ifun.strip(),the_rest))  # dbg
     return pre, esc or '', ifun.strip(), the_rest.lstrip()
 
 

--- a/IPython/core/tests/tclass.py
+++ b/IPython/core/tests/tclass.py
@@ -26,7 +26,7 @@ else:
     if name.startswith('C'):
         c = C(name)
 
-#print >> sys.stderr, "ARGV:", sys.argv  # dbg
+# print(>> sys.stderr, "ARGV:", sys.argv)  # dbg
 
 # This next print statement is NOT debugging, we're making the check on a
 # completely separate process so we verify by capturing stdout:

--- a/IPython/core/tests/tclass.py
+++ b/IPython/core/tests/tclass.py
@@ -26,7 +26,7 @@ else:
     if name.startswith('C'):
         c = C(name)
 
-# print(>> sys.stderr, "ARGV:", sys.argv)  # dbg
+# print("ARGV:", sys.argv, file=sys.stderr)  # dbg
 
 # This next print statement is NOT debugging, we're making the check on a
 # completely separate process so we verify by capturing stdout:

--- a/IPython/core/tests/test_inputsplitter.py
+++ b/IPython/core/tests/test_inputsplitter.py
@@ -43,7 +43,7 @@ def mini_interactive_loop(input_func):
     # Here we just return input so we can use it in a test suite, but a real
     # interpreter would instead send it for execution somewhere.
     src = isp.source_reset()
-    #print 'Input source was:\n', src  # dbg
+    # print('Input source was:\n', src)  # dbg
     return src
 
 #-----------------------------------------------------------------------------

--- a/IPython/extensions/storemagic.py
+++ b/IPython/extensions/storemagic.py
@@ -25,7 +25,7 @@ def restore_aliases(ip, alias=None):
     staliases = ip.db.get('stored_aliases', {})
     if alias is None:
         for k,v in staliases.items():
-            #print "restore alias",k,v # dbg
+            # print("restore alias",k,v)  # dbg
             #self.alias_table[k] = v
             ip.alias_manager.define_alias(k,v)
     else:
@@ -43,7 +43,7 @@ def refresh_variables(ip):
             print("Unable to restore variable '%s', ignoring (use %%store -d to forget!)" % justkey)
             print("The error was:", sys.exc_info()[0])
         else:
-            #print "restored",justkey,"=",obj #dbg
+            # print("restored",justkey,"=",obj)  # dbg
             ip.user_ns[justkey] = obj
 
 

--- a/IPython/lib/lexers.py
+++ b/IPython/lib/lexers.py
@@ -456,13 +456,13 @@ class IPythonConsoleLexer(Lexer):
             # does not use the continuation marker cannot be detected.
             # For example, the 3 in the following is clearly output:
             #
-            #    In [1]: print 3
+            #    In [1]: print(3)
             #    3
             #
             # But the following second line is part of the input:
             #
             #    In [2]: while True:
-            #        print True
+            #        print(True)
             #
             # In both cases, the 2nd line will be 'output'.
             #

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -300,7 +300,7 @@ def block_parser(part, rgxin, rgxout, fmtin, fmtout):
 
                 nextline = lines[i]
                 matchout = rgxout.match(nextline)
-                #print "nextline=%s, continuation=%s, starts=%s"%(nextline, continuation, nextline.startswith(continuation))
+                # print("nextline=%s, continuation=%s, starts=%s"%(nextline, continuation, nextline.startswith(continuation)))
                 if matchout or nextline.startswith('#'):
                     break
                 elif nextline.startswith(continuation):
@@ -538,7 +538,7 @@ class EmbeddedSphinxShell(object):
             # When there is stdout from the input, it also has a '\n' at the
             # tail end, and so this ensures proper spacing as well. E.g.:
             #
-            #   In [1]: print x
+            #   In [1]: print(x)
             #   5
             #
             #   In [2]: x = 5
@@ -699,7 +699,7 @@ class EmbeddedSphinxShell(object):
         """
         self.ensure_pyplot()
         command = 'plt.gcf().savefig("%s")'%image_file
-        #print 'SAVEFIG', command  # dbg
+        # print('SAVEFIG', command)  # dbg
         self.process_input_line('bookmark ipy_thisdir', store_history=False)
         self.process_input_line('cd -b ipy_savedir', store_history=False)
         self.process_input_line(command, store_history=False)

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -270,7 +270,7 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         if self.subapp is not None:
             # don't bother initializing further, starting subapp
             return
-        # print self.extra_args
+        # print(self.extra_args)
         if self.extra_args and not self.something_to_run:
             self.file_to_run = self.extra_args[0]
         self.init_path()

--- a/IPython/terminal/pt_inputhooks/glut.py
+++ b/IPython/terminal/pt_inputhooks/glut.py
@@ -127,11 +127,11 @@ def inputhook(context):
             # 0.05    0.5%
             used_time = clock() - t
             if used_time > 10.0:
-                # print 'Sleep for 1 s'  # dbg
+                # print('Sleep for 1 s')  # dbg
                 time.sleep(1.0)
             elif used_time > 0.1:
                 # Few GUI events coming in, so we can sleep longer
-                # print 'Sleep for 0.05 s'  # dbg
+                # print('Sleep for 0.05 s')  # dbg
                 time.sleep(0.05)
             else:
                 # Many GUI events coming in, so sleep only very little

--- a/IPython/terminal/pt_inputhooks/pyglet.py
+++ b/IPython/terminal/pt_inputhooks/pyglet.py
@@ -53,11 +53,11 @@ def inputhook(context):
             # 0.05    0.5%
             used_time = clock() - t
             if used_time > 10.0:
-                # print 'Sleep for 1 s'  # dbg
+                # print('Sleep for 1 s')  # dbg
                 time.sleep(1.0)
             elif used_time > 0.1:
                 # Few GUI events coming in, so we can sleep longer
-                # print 'Sleep for 0.05 s'  # dbg
+                # print('Sleep for 0.05 s')  # dbg
                 time.sleep(0.05)
             else:
                 # Many GUI events coming in, so sleep only very little

--- a/IPython/terminal/pt_inputhooks/wx.py
+++ b/IPython/terminal/pt_inputhooks/wx.py
@@ -137,11 +137,11 @@ def inputhook_wx3(context):
             # 0.05    0.5%
             used_time = clock() - t
             if used_time > 10.0:
-                # print 'Sleep for 1 s'  # dbg
+                # print('Sleep for 1 s')  # dbg
                 time.sleep(1.0)
             elif used_time > 0.1:
                 # Few GUI events coming in, so we can sleep longer
-                # print 'Sleep for 0.05 s'  # dbg
+                # print('Sleep for 0.05 s')  # dbg
                 time.sleep(0.05)
             else:
                 # Many GUI events coming in, so sleep only very little

--- a/IPython/testing/ipunittest.py
+++ b/IPython/testing/ipunittest.py
@@ -108,7 +108,7 @@ class IPython2PythonConverter(object):
             
             newline(line)
         newline('')  # ensure a closing newline, needed by doctest
-        #print "PYSRC:", '\n'.join(out)  # dbg
+        # print("PYSRC:", '\n'.join(out))  # dbg
         return '\n'.join(out)
 
     #return dnew

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -68,7 +68,7 @@ class IPDoctestOutputChecker(doctest.OutputChecker):
         ret = doctest.OutputChecker.check_output(self, want, got,
                                                  optionflags)
         if not ret and self.random_re.search(want):
-            #print >> sys.stderr, 'RANDOM OK:',want  # dbg
+            # print(>> sys.stderr, 'RANDOM OK:',want)  # dbg
             return True
 
         return ret
@@ -141,7 +141,7 @@ class IPDocTestParser(doctest.DocTestParser):
         used for error messages.
         """
 
-        #print 'Parse string:\n',string # dbg
+        # print('Parse string:\n',string)  # dbg
 
         string = string.expandtabs()
         # If all lines begin with the same indentation, then strip it.

--- a/IPython/testing/plugin/ipdoctest.py
+++ b/IPython/testing/plugin/ipdoctest.py
@@ -68,7 +68,7 @@ class IPDoctestOutputChecker(doctest.OutputChecker):
         ret = doctest.OutputChecker.check_output(self, want, got,
                                                  optionflags)
         if not ret and self.random_re.search(want):
-            # print(>> sys.stderr, 'RANDOM OK:',want)  # dbg
+            # print('RANDOM OK:',want, file=sys.stderr)  # dbg
             return True
 
         return ret

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -245,8 +245,8 @@ def ipexec_validate(fname, expected_out, expected_err='',
     __tracebackhide__ = True
 
     out, err = ipexec(fname, options, commands)
-    #print 'OUT', out  # dbg
-    #print 'ERR', err  # dbg
+    # print('OUT', out)  # dbg
+    # print('ERR', err)  # dbg
     # If there are any errors, we must check those before stdout, as they may be
     # more informative than simply having an empty stdout.
     if err:

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -308,8 +308,8 @@ def target_outdated(target,deps):
     for dep in deps:
         dep_time = os.path.getmtime(dep)
         if dep_time > target_time:
-            #print "For target",target,"Dep failed:",dep # dbg
-            #print "times (dep,tar):",dep_time,target_time # dbg
+            # print("For target",target,"Dep failed:",dep)  # dbg
+            # print("times (dep,tar):",dep_time,target_time)  # dbg
             return 1
     return 0
 

--- a/IPython/utils/strdispatch.py
+++ b/IPython/utils/strdispatch.py
@@ -48,7 +48,7 @@ class StrDispatch(object):
             if re.match(r, key):
                 yield obj
             else:
-                #print "nomatch",key  # dbg
+                # print("nomatch",key)  # dbg
                 pass
 
     def __repr__(self):

--- a/IPython/utils/tests/test_path.py
+++ b/IPython/utils/tests/test_path.py
@@ -254,10 +254,10 @@ def test_get_xdg_dir_3():
 def test_filefind():
     """Various tests for filefind"""
     f = tempfile.NamedTemporaryFile()
-    # print 'fname:',f.name
+    # print('fname:',f.name)
     alt_dirs = paths.get_ipython_dir()
     t = path.filefind(f.name, alt_dirs)
-    # print 'found:',t
+    # print('found:',t)
 
 
 @dec.skip_if_not_win32

--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -72,8 +72,8 @@ class LSString(str):
 
 # def print_lsstring(arg):
 #     """ Prettier (non-repr-like) and more informative printer for LSString """
-#     print "LSString (.p, .n, .l, .s available). Value:"
-#     print arg
+#     print("LSString (.p, .n, .l, .s available). Value:")
+#     print(arg)
 #
 #
 # print_lsstring = result_display.register(LSString)(print_lsstring)
@@ -231,7 +231,7 @@ class SList(list):
 
 # def print_slist(arg):
 #     """ Prettier (non-repr-like) and more informative printer for SList """
-#     print "SList (.p, .n, .l, .s, .grep(), .fields(), sort() available):"
+#     print("SList (.p, .n, .l, .s, .grep(), .fields(), sort() available):")
 #     if hasattr(arg,  'hideonce') and arg.hideonce:
 #         arg.hideonce = False
 #         return

--- a/setupbase.py
+++ b/setupbase.py
@@ -144,8 +144,8 @@ def target_outdated(target,deps):
     for dep in deps:
         dep_time = os.path.getmtime(dep)
         if dep_time > target_time:
-            #print "For target",target,"Dep failed:",dep # dbg
-            #print "times (dep,tar):",dep_time,target_time # dbg
+            # print("For target",target,"Dep failed:",dep)  # dbg
+            # print("times (dep,tar):",dep_time,target_time)  # dbg
             return 1
     return 0
 

--- a/tools/tests/heartbeat/gilsleep.ipynb
+++ b/tools/tests/heartbeat/gilsleep.ipynb
@@ -32,7 +32,7 @@
     "    ])\n",
     "    while True:\n",
     "        inline(code, quiet=True, t=t)\n",
-    "        print time.time()\n",
+    "        print(time.time())\n",
     "        sys.stdout.flush() # this is important\n",
     "\n",
     "gilsleep(5)"


### PR DESCRIPTION
The main interest was to transform py2-style print statements that still appeared in some docstrings (e.g. for %history) and would thus show up when looking at the docs either interactively or in the rendered website.  I also fixed a number of commented-out print statements at the same time, mostly because it was easier for me to just regexp-change all of them so that I could focus on the others.