### PR TITLE
Fix compatibility with the latest Sphinx 8

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,7 +118,7 @@ except ModuleNotFoundError:
     intersphinx_mapping = config["intersphinx_mapping"]
     for k, v in intersphinx_mapping.items():
         intersphinx_mapping[k] = tuple(
-            [intersphinx_mapping[k]["url"], intersphinx_mapping[k]["fallback"]]
+            [intersphinx_mapping[k]["url"], intersphinx_mapping[k]["fallback"] or None]
         )
 
 


### PR DESCRIPTION
Resolves: https://github.com/ipython/ipython/issues/14595

The `fallback` value cannot be an empty string in Sphinx 8 and there is no way to store `None` in TOML so it has to be handled in `conf.py`.