### PR TITLE
Fixed bug with a warning message incorrectly displayed

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -898,7 +898,7 @@ class InteractiveShell(SingletonConfigurable):
             return
 
         p = Path(sys.executable)
-        p_venv = Path(os.environ["VIRTUAL_ENV"])
+        p_venv = Path(os.environ["VIRTUAL_ENV"]).resolve()
 
         # fallback venv detection:
         # stdlib venv may symlink sys.executable, so we can't use realpath.
@@ -911,7 +911,7 @@ class InteractiveShell(SingletonConfigurable):
             drive_name = p_venv.parts[2]
             p_venv = (drive_name + ":/") / Path(*p_venv.parts[3:])
 
-        if any(p_venv == p.parents[1] for p in paths):
+        if any(p_venv == p.parents[1].resolve() for p in paths):
             # Our exe is inside or has access to the virtualenv, don't need to do anything.
             return
 


### PR DESCRIPTION
Fixed an issue where the warning message:

> Attempting to work in a virtualenv. If you encounter problems please install IPython inside the virtualenv.

was incorrectly triggered in systems involving symlinks.

When the path provided by `$VIRTUAL_ENV` and the corresponding environment path derived from the executable iPython pointed to the same physical directory, but their strings differed because of symlinks, the warning was incorrectly triggered. By using the `resolve()` function, we ensure that we compare fully resolved paths. The warning disappears when the two folders, once resolved, coincide.