### PR TITLE
more intuitive behavior for token_at_cursor for inspect requests

### DIFF
--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -304,7 +304,7 @@ def accept_token(event: KeyPressEvent):
         substrings = [""]
         i = 0
 
-        for token in generate_tokens(text):
+        for token in generate_tokens(StringIO(text).readline):
             if token.type == tokenize.NEWLINE:
                 index = len(text)
             else:

--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -304,7 +304,7 @@ def accept_token(event: KeyPressEvent):
         substrings = [""]
         i = 0
 
-        for token in generate_tokens(StringIO(text).readline):
+        for token in generate_tokens(text):
             if token.type == tokenize.NEWLINE:
                 index = len(text)
             else:

--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -15,6 +15,7 @@ def expect_token(expected: str, cell: str, cursor_pos: int | None = None) -> Non
     Assert that the token at the cursor position is `expected`.
     """
     if cursor_pos is None:
+        assert cell.count("|") == 1, "Cursor position not specified and no | found"
         cursor_pos = cell.index("|")
         cell = cell.replace("|", "")
     token = token_at_cursor(cell, cursor_pos)

--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -15,7 +15,11 @@ def expect_token(expected: str, cell: str, cursor_pos: int | None = None) -> Non
     Assert that the token at the cursor position is `expected`.
     """
     if cursor_pos is None:
-        assert cell.count("|") == 1, "Cursor position not specified and no | found"
+        assert (
+            cursor_count := cell.count("|")
+        ) == 1, (
+            f"Cursor position not specified and found {cursor_count} instance(s) of '|'"
+        )
         cursor_pos = cell.index("|")
         cell = cell.replace("|", "")
     token = token_at_cursor(cell, cursor_pos)

--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -1,8 +1,10 @@
 """Tests for tokenutil"""
+
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
 import pytest
+import textwrap
 
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 
@@ -53,16 +55,17 @@ def test_function():
     "cell",
     [
         "\n".join(["a = 5", "b = hello('string', there)"]),
-        "\n".join(
-            [
-                '"""\n\nxxxxxxxxxx\n\n"""',
-                '5, """',
-                "docstring",
-                "multiline token",
-                '""", [',
-                '2, 3, "complicated"]',
-                'b = hello("string", there)',
-            ]
+        textwrap.dedent(
+            '''
+            """\n\nxxxxxxxxxx\n\n"""
+            5, """
+            """\n\nxxxxxxxxxx\n\n"""
+            docstring
+            multiline token
+            """, [
+            2, 3, "complicated"]
+            b = hello("string", there)
+        '''
         ),
     ],
 )
@@ -125,16 +128,16 @@ def test_outer_name():
 
 def test_attrs():
     cell = "a = obj.attr.subattr"
-    expected = 'obj'
-    idx = cell.find('obj') + 1
+    expected = "obj"
+    idx = cell.find("obj") + 1
     for i in range(idx, idx + 3):
         expect_token(expected, cell, i)
-    idx = cell.find('.attr') + 2
-    expected = 'obj.attr'
+    idx = cell.find(".attr") + 2
+    expected = "obj.attr"
     for i in range(idx, idx + 4):
         expect_token(expected, cell, i)
-    idx = cell.find('.subattr') + 2
-    expected = 'obj.attr.subattr'
+    idx = cell.find(".subattr") + 2
+    expected = "obj.attr.subattr"
     for i in range(idx, len(cell)):
         expect_token(expected, cell, i)
 

--- a/IPython/utils/tests/test_tokenutil.py
+++ b/IPython/utils/tests/test_tokenutil.py
@@ -6,14 +6,22 @@ import pytest
 
 from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
 
-def expect_token(expected, cell, cursor_pos):
+
+def expect_token(expected: str, cell: str, cursor_pos: int | None = None) -> None:
+    """
+    If cursor_pos is `None`, look for `|` as the cursor position.
+    Assert that the token at the cursor position is `expected`.
+    """
+    if cursor_pos is None:
+        cursor_pos = cell.index("|")
+        cell = cell.replace("|", "")
     token = token_at_cursor(cell, cursor_pos)
     offset = 0
     for line in cell.splitlines():
         if offset + len(line) >= cursor_pos:
             break
         else:
-            offset += len(line)+1
+            offset += len(line) + 1
     column = cursor_pos - offset
     line_with_cursor = "%s|%s" % (line[:column], line[column:])
     assert token == expected, "Expected %r, got %r in: %r (pos %i)" % (
@@ -29,66 +37,91 @@ def test_simple():
     for i in range(len(cell)):
         expect_token("foo", cell, i)
 
+
 def test_function():
     cell = "foo(a=5, b='10')"
-    expected = 'foo'
-    # up to `foo(|a=`
-    for i in range(cell.find('a=') + 1):
+    for i in range(len(cell)):
         expect_token("foo", cell, i)
-    # find foo after `=`
-    for i in [cell.find('=') + 1, cell.rfind('=') + 1]:
-        expect_token("foo", cell, i)
-    # in between `5,|` and `|b=`
-    for i in range(cell.find(','), cell.find('b=')):
-        expect_token("foo", cell, i)
+    expect_token("a", "foo(|a, b)")
+    expect_token("foo", "foo(a|, b)")
+    expect_token("foo", "foo(a,| b)")
+    expect_token("b", "foo(a, |b)")
+    expect_token("foo", "foo(a, b|)")
 
-def test_multiline():
-    cell = '\n'.join([
-        'a = 5',
-        'b = hello("string", there)'
-    ])
-    expected = 'hello'
-    start = cell.index(expected) + 1
-    for i in range(start, start + len(expected)):
-        expect_token(expected, cell, i)
-    expected = 'hello'
-    start = cell.index(expected) + 1
-    for i in range(start, start + len(expected)):
-        expect_token(expected, cell, i)
 
-def test_multiline_token():
-    cell = '\n'.join([
-        '"""\n\nxxxxxxxxxx\n\n"""',
-        '5, """',
-        'docstring',
-        'multiline token',
-        '""", [',
-        '2, 3, "complicated"]',
-        'b = hello("string", there)'
-    ])
-    expected = 'hello'
+@pytest.mark.parametrize(
+    "cell",
+    [
+        "\n".join(["a = 5", "b = hello('string', there)"]),
+        "\n".join(
+            [
+                '"""\n\nxxxxxxxxxx\n\n"""',
+                '5, """',
+                "docstring",
+                "multiline token",
+                '""", [',
+                '2, 3, "complicated"]',
+                'b = hello("string", there)',
+            ]
+        ),
+    ],
+)
+def test_multiline(cell):
+    expected = "hello"
     start = cell.index(expected) + 1
     for i in range(start, start + len(expected)):
         expect_token(expected, cell, i)
-    expected = 'hello'
     start = cell.index(expected) + 1
     for i in range(start, start + len(expected)):
         expect_token(expected, cell, i)
 
-def test_nested_call():
+
+def test_nested_call_kwargs():
     cell = "foo(bar(a=5), b=10)"
-    expected = 'foo'
-    start = cell.index('bar') + 1
+    start = cell.index("bar")
+    last = start + len("bar")
+    for i in range(start, last + 1):
+        expect_token("bar", cell, i)
+    start = cell.index("a=")
     for i in range(start, start + 3):
-        expect_token(expected, cell, i)
-    expected = 'bar'
-    start = cell.index('a=')
-    for i in range(start, start + 3):
-        expect_token(expected, cell, i)
-    expected = 'foo'
-    start = cell.index(')') + 1
-    for i in range(start, len(cell)-1):
-        expect_token(expected, cell, i)
+        expect_token("bar", cell, i)
+    expect_token("bar", "foo(bar(a=|5), b=10)")
+    expect_token("bar", "foo(bar(a=5|), b=10)")
+    for i in range(cell.index(")") + 1, cell.index("b=") + 2):
+        expect_token("foo", cell, i)
+    expect_token("foo", cell, len(cell) - 1)
+
+
+def test_nested_call_args():
+    expect_token("bar", "foo(bar(x,| ))")
+    expect_token("bar", "foo(bar(x, |))")
+    expect_token("bar", "foo(ba|r(x, y))")
+    expect_token("x", "foo(bar(|x, y))")
+    expect_token("bar", "foo(bar(x|, y))")
+    expect_token("bar", "foo(bar(x,| y))")
+    expect_token("y", "foo(bar(x, |y))")
+    expect_token("bar", "foo(bar(x, y|))")
+    expect_token("foo", "foo(bar(x, y)|)")
+    expect_token("foo", "foo(bar(, y)|)")
+
+
+def test_outer_name():
+    expect_token("x", "|x + foo(a, b) + y + z")
+    expect_token("x", "x| + foo(a, b) + y + z")
+    expect_token("x", "x |+ foo(a, b) + y + z")
+    expect_token("x", "x +| foo(a, b) + y + z")
+    expect_token("foo", "x + |foo(a, b) + y + z")
+    expect_token("a", "x + foo(|a, b) + y + z")
+    expect_token("foo", "x + foo(a|, b) + y + z")
+    expect_token("foo", "x + foo(a, b)| + y + z")
+    expect_token("foo", "x + foo(a, b) |+ y + z")
+    expect_token("foo", "x + foo(a, b) +| y + z")
+    expect_token("y", "x + foo(a, b) + |y + z")
+    expect_token("y", "x + foo(a, b) + y| + z")
+    expect_token("y", "x + foo(a, b) + y |+ z")
+    expect_token("y", "x + foo(a, b) + y +| z")
+    expect_token("z", "x + foo(a, b) + y + |z")
+
 
 def test_attrs():
     cell = "a = obj.attr.subattr"
@@ -104,6 +137,7 @@ def test_attrs():
     expected = 'obj.attr.subattr'
     for i in range(idx, len(cell)):
         expect_token(expected, cell, i)
+
 
 def test_line_at_cursor():
     cell = ""

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -123,6 +123,7 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
     ]
     if not tokens:
         return ""
+    last_token: Token | None = None
     for tok, next_tok in itertools.pairwise(tokens + [None]):
         # token, text, start, end, line = tup
         start_line, start_col = tok.start
@@ -145,9 +146,9 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
         if cur_token_is_name := tok.token == tokenize.NAME and not iskeyword(tok.text):
             if (
                 names
-                and tokens
-                and tokens[-1].token == tokenize.OP
-                and tokens[-1].text == "."
+                and last_token
+                and last_token.token == tokenize.OP
+                and last_token.text == "."
             ):
                 names[-1] = "%s.%s" % (names[-1], tok.text)
             else:
@@ -170,7 +171,7 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
                 # keep track of the most recently popped call_name from the stack
                 closing_call_name = call_names.pop(-1)
 
-        tokens.append(tok)
+        last_token = tok
 
         if offsets[end_line] + end_col > cursor_pos:
             # we found the cursor, stop reading

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -170,8 +170,6 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
                 # keep track of the most recently popped call_name from the stack
                 closing_call_name = call_names.pop(-1)
 
-        tokens.append(tok)
-
         if offsets[end_line] + end_col > cursor_pos:
             # we found the cursor, stop reading
             # if the current token intersects directly, use it instead of the call token

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -2,20 +2,29 @@
 
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
-
-from collections import namedtuple
-from io import StringIO
-from keyword import iskeyword
+from __future__ import annotations
 
 import tokenize
+from io import StringIO
+from keyword import iskeyword
 from tokenize import TokenInfo
-from typing import List, Optional
+from typing import Generator, NamedTuple
 
 
-Token = namedtuple('Token', ['token', 'text', 'start', 'end', 'line'])
+class Token(NamedTuple):
+    token: int
+    text: str
+    start: int
+    end: int
+    line: str
 
-def generate_tokens(readline):
+
+def generate_tokens(text_or_readline) -> Generator[TokenInfo, None, None]:
     """wrap generate_tkens to catch EOF errors"""
+    if isinstance(text_or_readline, str):
+        readline = StringIO(text_or_readline).readline
+    else:
+        readline = text_or_readline
     try:
         for token in tokenize.generate_tokens(readline):
             yield token
@@ -25,7 +34,7 @@ def generate_tokens(readline):
 
 
 def generate_tokens_catch_errors(
-    readline, extra_errors_to_catch: Optional[List[str]] = None
+    readline, extra_errors_to_catch: list[str] | None = None
 ):
     default_errors_to_catch = [
         "unterminated string literal",
@@ -35,7 +44,7 @@ def generate_tokens_catch_errors(
     assert extra_errors_to_catch is None or isinstance(extra_errors_to_catch, list)
     errors_to_catch = default_errors_to_catch + (extra_errors_to_catch or [])
 
-    tokens: List[TokenInfo] = []
+    tokens: list[TokenInfo] = []
     try:
         for token in tokenize.generate_tokens(readline):
             tokens.append(token)
@@ -49,13 +58,13 @@ def generate_tokens_catch_errors(
             else:
                 start = end = (1, 0)
                 line = ""
-            yield tokenize.TokenInfo(tokenize.ERRORTOKEN, "", start, end, line)
+            yield TokenInfo(tokenize.ERRORTOKEN, "", start, end, line)
         else:
             # Catch EOF
             raise
 
 
-def line_at_cursor(cell, cursor_pos=0):
+def line_at_cursor(cell: str, cursor_pos: int = 0) -> tuple[str, int]:
     """Return the line in a cell at a given cursor position
 
     Used for calling line-based APIs that don't support multi-line input, yet.
@@ -86,7 +95,7 @@ def line_at_cursor(cell, cursor_pos=0):
         offset = next_offset
     else:
         line = ""
-    return (line, offset)
+    return line, offset
 
 
 def token_at_cursor(cell: str, cursor_pos: int = 0):
@@ -104,15 +113,19 @@ def token_at_cursor(cell: str, cursor_pos: int = 0):
     cursor_pos : int
         The location of the cursor in the block where the token should be found
     """
-    names: List[str] = []
-    tokens: List[Token] = []
-    call_names = []
-    
-    offsets = {1: 0} # lines start at 1
-    for tup in generate_tokens(StringIO(cell).readline):
-        
-        tok = Token(*tup)
-        
+    names: list[str] = []
+    call_names: list[str] = []
+    closing_call_name: str | None = None
+    most_recent_outer_name: str | None = None
+
+    offsets = {1: 0}  # lines start at 1
+    intersects_with_cursor = False
+    cur_token_is_name = False
+    tokens: list[Token] = [Token(*tup) for tup in generate_tokens(cell)]
+    if not tokens:
+        return ""
+    next_tokens: list[Token | None] = tokens[1:] + [None]
+    for tok, next_tok in zip(tokens, next_tokens):
         # token, text, start, end, line = tup
         start_line, start_col = tok.start
         end_line, end_col = tok.end
@@ -121,40 +134,69 @@ def token_at_cursor(cell: str, cursor_pos: int = 0):
             lines = tok.line.splitlines(True)
             for lineno, line in enumerate(lines, start_line + 1):
                 if lineno not in offsets:
-                    offsets[lineno] = offsets[lineno-1] + len(line)
+                    offsets[lineno] = offsets[lineno - 1] + len(line)
+
+        closing_call_name = None
         
         offset = offsets[start_line]
-        # allow '|foo' to find 'foo' at the beginning of a line
-        boundary = cursor_pos + 1 if start_col == 0 else cursor_pos
-        if offset + start_col >= boundary:
+        if offset + start_col > cursor_pos:
             # current token starts after the cursor,
             # don't consume it
             break
         
-        if tok.token == tokenize.NAME and not iskeyword(tok.text):
-            if names and tokens and tokens[-1].token == tokenize.OP and tokens[-1].text == '.':
+        if cur_token_is_name := tok.token == tokenize.NAME and not iskeyword(tok.text):
+            if (
+                names
+                and tokens
+                and tokens[-1].token == tokenize.OP
+                and tokens[-1].text == "."
+            ):
                 names[-1] = "%s.%s" % (names[-1], tok.text)
             else:
                 names.append(tok.text)
-        elif tok.token == tokenize.OP:
-            if tok.text == '=' and names:
+            if (
+                next_tok is not None
+                and next_tok.token == tokenize.OP
+                and next_tok.text == "="
+            ):
                 # don't inspect the lhs of an assignment
                 names.pop(-1)
-            if tok.text == '(' and names:
+                cur_token_is_name = False
+            if not call_names:
+                most_recent_outer_name = names[-1] if names else None
+        elif tok.token == tokenize.OP:
+            if tok.text == "(" and names:
                 # if we are inside a function call, inspect the function
                 call_names.append(names[-1])
-            elif tok.text == ')' and call_names:
-                call_names.pop(-1)
+            elif tok.text == ")" and call_names:
+                # keep track of the most recently popped call_name from the stack
+                closing_call_name = call_names.pop(-1)
         
         tokens.append(tok)
         
         if offsets[end_line] + end_col > cursor_pos:
             # we found the cursor, stop reading
+            # if the current token intersects directly, use it instead of the call token
+            intersects_with_cursor = offsets[start_line] + start_col <= cursor_pos
             break
         
-    if call_names:
+    if cur_token_is_name and intersects_with_cursor:
+        return names[-1]
+    # if the cursor isn't directly over a name token, use the most recent
+    # call name if we can find one
+    elif closing_call_name:
+        # if we're on a ")", use the most recently popped call name
+        return closing_call_name
+    elif call_names:
+        # otherwise, look for the most recent call name in the stack
         return call_names[-1]
+    elif most_recent_outer_name:
+        # if we've popped all the call names, use the most recently-seen
+        # outer name
+        return most_recent_outer_name
     elif names:
+        # failing that, use the most recently seen name
         return names[-1]
     else:
-        return ''
+        # give up
+        return ""

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -123,8 +123,9 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
     ]
     if not tokens:
         return ""
-    last_token: Token | None = None
-    for tok, next_tok in itertools.pairwise(tokens + [None]):
+    for prev_tok, (tok, next_tok) in zip(
+        [None] + tokens, itertools.pairwise(tokens + [None])
+    ):
         # token, text, start, end, line = tup
         start_line, start_col = tok.start
         end_line, end_col = tok.end
@@ -146,9 +147,9 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
         if cur_token_is_name := tok.token == tokenize.NAME and not iskeyword(tok.text):
             if (
                 names
-                and last_token
-                and last_token.token == tokenize.OP
-                and last_token.text == "."
+                and prev_tok
+                and prev_tok.token == tokenize.OP
+                and prev_tok.text == "."
             ):
                 names[-1] = "%s.%s" % (names[-1], tok.text)
             else:
@@ -170,8 +171,6 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
             elif tok.text == ")" and call_names:
                 # keep track of the most recently popped call_name from the stack
                 closing_call_name = call_names.pop(-1)
-
-        last_token = tok
 
         if offsets[end_line] + end_col > cursor_pos:
             # we found the cursor, stop reading

--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -170,6 +170,8 @@ def token_at_cursor(cell: str, cursor_pos: int = 0) -> str:
                 # keep track of the most recently popped call_name from the stack
                 closing_call_name = call_names.pop(-1)
 
+        tokens.append(tok)
+
         if offsets[end_line] + end_col > cursor_pos:
             # we found the cursor, stop reading
             # if the current token intersects directly, use it instead of the call token


### PR DESCRIPTION
This PR implements the suggested behavior in https://github.com/ipython/ipython/issues/14630 -- i.e., if the cursor is directly over a non-keyword token inside of parameter list, use that as the token_at_cursor rather than the function. Otherwise, if we're not directly over a token and we're inside some function call, use the most recently seen function call name token. If we're not inside a function call, use the most recently-seen outer name token.

This should yield more intuitive behavior for inspect, and is documented in comments and tests.