### PR TITLE
Fix some tests on Python 3.13 RC1

### DIFF
--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -139,8 +139,8 @@ def test_ipdb_magics():
     <BLANKLINE>
     ipdb> continue
 
-    Restore previous trace function, e.g. for coverage.py    
-    
+    Restore previous trace function, e.g. for coverage.py
+
     In [6]: sys.settrace(old_trace)
     '''
 
@@ -506,13 +506,17 @@ def test_decorator_skip_with_breakpoint():
             child.expect_exact("--> 47     bar(3, 4)")
             extra_step = []
 
-        for input_, expected in [
-            (f"b {name}.py:3", ""),
-        ] + extra_step + [
-            ("step", "1---> 3     pass # should not stop here except"),
-            ("step", "---> 38 @pdb_skipped_decorator"),
-            ("continue", ""),
-        ]:
+        for input_, expected in (
+            [
+                (f"b {name}.py:3", ""),
+            ]
+            + extra_step
+            + [
+                ("step", "1---> 3     pass # should not stop here except"),
+                ("step", "---> 38 @pdb_skipped_decorator"),
+                ("continue", ""),
+            ]
+        ):
             child.expect("ipdb>")
             child.sendline(input_)
             child.expect_exact(input_)

--- a/IPython/core/tests/test_debugger.py
+++ b/IPython/core/tests/test_debugger.py
@@ -59,40 +59,43 @@ def test_ipdb_magics():
 
     First, set up some test functions and classes which we can inspect.
 
-    >>> class ExampleClass(object):
-    ...    """Docstring for ExampleClass."""
-    ...    def __init__(self):
-    ...        """Docstring for ExampleClass.__init__"""
-    ...        pass
-    ...    def __str__(self):
-    ...        return "ExampleClass()"
+    In [1]: class ExampleClass(object):
+       ...:    """Docstring for ExampleClass."""
+       ...:    def __init__(self):
+       ...:        """Docstring for ExampleClass.__init__"""
+       ...:        pass
+       ...:    def __str__(self):
+       ...:        return "ExampleClass()"
 
-    >>> def example_function(x, y, z="hello"):
-    ...     """Docstring for example_function."""
-    ...     pass
+    In [2]: def example_function(x, y, z="hello"):
+       ...:     """Docstring for example_function."""
+       ...:     pass
 
-    >>> old_trace = sys.gettrace()
+    In [3]: old_trace = sys.gettrace()
 
     Create a function which triggers ipdb.
 
-    >>> def trigger_ipdb():
-    ...    a = ExampleClass()
-    ...    debugger.Pdb().set_trace()
+    In [4]: def trigger_ipdb():
+       ...:    a = ExampleClass()
+       ...:    debugger.Pdb().set_trace()
 
-    >>> with PdbTestInput([
-    ...    'pdef example_function',
-    ...    'pdoc ExampleClass',
-    ...    'up',
-    ...    'down',
-    ...    'list',
-    ...    'pinfo a',
-    ...    'll',
-    ...    'continue',
-    ... ]):
-    ...     trigger_ipdb()
-    --Return--
-    None
-    > <doctest ...>(3)trigger_ipdb()
+    Run ipdb with faked input & check output. Because of a difference between
+    Python 3.13 & older versions, the first bit of the output is inconsistent.
+    We need to use ... to accommodate that, so the examples have to use IPython
+    prompts so that ... is distinct from the Python PS2 prompt.
+
+    In [5]: with PdbTestInput([
+       ...:    'pdef example_function',
+       ...:    'pdoc ExampleClass',
+       ...:    'up',
+       ...:    'down',
+       ...:    'list',
+       ...:    'pinfo a',
+       ...:    'll',
+       ...:    'continue',
+       ...: ]):
+       ...:     trigger_ipdb()
+    ...> <doctest ...>(3)trigger_ipdb()
           1 def trigger_ipdb():
           2    a = ExampleClass()
     ----> 3    debugger.Pdb().set_trace()
@@ -112,8 +115,7 @@ def test_ipdb_magics():
          10 ]):
     ---> 11     trigger_ipdb()
     <BLANKLINE>
-    ipdb> down
-    None
+    ipdb> down...
     > <doctest ...>(3)trigger_ipdb()
           1 def trigger_ipdb():
           2    a = ExampleClass()
@@ -136,10 +138,10 @@ def test_ipdb_magics():
     ----> 3    debugger.Pdb().set_trace()
     <BLANKLINE>
     ipdb> continue
-    
+
     Restore previous trace function, e.g. for coverage.py    
     
-    >>> sys.settrace(old_trace)
+    In [6]: sys.settrace(old_trace)
     '''
 
 def test_ipdb_magics2():

--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -516,23 +516,23 @@ def test_pinfo_docstring_dynamic(capsys):
 
     ip.run_line_magic("pinfo", "b.prop")
     captured = capsys.readouterr()
-    assert "Docstring:   cdoc for prop" in captured.out
+    assert re.search(r"Docstring:\s+cdoc for prop", captured.out)
 
     ip.run_line_magic("pinfo", "b.non_exist")
     captured = capsys.readouterr()
-    assert "Docstring:   cdoc for non_exist" in captured.out
+    assert re.search(r"Docstring:\s+cdoc for non_exist", captured.out)
 
     ip.run_cell("b.prop?")
     captured = capsys.readouterr()
-    assert "Docstring:   cdoc for prop" in captured.out
+    assert re.search(r"Docstring:\s+cdoc for prop", captured.out)
 
     ip.run_cell("b.non_exist?")
     captured = capsys.readouterr()
-    assert "Docstring:   cdoc for non_exist" in captured.out
+    assert re.search(r"Docstring:\s+cdoc for non_exist", captured.out)
 
     ip.run_cell("b.undefined?")
     captured = capsys.readouterr()
-    assert "Docstring:   <no docstring>" in captured.out
+    assert re.search(r"Type:\s+NoneType", captured.out)
 
 
 def test_pinfo_magic():


### PR DESCRIPTION
Random little odds and ends that have changed in 3.13 break the tests. I think this should get the CI working again. :crossed_fingers: 

Closes #14457
Closes #14458