### PR TITLE
Remove check_linecache_ipython – deprecated since 8.6

### DIFF
--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -190,25 +190,3 @@ class CachingCompiler(codeop.Compile):
             # turn off only the bits we turned on so that something like
             # __future__ that set flags stays.
             self.flags &= ~turn_on_bits
-
-
-def check_linecache_ipython(*args):
-    """Deprecated since IPython 8.6.  Call linecache.checkcache() directly.
-
-    It was already not necessary to call this function directly.  If no
-    CachingCompiler had been created, this function would fail badly.  If
-    an instance had been created, this function would've been monkeypatched
-    into place.
-
-    As of IPython 8.6, the monkeypatching has gone away entirely.  But there
-    were still internal callers of this function, so maybe external callers
-    also existed?
-    """
-    import warnings
-
-    warnings.warn(
-        "Deprecated Since IPython 8.6, Just call linecache.checkcache() directly.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    linecache.checkcache()


### PR DESCRIPTION
Part of the spring cleaning for IPython 9.0