### PR TITLE
bugfix for call to structured_traceback

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2033,7 +2033,7 @@ class InteractiveShell(SingletonConfigurable):
                     print(self.InteractiveTB.stb2text(stb))
                     print("The original exception:")
                     stb = self.InteractiveTB.structured_traceback(
-                                            (etype,value,tb), tb_offset=tb_offset
+                                            etype, value, tb, tb_offset=tb_offset
                     )
                 return stb
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2033,7 +2033,7 @@ class InteractiveShell(SingletonConfigurable):
                     print(self.InteractiveTB.stb2text(stb))
                     print("The original exception:")
                     stb = self.InteractiveTB.structured_traceback(
-                                            etype, value, tb, tb_offset=tb_offset
+                        etype, value, tb, tb_offset=tb_offset
                     )
                 return stb
 


### PR DESCRIPTION
Calls to `structured_traceback` take the exploded 3-tuple of `*sys.exc_info()` as separate arguments, so we don't want to pass the 3-tuple as one argument. This should fix some of the symptoms people are seeing in https://github.com/ipython/ipython/issues/12831

Test plan: local editable install, seems to work OK. Haven't tried to repro the problem from the linked issue but this change probably can't hurt.

From https://github.com/ipython/ipython/pull/14454, which is just an empty commit, I see the same test failures as in this PR's "Run Downstream tests" job: https://github.com/ipython/ipython/actions/runs/9375565881/job/25813901627?pr=14454

So I'm guessing it's not related to the change in this PR.