### PR TITLE
Fix re pattern pretty print

### DIFF
--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -726,7 +726,7 @@ class _ReFlags:
         done_one = False
         for flag in ('TEMPLATE', 'IGNORECASE', 'LOCALE', 'MULTILINE', 'DOTALL',
             'UNICODE', 'VERBOSE', 'DEBUG'):
-            if self.value & getattr(re, flag):
+            if self.value & getattr(re, flag, 0):
                 if done_one:
                     p.text('|')
                 p.text('re.' + flag)


### PR DESCRIPTION
`re.TEMPLATE` is gone in Python 3.13 resulting in a crash in the pattern pretty printer

Reproducer:

```
>>> import re
>>> re.compile("")
```

<details>
  <summary>Click me to see the traceback!</summary>

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/.local/lib/python3.13/site-packages/IPython/core/formatters.py:711, in PlainTextFormatter.__call__(self, obj)
    704 stream = StringIO()
    705 printer = pretty.RepresentationPrinter(stream, self.verbose,
    706     self.max_width, self.newline,
    707     max_seq_length=self.max_seq_length,
    708     singleton_pprinters=self.singleton_printers,
    709     type_pprinters=self.type_printers,
    710     deferred_pprinters=self.deferred_printers)
--> 711 printer.pretty(obj)
    712 printer.flush()
    713 return stream.getvalue()

File ~/.local/lib/python3.13/site-packages/IPython/lib/pretty.py:394, in RepresentationPrinter.pretty(self, obj)
    391 for cls in _get_mro(obj_class):
    392     if cls in self.type_pprinters:
    393         # printer registered in self.type_pprinters
--> 394         return self.type_pprinters[cls](obj, self, cycle)
    395     else:
    396         # deferred printer
    397         printer = self._in_deferred_types(cls)

File ~/.local/lib/python3.13/site-packages/IPython/lib/pretty.py:740, in _re_pattern_pprint(obj, p, cycle)
    738 re_compile = CallExpression.factory('re.compile')
    739 if obj.flags:
--> 740     p.pretty(re_compile(RawStringLiteral(obj.pattern), _ReFlags(obj.flags)))
    741 else:
    742     p.pretty(re_compile(RawStringLiteral(obj.pattern)))

File ~/.local/lib/python3.13/site-packages/IPython/lib/pretty.py:408, in RepresentationPrinter.pretty(self, obj)
    406     meth = cls._repr_pretty_
    407     if callable(meth):
--> 408         return meth(obj, self, cycle)
    409 if (
    410     cls is not object
    411     # check if cls defines __repr__
   (...)
    417     and callable(_safe_getattr(cls, "__repr__", None))
    418 ):
    419     return _repr_pprint(obj, self, cycle)

File ~/.local/lib/python3.13/site-packages/IPython/lib/pretty.py:573, in CallExpression._repr_pretty_(self, p, cycle)
    571 for arg in self.args:
    572     new_item()
--> 573     p.pretty(arg)
    574 for arg_name, arg in self.kwargs.items():
    575     new_item()

File ~/.local/lib/python3.13/site-packages/IPython/lib/pretty.py:408, in RepresentationPrinter.pretty(self, obj)
    406     meth = cls._repr_pretty_
    407     if callable(meth):
--> 408         return meth(obj, self, cycle)
    409 if (
    410     cls is not object
    411     # check if cls defines __repr__
   (...)
    417     and callable(_safe_getattr(cls, "__repr__", None))
    418 ):
    419     return _repr_pprint(obj, self, cycle)

File ~/.local/lib/python3.13/site-packages/IPython/lib/pretty.py:729, in _ReFlags._repr_pretty_(self, p, cycle)
    726 done_one = False
    727 for flag in ('TEMPLATE', 'IGNORECASE', 'LOCALE', 'MULTILINE', 'DOTALL',
    728     'UNICODE', 'VERBOSE', 'DEBUG'):
--> 729     if self.value & getattr(re, flag):
    730         if done_one:
    731             p.text('|')

AttributeError: module 're' has no attribute 'TEMPLATE'
```

</details>


Apparently it was "undocumented and never working" ([#32300](https://github.com/python/cpython/pull/32300)). That was reverted and then usage deprecated immediately in [#93161](https://github.com/python/cpython/pull/93161).

Status of existing `re.TEMPLATE` attribute in currently supported Python versions for IPython:

- https://github.com/python/cpython/blob/3.10/Lib/re.py#L154 "disable backtracking"
- https://github.com/python/cpython/blob/3.11/Lib/re/__init__.py#L152 "unknown purpose, deprecated"
- https://github.com/python/cpython/blob/3.12/Lib/re/__init__.py#L153 "unknown purpose, deprecated"

Since 3.11, using it in the first place causes warnings:

```
$ python3.11 -Wall
Python 3.11.10 (main, Oct 16 2024, 10:51:55) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.compile("", flags=re.TEMPLATE)
.../Python-3.11.10/lib/python3.11/re/__init__.py:289: DeprecationWarning: The re.TEMPLATE/re.T flag is deprecated as it is an undocumented flag without an obvious purpose. Don't use it.
  warnings.warn("The re.TEMPLATE/re.T flag is deprecated "
re.compile('', re.TEMPLATE)
```

https://github.com/ipython/ipython/pull/14559 offers an alternative approach, but it will change the pretty-print result for 3.10-3.12, I'm not sure if that would be considered a backwards-compatibility breaking change.