### PR TITLE
Remove deprecated (since 7.23) configure_inline_support.

### DIFF
--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -448,33 +448,6 @@ def import_pylab(user_ns, import_all=True):
     user_ns['getfigs'] = getfigs
 
 
-def configure_inline_support(shell, backend):
-    """
-    .. deprecated:: 7.23
-
-        use `matplotlib_inline.backend_inline.configure_inline_support()`
-
-    Configure an IPython shell object for matplotlib use.
-
-    Parameters
-    ----------
-    shell : InteractiveShell instance
-    backend : matplotlib backend
-    """
-    warnings.warn(
-        "`configure_inline_support` is deprecated since IPython 7.23, directly "
-        "use `matplotlib_inline.backend_inline.configure_inline_support()`",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    from matplotlib_inline.backend_inline import (
-        configure_inline_support as configure_inline_support_orig,
-    )
-
-    configure_inline_support_orig(shell, backend)
-
-
 # Determine if Matplotlib manages backends only if needed, and cache result.
 # Do not read this directly, instead use _matplotlib_manages_backends().
 _matplotlib_manages_backends_value: bool | None = None

--- a/IPython/core/tests/test_pylabtools.py
+++ b/IPython/core/tests/test_pylabtools.py
@@ -181,13 +181,10 @@ class TestPylabSwitch(object):
         pt.activate_matplotlib = act_mpl
         self._save_ip = pt.import_pylab
         pt.import_pylab = lambda *a,**kw:None
-        self._save_cis = backend_inline.configure_inline_support
-        backend_inline.configure_inline_support = lambda *a, **kw: None
 
     def teardown_method(self):
         pt.activate_matplotlib = self._save_am
         pt.import_pylab = self._save_ip
-        backend_inline.configure_inline_support = self._save_cis
         import matplotlib
         matplotlib.rcParams = self._saved_rcParams
         matplotlib.rcParamsOrig = self._saved_rcParamsOrig


### PR DESCRIPTION
Use directly matplotlib API.