### PR TITLE
Convert matplotlib gui name in enable_gui

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -943,6 +943,11 @@ class TerminalInteractiveShell(InteractiveShell):
     active_eventloop: Optional[str] = None
 
     def enable_gui(self, gui: Optional[str] = None) -> None:
+        if gui:
+            from ..core.pylabtools import _convert_gui_from_matplotlib
+
+            gui = _convert_gui_from_matplotlib(gui)
+
         if self.simple_prompt is True and gui is not None:
             print(
                 f'Cannot install event loop hook for "{gui}" when running with `--simple-prompt`.'

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -147,10 +147,13 @@ skip_osx = skipif(sys.platform == 'darwin',"This test does not run under OS X")
 
 
 # Decorators to skip tests if not on specific platforms.
-skip_if_not_win32 = skipif(sys.platform != 'win32',
-                           "This test only runs under Windows")
-skip_if_not_linux = skipif(not sys.platform.startswith('linux'),
-                           "This test only runs under Linux")
+skip_if_not_win32 = skipif(sys.platform != "win32", "This test only runs under Windows")
+skip_if_not_linux = skipif(
+    not sys.platform.startswith("linux"), "This test only runs under Linux"
+)
+skip_if_not_osx = skipif(
+    not sys.platform.startswith("darwin"), "This test only runs under macOS"
+)
 
 _x11_skip_cond = (sys.platform not in ('darwin', 'win32') and
                   os.environ.get('DISPLAY', '') == '')


### PR DESCRIPTION
This is a bug that I discovered whilst dealing with matplotlib/matplotlib#28332. The change here is in `TerminalInteractiveShell.enable_gui` which needs to convert a gui of `macosx` from Matplotlib into `osx` in IPython. It reuses the converter function created in #14420.

I've added a test that uses `enable_gui` and raises an exception before this PR but passes with it.

The remainder of the changes are formatting changes from `pre-commit`.