### PR TITLE
ENH: add webp support to IPython.display.Image and complete identification of JPEG,PNG,GIF,WEBP image types by initial bytes

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -798,8 +798,8 @@ class Javascript(TextDisplayObject):
 # constants for identifying png/jpeg/gif/webp data
 _PNG = b'\x89PNG\r\n\x1a\n'
 _JPEG = b'\xff\xd8'
-_GIF1 = b"GIF87a"
-_GIF2 = b"GIF89a"
+_GIF1 = b'GIF87a'
+_GIF2 = b'GIF89a'
 _WEBP = b'WEBP'
 
 
@@ -838,16 +838,18 @@ def _gifxy(data):
 def _webpxy(data):
     """read the (width, height) from a WEBP header"""
     if data[12:16] == b"VP8 ":
-        width, height = struct.unpack('<HH', data[24:30])
-        width = (width & 0x3fff)
-        height = (height & 0x3fff)
+        width, height = struct.unpack("<HH", data[24:30])
+        width = width & 0x3FFF
+        height = height & 0x3FFF
         return (width, height)
     elif data[12:16] == b"VP8L":
-        size_info = struct.unpack('<I', data[21:25])[0]
+        size_info = struct.unpack("<I", data[21:25])[0]
         width = 1 + ((size_info & 0x3F) << 8) | (size_info >> 24)
-        height = 1 + ((((size_info >> 8) & 0xF) << 10) |
-                      (((size_info >> 14) & 0x3FC) << 2) |
-                      ((size_info >> 22) & 0x3))
+        height = 1 + (
+            (((size_info >> 8) & 0xF) << 10)
+            | (((size_info >> 14) & 0x3FC) << 2)
+            | ((size_info >> 22) & 0x3)
+        )
         return (width, height)
     else:
         raise ValueError("Not a valid WEBP header")
@@ -855,17 +857,17 @@ def _webpxy(data):
 
 class Image(DisplayObject):
 
-    _read_flags = 'rb'
-    _FMT_JPEG = u'jpeg'
-    _FMT_PNG = u'png'
-    _FMT_GIF = u'gif'
-    _FMT_WEBP = u'webp'
+    _read_flags = "rb"
+    _FMT_JPEG = "jpeg"
+    _FMT_PNG = "png"
+    _FMT_GIF = "gif"
+    _FMT_WEBP = "webp"
     _ACCEPTABLE_EMBEDDINGS = [_FMT_JPEG, _FMT_PNG, _FMT_GIF, _FMT_WEBP]
     _MIMETYPES = {
-        _FMT_PNG: 'image/png',
-        _FMT_JPEG: 'image/jpeg',
-        _FMT_GIF: 'image/gif',
-        _FMT_WEBP: 'image/webp',
+        _FMT_PNG: "image/png",
+        _FMT_JPEG: "image/jpeg",
+        _FMT_GIF: "image/gif",
+        _FMT_WEBP: "image/webp",
     }
 
     def __init__(
@@ -987,7 +989,7 @@ class Image(DisplayObject):
                     format = self._FMT_PNG
                 elif ext == u'gif':
                     format = self._FMT_GIF
-                elif ext == u'webp':
+                elif ext == "webp":
                     format = self._FMT_WEBP
                 else:
                     format = ext.lower()

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -794,6 +794,7 @@ class Javascript(TextDisplayObject):
         r += _lib_t2*len(self.lib)
         return r
 
+
 # constants for identifying png/jpeg/gif/webp data
 _PNG = b'\x89PNG\r\n\x1a\n'
 _JPEG = b'\xff\xd8'
@@ -801,11 +802,13 @@ _GIF1 = b"GIF87a"
 _GIF2 = b"GIF89a"
 _WEBP = b'WEBP'
 
+
 def _pngxy(data):
     """read the (width, height) from a PNG header"""
     ihdr = data.index(b'IHDR')
     # next 8 bytes are width/height
     return struct.unpack('>ii', data[ihdr+4:ihdr+12])
+
 
 def _jpegxy(data):
     """read the (width, height) from a JPEG header"""
@@ -826,9 +829,11 @@ def _jpegxy(data):
     h, w = struct.unpack('>HH', data[iSOF+5:iSOF+9])
     return w, h
 
+
 def _gifxy(data):
     """read the (width, height) from a GIF header"""
     return struct.unpack('<HH', data[6:10])
+
 
 def _webpxy(data):
     """read the (width, height) from a WEBP header"""

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1023,7 +1023,7 @@ class Image(DisplayObject):
                     format = self._FMT_PNG
                 elif data[8:12] == _WEBP:
                     format = self._FMT_WEBP
-                elif data[:6] == self._GIF1 or data[:6] == self._GIF2:
+                elif data[:6] == _GIF1 or data[:6] == _GIF2:
                     format = self._FMT_GIF
 
         # failed to detect format, default png

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -21,14 +21,35 @@ from IPython.testing.skipdoctest import skip_doctest
 from . import display_functions
 
 
-__all__ = ['display_pretty', 'display_html', 'display_markdown',
-           'display_svg', 'display_png', 'display_jpeg', 'display_webp',
-           'display_latex', 'display_json',
-           'display_javascript', 'display_pdf', 'DisplayObject', 'TextDisplayObject',
-           'Pretty', 'HTML', 'Markdown', 'Math', 'Latex', 'SVG', 'ProgressBar', 'JSON',
-           'GeoJSON', 'Javascript', 'Image', 'set_matplotlib_formats',
-           'set_matplotlib_close',
-           'Video']
+__all__ = [
+    "display_pretty",
+    "display_html",
+    "display_markdown",
+    "display_svg",
+    "display_png",
+    "display_jpeg",
+    "display_webp",
+    "display_latex",
+    "display_json",
+    "display_javascript",
+    "display_pdf",
+    "DisplayObject",
+    "TextDisplayObject",
+    "Pretty",
+    "HTML",
+    "Markdown",
+    "Math",
+    "Latex",
+    "SVG",
+    "ProgressBar",
+    "JSON",
+    "GeoJSON",
+    "Javascript",
+    "Image",
+    "set_matplotlib_formats",
+    "set_matplotlib_close",
+    "Video",
+]
 
 _deprecated_names = ["display", "clear_output", "publish_display_data", "update_display", "DisplayHandle"]
 
@@ -215,7 +236,7 @@ def display_webp(*objs, **kwargs):
     metadata : dict (optional)
         Metadata to be associated with the specific mimetype output.
     """
-    _display_mimetype('image/webp', objs, **kwargs)
+    _display_mimetype("image/webp", objs, **kwargs)
 
 
 def display_latex(*objs, **kwargs):
@@ -796,11 +817,11 @@ class Javascript(TextDisplayObject):
 
 
 # constants for identifying png/jpeg/gif/webp data
-_PNG = b'\x89PNG\r\n\x1a\n'
-_JPEG = b'\xff\xd8'
-_GIF1 = b'GIF87a'
-_GIF2 = b'GIF89a'
-_WEBP = b'WEBP'
+_PNG = b"\x89PNG\r\n\x1a\n"
+_JPEG = b"\xff\xd8"
+_GIF1 = b"GIF87a"
+_GIF2 = b"GIF89a"
+_WEBP = b"WEBP"
 
 
 def _pngxy(data):

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -905,7 +905,7 @@ class Image(DisplayObject):
         metadata=None,
         alt=None,
     ):
-        """Create a PNG/JPEG/GIF image object given raw data.
+        """Create a PNG/JPEG/GIF/WEBP image object given raw data.
 
         When this object is returned by an input cell or passed to the
         display function, it will result in the image being displayed

--- a/docs/source/whatsnew/version8.rst
+++ b/docs/source/whatsnew/version8.rst
@@ -1,6 +1,15 @@
 ============
  8.x Series
 ============
+
+.. _version 8.29:
+
+IPython 8.29
+============
+
+
+ - Add support for WEBP to ``IPython.display.Image``. :ghpull:`14526`
+
 .. _version 8.28:
 
 IPython 8.28


### PR DESCRIPTION
- So that `Image('./example.webp')` does not raise a `"Cannot embed the 'webp' image format"` error.
- So that matplotlib animations saved as .webp images work (e.g. when ffmpeg+h264 isn't working).
