### PR TITLE
Implement `IPython.utils.io.Tee.isatty`

### DIFF
--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -75,6 +75,8 @@ class Tee(object):
         if not self._closed:
             self.close()
 
+    def isatty(self):
+        return False
 
 def ask_yes_no(prompt, default=None, interrupt=None):
     """Asks a question and returns a boolean (y/n) answer.


### PR DESCRIPTION
A lot of libraries would call `sys.stdout.isatty()`, but `IPython.utils.io.Tee` does not implement `isatty`.

Let's add the method to avoid errors.