### PR TITLE
Creates newlines in the %%timeit documentation

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -195,12 +195,16 @@ class ExecutionMagics(Magics):
 
         """Run a statement through the python code profiler.
 
-        Usage, in line mode:
+        **Usage, in line mode:**
+
           %prun [options] statement
 
-        Usage, in cell mode:
+        **Usage, in cell mode:**
+
           %%prun [options] [statement]
+
           code...
+
           code...
 
         In cell mode, the additional code lines are appended to the (possibly
@@ -1028,12 +1032,17 @@ class ExecutionMagics(Magics):
     def timeit(self, line='', cell=None, local_ns=None):
         """Time execution of a Python statement or expression
 
-        Usage, in line mode:
+        **Usage, in line mode:**
+
           %timeit [-n<N> -r<R> [-t|-c] -q -p<P> -o] statement
-        or in cell mode:
+
+        **or in cell mode:**
+
           %%timeit [-n<N> -r<R> [-t|-c] -q -p<P> -o] setup_code
-        code
-        code...
+
+          code
+
+          code...
 
         Time execution of a Python statement or expression using the timeit
         module.  This function can be used both as a line and cell magic:
@@ -1046,6 +1055,7 @@ class ExecutionMagics(Magics):
           body has access to any variables created in the setup code.
 
         Options:
+
         -n<N>: execute the given statement <N> times in a loop. If <N> is not
         provided, <N> is determined so as to get sufficient accuracy.
 
@@ -1066,7 +1076,7 @@ class ExecutionMagics(Magics):
         -q: Quiet, do not print result.
 
         -o: return a TimeitResult that can be stored in a variable to inspect
-            the result in more details.
+        the result in more details.
 
         .. versionchanged:: 7.3
             User variables are no longer expanded,


### PR DESCRIPTION
Fixes #13873 by adding empty lines after semicolons, rendering blocks correctly.
Fixes the issue pointed out by this [comment](https://github.com/ipython/ipython/issues/13873#issuecomment-1363442055)

Fixes unintentional bolding in the later part of the same section, by removing indentation:
![image](https://github.com/user-attachments/assets/0200ff8a-6a0d-4250-85d6-ddb94c04725c)

