### PR TITLE
Fix for embedded shell venv check index error

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -909,7 +909,7 @@ class InteractiveShell(SingletonConfigurable):
         paths = self.get_path_links(p)
 
         # In Cygwin paths like "c:\..." and '\cygdrive\c\...' are possible
-        if p_venv.parts[1] == "cygdrive":
+        if len(p_venv.parts) > 2 and p_venv.parts[1] == "cygdrive":
             drive_name = p_venv.parts[2]
             p_venv = (drive_name + ":/") / Path(*p_venv.parts[3:])
 


### PR DESCRIPTION
Fixes the issue from #14126 where we get an index out of range error when VIRTUAL_ENV is set to a 1 or 2 part path (eg ".venv").