### PR TITLE
Multiline suggest in prompt_toolkit and LLM autocompletion

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -26,7 +26,10 @@ from traitlets import (
     default,
     observe,
     validate,
+    DottedObjectName,
 )
+from traitlets.utils.importstring import import_item
+
 
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
@@ -224,7 +227,9 @@ class TerminalInteractiveShell(InteractiveShell):
 
     pt_app: UnionType[PromptSession, None] = None
     auto_suggest: UnionType[
-        AutoSuggestFromHistory, NavigableAutoSuggestFromHistory, None
+        AutoSuggestFromHistory,
+        NavigableAutoSuggestFromHistory,
+        None,
     ] = None
     debugger_history = None
 
@@ -431,6 +436,37 @@ class TerminalInteractiveShell(InteractiveShell):
         allow_none=True,
     ).tag(config=True)
 
+    llm_provider_class = DottedObjectName(
+        None,
+        allow_none=True,
+        help="""\
+        Provisional:
+            This is a provisinal API in IPython 8.32, before stabilisation
+            in 9.0, it may change without warnings.
+
+        class to use for the `NavigableAutoSuggestFromHistory` to request
+        completions from a LLM, this should inherit from
+        `jupyter_ai_magics:BaseProvider` and implement
+        `stream_inline_completions`
+    """,
+    ).tag(config=True)
+
+    @observe("llm_provider_class")
+    def _llm_provider_class_changed(self, change):
+        provider_class = change.new
+        if provider_class is not None:
+            warn(
+                "TerminalInteractiveShell.llm_provider_class is a provisional"
+                "  API as of IPython 8.32, and may change without warnings."
+            )
+            if isinstance(self.auto_suggest, NavigableAutoSuggestFromHistory):
+                self.auto_suggest._llm_provider = provider_class()
+            else:
+                self.log.warn(
+                    "llm_provider_class only has effects when using"
+                    "`NavigableAutoSuggestFromHistory` as auto_suggest."
+                )
+
     def _set_autosuggestions(self, provider):
         # disconnect old handler
         if self.auto_suggest and isinstance(
@@ -442,7 +478,15 @@ class TerminalInteractiveShell(InteractiveShell):
         elif provider == "AutoSuggestFromHistory":
             self.auto_suggest = AutoSuggestFromHistory()
         elif provider == "NavigableAutoSuggestFromHistory":
+            # LLM stuff are all Provisional in 8.32
+            if self.llm_provider_class:
+                llm_provider_constructor = import_item(self.llm_provider_class)
+                llm_provider = llm_provider_constructor()
+            else:
+                llm_provider = None
             self.auto_suggest = NavigableAutoSuggestFromHistory()
+            # Provisinal in 8.32
+            self.auto_suggest._llm_provider = llm_provider
         else:
             raise ValueError("No valid provider.")
         if self.pt_app:
@@ -832,7 +876,8 @@ class TerminalInteractiveShell(InteractiveShell):
                     & ~IsDone()
                     & Condition(
                         lambda: isinstance(
-                            self.auto_suggest, NavigableAutoSuggestFromHistory
+                            self.auto_suggest,
+                            NavigableAutoSuggestFromHistory,
                         )
                     ),
                 ),

--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -1,13 +1,15 @@
 import re
+import asyncio
 import tokenize
 from io import StringIO
-from typing import Callable, List, Optional, Union, Generator, Tuple
+from typing import Callable, List, Optional, Union, Generator, Tuple, ClassVar, Any
 import warnings
 
+import prompt_toolkit
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.key_binding import KeyPressEvent
 from prompt_toolkit.key_binding.bindings import named_commands as nc
-from prompt_toolkit.auto_suggest import AutoSuggestFromHistory, Suggestion
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory, Suggestion, AutoSuggest
 from prompt_toolkit.document import Document
 from prompt_toolkit.history import History
 from prompt_toolkit.shortcuts import PromptSession
@@ -22,6 +24,12 @@ from IPython.utils.tokenutil import generate_tokens
 
 from .filters import pass_through
 
+try:
+    import jupyter_ai_magics
+    import jupyter_ai.completions.models as jai_models
+except ModuleNotFoundError:
+    jai_models = None
+
 
 def _get_query(document: Document):
     return document.lines[document.cursor_position_row]
@@ -31,26 +39,124 @@ class AppendAutoSuggestionInAnyLine(Processor):
     """
     Append the auto suggestion to lines other than the last (appending to the
     last line is natively supported by the prompt toolkit).
+
+    This has a private `_debug` attribute that can be set to True to display
+    debug information as virtual suggestion on the end of any line. You can do
+    so with:
+
+        >>> from IPython.terminal.shortcuts.auto_suggest import AppendAutoSuggestionInAnyLine
+        >>> AppendAutoSuggestionInAnyLine._debug = True
+
     """
+
+    _debug: ClassVar[bool] = False
 
     def __init__(self, style: str = "class:auto-suggestion") -> None:
         self.style = style
 
     def apply_transformation(self, ti: TransformationInput) -> Transformation:
-        is_last_line = ti.lineno == ti.document.line_count - 1
-        is_active_line = ti.lineno == ti.document.cursor_position_row
+        """
+         Apply transformation to the line that is currently being edited.
 
-        if not is_last_line and is_active_line:
-            buffer = ti.buffer_control.buffer
+         This is a variation of the original implementation in prompt toolkit
+         that allows to not only append suggestions to any line, but also to show
+         multi-line suggestions.
 
-            if buffer.suggestion and ti.document.is_cursor_at_the_end_of_line:
-                suggestion = buffer.suggestion.text
+         As transformation are applied on a line-by-line basis; we need to trick
+         a bit, and elide any line that is after the line we are currently
+         editing, until we run out of completions. We cannot shift the existing
+         lines
+
+         There are multiple cases to handle:
+
+         The completions ends before the end of the buffer:
+             We can resume showing the normal line, and say that some code may
+             be hidden.
+
+        The completions ends at the end of the buffer
+             We can just say that some code may be hidden.
+
+         And separately:
+
+         The completions ends beyond the end of the buffer
+             We need to both say that some code may be hidden, and that some
+             lines are not shown.
+
+        """
+        last_line_number = ti.document.line_count - 1
+        is_last_line = ti.lineno == last_line_number
+
+        noop = lambda text: Transformation(
+            fragments=ti.fragments + [(self.style, " " + text if self._debug else "")]
+        )
+        if ti.document.line_count == 1:
+            return noop("noop:oneline")
+        if ti.document.cursor_position_row == last_line_number and is_last_line:
+            # prompt toolkit already appends something; just leave it be
+            return noop("noop:last line and cursor")
+
+        # first everything before the current line is unchanged.
+        if ti.lineno < ti.document.cursor_position_row:
+            return noop("noop:before cursor")
+
+        buffer = ti.buffer_control.buffer
+        if not buffer.suggestion or not ti.document.is_cursor_at_the_end_of_line:
+            return noop("noop:not eol")
+
+        delta = ti.lineno - ti.document.cursor_position_row
+        suggestions = buffer.suggestion.text.splitlines()
+
+        if len(suggestions) == 0:
+            return noop("noop: no suggestions")
+
+        suggestions_longer_than_buffer: bool = (
+            len(suggestions) + ti.document.cursor_position_row > ti.document.line_count
+        )
+
+        if len(suggestions) >= 1 and prompt_toolkit.VERSION < (3, 0, 49):
+            if ti.lineno == ti.document.cursor_position_row:
+                return Transformation(
+                    fragments=ti.fragments
+                    + [
+                        (
+                            "red",
+                            "(Cannot show multiline suggestion; requires prompt_toolkit > 3.0.49)",
+                        )
+                    ]
+                )
             else:
-                suggestion = ""
-
+                return Transformation(fragments=ti.fragments)
+        if delta == 0:
+            suggestion = suggestions[0]
             return Transformation(fragments=ti.fragments + [(self.style, suggestion)])
+        if is_last_line:
+            if delta < len(suggestions):
+                extra = f"; {len(suggestions) - delta} line(s) hidden"
+                suggestion = f"… rest of suggestion ({len(suggestions) - delta} lines) and code hidden"
+                return Transformation([(self.style, suggestion)])
+
+            n_elided = len(suggestions)
+            for i in range(len(suggestions)):
+                ll = ti.get_line(last_line_number - i)
+                el = "".join(l[1] for l in ll).strip()
+                if el:
+                    break
+                else:
+                    n_elided -= 1
+            if n_elided:
+                return Transformation([(self.style, f"… {n_elided} line(s) hidden")])
+            else:
+                return Transformation(
+                    ti.get_line(last_line_number - len(suggestions) + 1)
+                    + ([(self.style, "shift-last-line")] if self._debug else [])
+                )
+
+        elif delta < len(suggestions):
+            suggestion = suggestions[delta]
+            return Transformation([(self.style, suggestion)])
         else:
-            return Transformation(fragments=ti.fragments)
+            shift = ti.lineno - len(suggestions) + 1
+            return Transformation(ti.get_line(shift))
 
 
 class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
@@ -63,17 +169,26 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
     skip_lines: int
     _connected_apps: list[PromptSession]
 
-    def __init__(
-        self,
-    ):
+    # handle to the currently running llm task that appends suggestions to the
+    # current buffer; we keep a handle to it in order to cancell it when there is a cursor movement, or
+    # another request.
+    _llm_task: asyncio.Task | None = None
+
+    # This is the instance of the LLM provider from jupyter-ai to which we forward the request
+    # to generate inline completions.
+    _llm_provider: Any | None
+
+    def __init__(self):
         super().__init__()
         self.skip_lines = 0
         self._connected_apps = []
+        self._llm_provider = None
 
     def reset_history_position(self, _: Buffer) -> None:
         self.skip_lines = 0
 
     def disconnect(self) -> None:
+        self._cancel_running_llm_task()
         for pt_app in self._connected_apps:
             text_insert_event = pt_app.default_buffer.on_text_insert
             text_insert_event.remove_handler(self.reset_history_position)
@@ -99,6 +214,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
         return None
 
     def _dismiss(self, buffer, *args, **kwargs) -> None:
+        self._cancel_running_llm_task()
         buffer.suggestion = None
 
     def _find_match(
@@ -153,6 +269,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
         )
 
     def up(self, query: str, other_than: str, history: History) -> None:
+        self._cancel_running_llm_task()
         for suggestion, line_number in self._find_next_match(
             query, self.skip_lines, history
         ):
@@ -169,6 +286,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
             self.skip_lines = 0
 
     def down(self, query: str, other_than: str, history: History) -> None:
+        self._cancel_running_llm_task()
         for suggestion, line_number in self._find_previous_match(
             query, self.skip_lines, history
         ):
@@ -183,6 +301,131 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
                 if query + suggestion != other_than:
                     self.skip_lines = line_number
                     break
+
+    def _cancel_running_llm_task(self) -> None:
+        """
+        Try to cancell the currently running llm_task if exists, and set it to None.
+        """
+        if self._llm_task is not None:
+            if self._llm_task.done():
+                self._llm_task = None
+                return
+            cancelled = self._llm_task.cancel()
+            if cancelled:
+                self._llm_task = None
+            if not cancelled:
+                warnings.warn(
+                    "LLM task not cancelled, does your provider support cancellation?"
+                )
+
+    async def _trigger_llm(self, buffer) -> None:
+        """
+        This will ask the current llm provider a suggestion for the current buffer.
+
+        If there is a currently running llm task, it will cancel it.
+        """
+        # we likely want to store the current cursor position, and cancel if the cursor has moved.
+        if not self._llm_provider:
+            warnings.warn("No LLM provider found, cannot trigger LLM completions")
+            return
+        if jai_models is None:
+            warnings.warn(
+                "LLM Completion requires `jupyter_ai_magics` and `jupyter_ai` to be installed"
+            )
+
+        self._cancel_running_llm_task()
+
+        async def error_catcher(buffer):
+            """
+            This catches and log any errors, as otherwise this is just
+            lost in the void of the future running task.
+            """
+            try:
+                await self._trigger_llm_core(buffer)
+            except Exception as e:
+                get_ipython().log.error("error")
+                raise
+
+        # here we need a cancellable task so we can't just await the error catched
+        self._llm_task = asyncio.create_task(error_catcher(buffer))
+        await self._llm_task
+
+    async def _trigger_llm_core(self, buffer: Buffer):
+        """
+        This is the core of the current llm request.
+
+        Here we build a compatible `InlineCompletionRequest` and ask the llm
+        provider to stream it's response back to us iteratively setting it as
+        the suggestion on the current buffer.
+
+        Unlike with JupyterAi, as we do not have multiple cell, the cell number
+        is always set to `0`, note that we _could_ set it to a new number each
+        time and ignore threply from past numbers.
+
+        We set the prefix to the current cell content, but could also inset the
+        rest of the history or even just the non-fail history.
+
+        In the same way, we do not have cell id.
+
+        LLM provider may return multiple suggestion stream, but for the time
+        being we only support one.
+
+        Here we make the assumption that the provider will have
+        stream_inline_completions, I'm not sure it is the case for all
+        providers.
+        """
+
+        request = jai_models.InlineCompletionRequest(
+            number=0,
+            prefix=buffer.document.text,
+            suffix="",
+            mime="text/x-python",
+            stream=True,
+            path=None,
+            language="python",
+            cell_id=None,
+        )
+
+        async for reply_and_chunks in self._llm_provider.stream_inline_completions(
+            request
+        ):
+            if isinstance(reply_and_chunks, jai_models.InlineCompletionReply):
+                if len(reply_and_chunks.list.items) > 1:
+                    raise ValueError(
+                        "Terminal IPython cannot deal with multiple LLM suggestions at once"
+                    )
+                buffer.suggestion = Suggestion(
+                    reply_and_chunks.list.items[0].insertText
+                )
+                buffer.on_suggestion_set.fire()
+            elif isinstance(reply_and_chunks, jai_models.InlineCompletionStreamChunk):
+                buffer.suggestion = Suggestion(reply_and_chunks.response.insertText)
+                buffer.on_suggestion_set.fire()
+        return
+
+
+_MIN_LINES = 5
+
+
+async def llm_autosuggestion(event: KeyPressEvent):
+    """
+    Ask the AutoSuggester from history to delegate to ask an LLM for completion
+
+    This will first make sure that the current buffer have _MIN_LINES (7)
+    available lines to insert the LLM completion
+
+    Provisional as of 8.32, may change without warnigns
+
+    """
+    provider = get_ipython().auto_suggest
+    if not isinstance(provider, NavigableAutoSuggestFromHistory):
+        return
+    doc = event.current_buffer.document
+    lines_to_insert = max(0, _MIN_LINES - doc.line_count + doc.cursor_position_row)
+    for _ in range(lines_to_insert):
+        event.current_buffer.insert_text("\n", move_cursor=False)
+
+    await provider._trigger_llm(event.current_buffer)
 
 
 def accept_or_jump_to_end(event: KeyPressEvent):

--- a/examples/auto_suggest_llm.py
+++ b/examples/auto_suggest_llm.py
@@ -1,0 +1,130 @@
+"""
+This is an example of Fake LLM Completer for IPython 
+8.32 – this is provisional and may change.
+
+To test this you can run the following command from the root of IPython 
+directory:
+
+    $ ipython --TerminalInteractiveShell.llm_provider_class=examples.auto_suggest_llm.ExampleCompletionProvider
+
+Or you can set the value in your config file
+
+    c.TerminalInteractiveShell.llm_provider_class="fully.qualified.name.ToYourCompleter"
+
+And at runtime bing for example `ctrl-q` to triger autosugges:
+
+    In [1]: from examples.auto_suggest_llm import setup_shortcut
+       ...: setup_shortcut('c-q')
+
+
+"""
+
+import asyncio
+import textwrap
+from asyncio import FIRST_COMPLETED, Task, create_task, wait
+from typing import Any, AsyncIterable, AsyncIterator, Collection, TypeVar
+
+from jupyter_ai.completions.models import (
+    InlineCompletionList,
+    InlineCompletionReply,
+    InlineCompletionRequest,
+    InlineCompletionStreamChunk,
+)
+from jupyter_ai_magics import BaseProvider
+from langchain_community.llms import FakeListLLM
+
+
+from IPython.terminal.shortcuts import Binding
+from IPython.terminal.shortcuts.filters import (
+    navigable_suggestions,
+    default_buffer_focused,
+)
+from IPython.terminal.shortcuts.auto_suggest import llm_autosuggestion
+
+
+def setup_shortcut(seq):
+    import IPython
+
+    ip = IPython.get_ipython()
+    ip.pt_app.key_bindings.add_binding(
+        seq, filter=(navigable_suggestions & default_buffer_focused)
+    )(llm_autosuggestion),
+
+
+class ExampleCompletionProvider(BaseProvider, FakeListLLM):  # type: ignore[misc, valid-type]
+    """
+    This is an example Fake LLM provider for IPython
+
+    As of 8.32 this is provisional and may change without any warnings
+    """
+
+    id = "my_provider"
+    name = "My Provider"
+    model_id_key = "model"
+    models = ["model_a"]
+
+    def __init__(self, **kwargs: Any):
+        kwargs["responses"] = ["This fake response will not be used for completion"]
+        kwargs["model_id"] = "model_a"
+        super().__init__(**kwargs)
+
+    async def generate_inline_completions(
+        self, request: InlineCompletionRequest
+    ) -> InlineCompletionReply:
+        raise ValueError("IPython 8.32 only support streaming models for now.")
+
+    async def stream_inline_completions(
+        self, request: InlineCompletionRequest
+    ) -> AsyncIterator[InlineCompletionStreamChunk]:
+        token_1 = f"t{request.number}s0"
+
+        yield InlineCompletionReply(
+            list=InlineCompletionList(
+                items=[
+                    {"insertText": "It", "isIncomplete": True, "token": token_1},
+                ]
+            ),
+            reply_to=request.number,
+        )
+
+        reply: InlineCompletionStreamChunk
+        async for reply in self._stream(
+            textwrap.dedent(
+                """
+                was then that the fox appeared.
+                “Good morning,” said the fox.
+                “Good morning,” the little prince responded politely, although when he turned around he saw nothing.
+                “I am right here,” the voice said, “under the apple tree.”
+                “Who are you?” asked the little prince, and added, “You are very pretty to look at.”
+                “I am a fox,” said the fox.
+                “Come and play with me,” proposed the little prince. “I am so unhappy.”
+                """
+            ).strip(),
+            request.number,
+            token_1,
+            start_with="It",
+        ):
+            yield reply
+
+    async def _stream(
+        self, sentence: str, request_number: int, token: str, start_with: str = ""
+    ) -> AsyncIterable[InlineCompletionStreamChunk]:
+        suggestion = start_with
+
+        for fragment in sentence.split(" "):
+            await asyncio.sleep(0.05)
+            suggestion += " " + fragment
+            yield InlineCompletionStreamChunk(
+                type="stream",
+                response={"insertText": suggestion, "token": token},
+                reply_to=request_number,
+                done=False,
+            )
+
+        # finally, send a message confirming that we are done
+        yield InlineCompletionStreamChunk(
+            type="stream",
+            response={"insertText": suggestion, "token": token},
+            reply_to=request_number,
+            done=True,
+        )


### PR DESCRIPTION
This is a preview-draft of modification to IPython in order
to allow multi-line suggestion in the terminal, and add the necesarry
hooks and examples, in order to trigger LLM autocomplation via a
shortcut.

This will not be complete, but will be available as a preview in IPython
8.32 in order to gather feedback.

This tries to be as compatible as possible with jupyter_ai and
jupyter_ai_magics, except the Provider cannot take parameters in their
constructor.