### PR TITLE
Fix the failure of "Build docs" workflow

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -131,7 +131,6 @@ warning_is_error = config["numpydoc"]["warning_is_error"]
 
 # Options for HTML output
 # -----------------------
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # - html_theme
 # - html_static_path
 #     Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Fixes #14542.

Local run of the following command (along with previous steps) failed before deleting this line, and succeeded afterwards.

```
make -C docs/ html SPHINXOPTS="-W" \
          PYTHON="coverage run -a" \
          SPHINXBUILD="coverage run -a -m sphinx.cmd.build"
```