### PR TITLE
Issue with parsing full windows path when adding a breakpoint using %run with -d and -b

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1568,12 +1568,22 @@ class ExecutionMagics(Magics):
 
 def parse_breakpoint(text, current_file):
     '''Returns (file, line) for file:line and (current_file, line) for line'''
-    colon = text.find(':')
-    if colon == -1:
-        return current_file, int(text)
-    else:
-        return text[:colon], int(text[colon+1:])
-    
+    text = text.strip("'").strip('"')
+    token = text.split(':')
+    reg = re.compile(r"[^\d]")
+    if len(token) == 1 or len(token) == 0:
+        num = reg.sub("", text)
+        return (current_file, int(text))
+    elif len(token) == 2:
+        colon = text.find(':')
+        num = (reg.sub("", text[colon+1:]))
+        return text[:colon], int(num)
+    elif len(token) == 3:
+        num = reg.sub("", token[2])
+        return (':'.join(token[:2]), int(num))
+    elif len(token) > 3:
+        raise Exception("More than 2 colons in text")
+
 def _format_time(timespan, precision=3):
     """Formats the timespan in a human readable form"""
 


### PR DESCRIPTION
When trying to add a breakpoint using this command `%run -d -b C:/path/to/file.py:100 path/to/start.py` it breaks due to there being more than one colon in the str.