### PR TITLE
bugfix for oinspect.object_info

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -173,8 +173,8 @@ def object_info(
     **kw,
 ) -> InfoDict:
     """Make an object info dict with all fields present."""
-    infodict = kw
-    infodict = {k: None for k in _info_fields if k not in infodict}
+    infodict = dict(kw)
+    infodict.update({k: None for k in _info_fields if k not in infodict})
     infodict["name"] = name  # type: ignore
     infodict["found"] = found  # type: ignore
     infodict["isclass"] = isclass  # type: ignore


### PR DESCRIPTION
`oinspect.object_info` loses stuff passed in as kwargs. I suspect it's not intentional (previous versions of `object_info` don't do this) and it seems to be the root cause of some CI failures when trying out new versions of IPython at Databricks. In this PR we preserve the fields passed in as kwargs.

Test plan: let pre-merge tests run.