### PR TITLE
Remove set_matplotlib_close deprecated since 7.23

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -46,7 +46,6 @@ __all__ = [
     "GeoJSON",
     "Javascript",
     "Image",
-    "set_matplotlib_close",
     "Video",
 ]
 
@@ -1265,44 +1264,3 @@ class Video(DisplayObject):
     def reload(self):
         # TODO
         pass
-
-
-@skip_doctest
-def set_matplotlib_close(close=True):
-    """
-    .. deprecated:: 7.23
-
-        use `matplotlib_inline.backend_inline.set_matplotlib_close()`
-
-    Set whether the inline backend closes all figures automatically or not.
-
-    By default, the inline backend used in the IPython Notebook will close all
-    matplotlib figures automatically after each cell is run. This means that
-    plots in different cells won't interfere. Sometimes, you may want to make
-    a plot in one cell and then refine it in later cells. This can be accomplished
-    by::
-
-        In [1]: set_matplotlib_close(False)
-
-    To set this in your config files use the following::
-
-        c.InlineBackend.close_figures = False
-
-    Parameters
-    ----------
-    close : bool
-        Should all matplotlib figures be automatically closed after each cell is
-        run?
-    """
-    warnings.warn(
-        "`set_matplotlib_close` is deprecated since IPython 7.23, directly "
-        "use `matplotlib_inline.backend_inline.set_matplotlib_close()`",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    from matplotlib_inline.backend_inline import (
-        set_matplotlib_close as set_matplotlib_close_orig,
-    )
-
-    set_matplotlib_close_orig(close)

--- a/IPython/core/tests/test_display.py
+++ b/IPython/core/tests/test_display.py
@@ -158,13 +158,13 @@ def _get_inline_config():
 
 @dec.skip_without("matplotlib")
 def test_set_matplotlib_close():
+    from matplotlib_inline.backend_inline import set_matplotlib_close
     cfg = _get_inline_config()
     cfg.close_figures = False
-    with pytest.deprecated_call():
-        display.set_matplotlib_close()
+
+    set_matplotlib_close()
     assert cfg.close_figures
-    with pytest.deprecated_call():
-        display.set_matplotlib_close(False)
+    set_matplotlib_close(False)
     assert not cfg.close_figures
 
 _fmt_mime_map = {

--- a/IPython/display.py
+++ b/IPython/display.py
@@ -37,7 +37,6 @@ from IPython.core.display import (
     GeoJSON as GeoJSON,
     Javascript as Javascript,
     Image as Image,
-    set_matplotlib_close as set_matplotlib_close,
     Video as Video,
 )
 from IPython.lib.display import *


### PR DESCRIPTION
Use directly the matplotlib_inline corresponding method.