### PR TITLE
Fix use of pyside6 >= 6.7.0

### DIFF
--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -302,6 +302,7 @@ def import_pyside6():
 
     ImportErrors raised within this function are non-recoverable
     """
+
     def get_attrs(module):
         return {
             name: getattr(module, name)

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -302,13 +302,24 @@ def import_pyside6():
 
     ImportErrors raised within this function are non-recoverable
     """
+    def get_attrs(module):
+        return {
+            name: getattr(module, name)
+            for name in dir(module)
+            if not name.startswith("_")
+        }
+
     from PySide6 import QtGui, QtCore, QtSvg, QtWidgets, QtPrintSupport
 
     # Join QtGui and QtWidgets for Qt4 compatibility.
     QtGuiCompat = types.ModuleType("QtGuiCompat")
     QtGuiCompat.__dict__.update(QtGui.__dict__)
-    QtGuiCompat.__dict__.update(QtWidgets.__dict__)
-    QtGuiCompat.__dict__.update(QtPrintSupport.__dict__)
+    if QtCore.__version_info__ < (6, 7):
+        QtGuiCompat.__dict__.update(QtWidgets.__dict__)
+        QtGuiCompat.__dict__.update(QtPrintSupport.__dict__)
+    else:
+        QtGuiCompat.__dict__.update(get_attrs(QtWidgets))
+        QtGuiCompat.__dict__.update(get_attrs(QtPrintSupport))
 
     return QtCore, QtGuiCompat, QtSvg, QT_API_PYSIDE6
 


### PR DESCRIPTION
Fixes #14463.

Using `pyside6 >= 6.7.0` as the `qt6` gui loop gives the following error:
```
In [1]: %gui qt6

In [2]: Traceback (most recent call last):
  File "/Users/iant/micromamba/envs/temp/bin/ipython", line 8, in <module>
    sys.exit(start_ipython())
             ^^^^^^^^^^^^^^^
  File "/Users/iant/github/ipython/IPython/__init__.py", line 130, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/iant/micromamba/envs/temp/lib/python3.12/site-packages/traitlets/config/application.py", line 1075, in launch_instance
    app.start()
  File "/Users/iant/github/ipython/IPython/terminal/ipapp.py", line 317, in start
    self.shell.mainloop()
  File "/Users/iant/github/ipython/IPython/terminal/interactiveshell.py", line 917, in mainloop
    self.interact()
  File "/Users/iant/github/ipython/IPython/terminal/interactiveshell.py", line 902, in interact
    code = self.prompt_for_code()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/iant/github/ipython/IPython/terminal/interactiveshell.py", line 845, in prompt_for_code
    text = self.pt_app.prompt(
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/iant/micromamba/envs/temp/lib/python3.12/site-packages/prompt_toolkit/shortcuts/prompt.py", line 1035, in prompt
    return self.app.run(
           ^^^^^^^^^^^^^
  File "/Users/iant/micromamba/envs/temp/lib/python3.12/site-packages/prompt_toolkit/application/application.py", line 978, in run
    result = loop.run_until_complete(coro)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/iant/micromamba/envs/temp/lib/python3.12/asyncio/base_events.py", line 674, in run_until_complete
    self.run_forever()
  File "/Users/iant/micromamba/envs/temp/lib/python3.12/asyncio/base_events.py", line 641, in run_forever
    self._run_once()
  File "/Users/iant/micromamba/envs/temp/lib/python3.12/asyncio/base_events.py", line 1948, in _run_once
    event_list = self._selector.select(timeout)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/iant/micromamba/envs/temp/lib/python3.12/site-packages/prompt_toolkit/eventloop/inputhook.py", line 150, in select
    self.inputhook(InputHookContext(self._r, input_is_ready))
  File "/Users/iant/github/ipython/IPython/terminal/pt_inputhooks/qt.py", line 50, in inputhook
    _appref = app = QtGui.QApplication([" "])
                    ^^^^^^^^^^^^^^^^^^
AttributeError: module 'PySide6.QtPrintSupport' has no attribute 'QApplication'

If you suspect this is an IPython 8.28.0.dev bug, please report it at:
    https://github.com/ipython/ipython/issues
or send an email to the mailing list at ipython-dev@python.org

You can print a more detailed traceback right now with "%tb", or use "%debug"
to interactively debug it.

Extra-detailed tracebacks for bug-reporting purposes can be enabled via:
    %config Application.verbose_crash=True
```

This is because we use the imported module's `__dict__` to get the classes and functions available in the module here:
https://github.com/ipython/ipython/blob/9b8cd4a397e5894ffeadad52477bb53e0fb664fc/IPython/external/qt_loaders.py#L309-L311

This no longer works as not all the classes and functions are in the `__dict__`. The solution in this PR is to use `dir(module)` instead.

I have tested this locally using `pyside6` 6.6.3.1, 6.7.0, 6.7.1 and 6.7.2 and it works for me. It also successfully creates Matplotlib plots using for example
```
In [1]: %matplotlib qt6
In [2]: import matplotlib.pyplot as plt
In [3]: plt.plot([1,3,2])
```

It would be good to get independent confirmation that this fixes other downstream libraries as I tend to work directly with IPython and IPyKernel.