### PR TITLE
Don't force matplotlib backend names to be lowercase

### DIFF
--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -100,7 +100,7 @@ class PylabMagics(Magics):
                 % _list_matplotlib_backends_and_gui_loops()
             )
         else:
-            gui, backend = self.shell.enable_matplotlib(args.gui.lower() if isinstance(args.gui, str) else args.gui)
+            gui, backend = self.shell.enable_matplotlib(args.gui)
             self._show_matplotlib_backend(args.gui, backend)
 
     @skip_doctest

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -350,3 +350,27 @@ def test_backend_entry_point():
 def test_backend_unknown():
     with pytest.raises(RuntimeError if pt._matplotlib_manages_backends() else KeyError):
         pt.find_gui_and_backend("name-does-not-exist")
+
+
+@dec.skipif(not pt._matplotlib_manages_backends())
+def test_backend_module_name_case_sensitive():
+    # Matplotlib backend names are case insensitive unless explicitly specified using
+    # "module://some_module.some_name" syntax which are case sensitive for mpl >= 3.9.1
+    all_lowercase = "module://matplotlib_inline.backend_inline"
+    some_uppercase = "module://matplotlib_inline.Backend_inline"
+    ip = get_ipython()
+    mpl3_9_1 = matplotlib.__version_info__ >= (3, 9, 1)
+
+    ip.enable_matplotlib(all_lowercase)
+    if mpl3_9_1:
+        with pytest.raises(RuntimeError):
+            ip.enable_matplotlib(some_uppercase)
+    else:
+        ip.enable_matplotlib(some_uppercase)
+
+    ip.run_line_magic("matplotlib", all_lowercase)
+    if mpl3_9_1:
+        with pytest.raises(RuntimeError):
+            ip.run_line_magic("matplotlib", some_uppercase)
+    else:
+        ip.run_line_magic("matplotlib", some_uppercase)

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -258,6 +258,29 @@ class TestPylabSwitch(object):
         assert gui == "qt"
         assert s.pylab_gui_select == "qt"
 
+    @dec.skipif(not pt._matplotlib_manages_backends())
+    def test_backend_module_name_case_sensitive(self):
+        # Matplotlib backend names are case insensitive unless explicitly specified using
+        # "module://some_module.some_name" syntax which are case sensitive for mpl >= 3.9.1
+        all_lowercase = "module://matplotlib_inline.backend_inline"
+        some_uppercase = "module://matplotlib_inline.Backend_inline"
+        mpl3_9_1 = matplotlib.__version_info__ >= (3, 9, 1)
+
+        s = self.Shell()
+        s.enable_matplotlib(all_lowercase)
+        if mpl3_9_1:
+            with pytest.raises(RuntimeError):
+                s.enable_matplotlib(some_uppercase)
+        else:
+            s.enable_matplotlib(some_uppercase)
+
+        s.run_line_magic("matplotlib", all_lowercase)
+        if mpl3_9_1:
+            with pytest.raises(RuntimeError):
+                s.run_line_magic("matplotlib", some_uppercase)
+        else:
+            s.run_line_magic("matplotlib", some_uppercase)
+
 
 def test_no_gui_backends():
     for k in ['agg', 'svg', 'pdf', 'ps']:
@@ -350,27 +373,3 @@ def test_backend_entry_point():
 def test_backend_unknown():
     with pytest.raises(RuntimeError if pt._matplotlib_manages_backends() else KeyError):
         pt.find_gui_and_backend("name-does-not-exist")
-
-
-@dec.skipif(not pt._matplotlib_manages_backends())
-def test_backend_module_name_case_sensitive():
-    # Matplotlib backend names are case insensitive unless explicitly specified using
-    # "module://some_module.some_name" syntax which are case sensitive for mpl >= 3.9.1
-    all_lowercase = "module://matplotlib_inline.backend_inline"
-    some_uppercase = "module://matplotlib_inline.Backend_inline"
-    ip = get_ipython()
-    mpl3_9_1 = matplotlib.__version_info__ >= (3, 9, 1)
-
-    ip.enable_matplotlib(all_lowercase)
-    if mpl3_9_1:
-        with pytest.raises(RuntimeError):
-            ip.enable_matplotlib(some_uppercase)
-    else:
-        ip.enable_matplotlib(some_uppercase)
-
-    ip.run_line_magic("matplotlib", all_lowercase)
-    if mpl3_9_1:
-        with pytest.raises(RuntimeError):
-            ip.run_line_magic("matplotlib", some_uppercase)
-    else:
-        ip.run_line_magic("matplotlib", some_uppercase)


### PR DESCRIPTION
This is something I missed as part of moving the backend resolution to Matplotlib. Since version 3.9.0 Matplotlib handles the case-sensitivity of backend names, making them all lowercase for internal use. But since matplotlib/matplotlib#28473 uppercase letters are allowed in backend names of the form `module://soMe_moDule.sOmE_NAme`. Hence we need to not force backend names to be lowercase in IPython when passing them to Matplotlib. It is just a one line change that happens to make the code simpler, plus a new test.

The Matplotlib change will be released in 3.9.1 which is due shortly, possibly today. The new test checks the Matplotlib version to know whether uppercase backend module names are allowed or not.