### PR TITLE
Fixes newline issue in sphinx docstring build

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1032,8 +1032,8 @@ class ExecutionMagics(Magics):
           %timeit [-n<N> -r<R> [-t|-c] -q -p<P> -o] statement
         or in cell mode:
           %%timeit [-n<N> -r<R> [-t|-c] -q -p<P> -o] setup_code
-          code
-          code...
+        code
+        code...
 
         Time execution of a Python statement or expression using the timeit
         module.  This function can be used both as a line and cell magic:


### PR DESCRIPTION
Added a newline under the %%timeit magic command in cell mode in the built-in magic commands section of the tutorial in the documentation