### PR TITLE
DOC: fix typo in deprecation warning

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -41,7 +41,7 @@ from warnings import warn
 
 def __getattr__(name):
     if name in _deprecated_names:
-        warn(f"Importing {name} from IPython.core.display is deprecated since IPython 7.14, please import from IPython display", DeprecationWarning, stacklevel=2)
+        warn(f"Importing {name} from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display", DeprecationWarning, stacklevel=2)
         return getattr(display_functions, name)
 
     if name in globals().keys():

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -41,7 +41,11 @@ from warnings import warn
 
 def __getattr__(name):
     if name in _deprecated_names:
-        warn(f"Importing {name} from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display", DeprecationWarning, stacklevel=2)
+        warn(
+            f"Importing {name} from IPython.core.display is deprecated since IPython 7.14, please import from IPython.display",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return getattr(display_functions, name)
 
     if name in globals().keys():


### PR DESCRIPTION
I'm sorry about the ridiculous level of triviality here, but just reading the message it wasn't clear at first if I need to import from `IPython` or from `IPython.display` and naturally I went with the wrong one at first.

(My line was `from IPython.core.display import display`, so it wasn't obvious at first if the 'display' in the deprecation message was for the function or the module.)