### PR TITLE
`AssertionError`: `assert _xterm_term_title_saved` in WSL

### DIFF
--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -80,7 +80,13 @@ def _set_term_title_xterm(title):
 def _restore_term_title_xterm():
     # Make sure the restore has at least one accompanying set.
     global _xterm_term_title_saved
-    assert _xterm_term_title_saved
+    if not _xterm_term_title_saved:
+        warnings.warn(
+            "Expecting xterm_term_title_saved to be True, but is not; will not restore terminal title.",
+            stacklevel=1,
+        )
+        return
+
     sys.stdout.write('\033[23;0t') 
     _xterm_term_title_saved = False
 


### PR DESCRIPTION
`AssertionError`: `assert _xterm_term_title_saved`

In some (unknown) situation, it is possible that the `_xterm_term_title_saved` is unset,
but the code would make a call to `_restore_term_title_xterm`, resulting in `AssertionError`.

At least on replicatable reproduction is
returning from `ipython` to `pudb` via `^D^D` on an empty cell.

See more details in https://github.com/ipython/ipython/pull/14480

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>

<details>
<summary><em>was:</em></summary>

In some (unknown) situation, it is possible that the `_xterm_term_title_saved` is unset, but the code would make a call to `_restore_term_title_xterm`, resulting in `AssertionError`.

As title stacking does not seem to be getting traction (https://github.com/microsoft/terminal/issues/14575), do not set the `xterm` variants of `_set_term_title` / `_restore_term_title`.

WSL detection: https://superuser.com/a/1749811/533196

Additionally, almost-`black` the file.

</details>