### PR TITLE
Use AST token constants from token module.

### DIFF
--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -61,76 +61,70 @@ Colors = TermColors  # just a shorthand
 
 # Build a few color schemes
 NoColor = ColorScheme(
-    'NoColor',{
-    'header'         : Colors.NoColor,
-    token.NUMBER     : Colors.NoColor,
-    token.OP         : Colors.NoColor,
-    token.STRING     : Colors.NoColor,
-    tokenize.COMMENT : Colors.NoColor,
-    token.NAME       : Colors.NoColor,
-    token.ERRORTOKEN : Colors.NoColor,
-
-    _KEYWORD         : Colors.NoColor,
-    _TEXT            : Colors.NoColor,
-
-    'in_prompt'      : InputTermColors.NoColor,  # Input prompt
-    'in_number'      : InputTermColors.NoColor,  # Input prompt number
-    'in_prompt2'     : InputTermColors.NoColor, # Continuation prompt
-    'in_normal'      : InputTermColors.NoColor,  # color off (usu. Colors.Normal)
-
-    'out_prompt'     : Colors.NoColor, # Output prompt
-    'out_number'     : Colors.NoColor, # Output prompt number
-
-    'normal'         : Colors.NoColor  # color off (usu. Colors.Normal)
-    }  )
+    "NoColor",
+    {
+        "header": Colors.NoColor,
+        token.NUMBER: Colors.NoColor,
+        token.OP: Colors.NoColor,
+        token.STRING: Colors.NoColor,
+        token.COMMENT: Colors.NoColor,
+        token.NAME: Colors.NoColor,
+        token.ERRORTOKEN: Colors.NoColor,
+        _KEYWORD: Colors.NoColor,
+        _TEXT: Colors.NoColor,
+        "in_prompt": InputTermColors.NoColor,  # Input prompt
+        "in_number": InputTermColors.NoColor,  # Input prompt number
+        "in_prompt2": InputTermColors.NoColor,  # Continuation prompt
+        "in_normal": InputTermColors.NoColor,  # color off (usu. Colors.Normal)
+        "out_prompt": Colors.NoColor,  # Output prompt
+        "out_number": Colors.NoColor,  # Output prompt number
+        "normal": Colors.NoColor,  # color off (usu. Colors.Normal)
+    },
+)
 
 LinuxColors = ColorScheme(
-    'Linux',{
-    'header'         : Colors.LightRed,
-    token.NUMBER     : Colors.LightCyan,
-    token.OP         : Colors.Yellow,
-    token.STRING     : Colors.LightBlue,
-    tokenize.COMMENT : Colors.LightRed,
-    token.NAME       : Colors.Normal,
-    token.ERRORTOKEN : Colors.Red,
-
-    _KEYWORD         : Colors.LightGreen,
-    _TEXT            : Colors.Yellow,
-
-    'in_prompt'      : InputTermColors.Green,
-    'in_number'      : InputTermColors.LightGreen,
-    'in_prompt2'     : InputTermColors.Green,
-    'in_normal'      : InputTermColors.Normal,  # color off (usu. Colors.Normal)
-
-    'out_prompt'     : Colors.Red,
-    'out_number'     : Colors.LightRed,
-
-    'normal'         : Colors.Normal  # color off (usu. Colors.Normal)
-    } )
+    "Linux",
+    {
+        "header": Colors.LightRed,
+        token.NUMBER: Colors.LightCyan,
+        token.OP: Colors.Yellow,
+        token.STRING: Colors.LightBlue,
+        token.COMMENT: Colors.LightRed,
+        token.NAME: Colors.Normal,
+        token.ERRORTOKEN: Colors.Red,
+        _KEYWORD: Colors.LightGreen,
+        _TEXT: Colors.Yellow,
+        "in_prompt": InputTermColors.Green,
+        "in_number": InputTermColors.LightGreen,
+        "in_prompt2": InputTermColors.Green,
+        "in_normal": InputTermColors.Normal,  # color off (usu. Colors.Normal)
+        "out_prompt": Colors.Red,
+        "out_number": Colors.LightRed,
+        "normal": Colors.Normal,  # color off (usu. Colors.Normal)
+    },
+)
 
 NeutralColors = ColorScheme(
-    'Neutral',{
-    'header'         : Colors.Red,
-    token.NUMBER     : Colors.Cyan,
-    token.OP         : Colors.Blue,
-    token.STRING     : Colors.Blue,
-    tokenize.COMMENT : Colors.Red,
-    token.NAME       : Colors.Normal,
-    token.ERRORTOKEN : Colors.Red,
-
-    _KEYWORD         : Colors.Green,
-    _TEXT            : Colors.Blue,
-
-    'in_prompt'      : InputTermColors.Blue,
-    'in_number'      : InputTermColors.LightBlue,
-    'in_prompt2'     : InputTermColors.Blue,
-    'in_normal'      : InputTermColors.Normal,  # color off (usu. Colors.Normal)
-
-    'out_prompt'     : Colors.Red,
-    'out_number'     : Colors.LightRed,
-
-    'normal'         : Colors.Normal  # color off (usu. Colors.Normal)
-    }  )
+    "Neutral",
+    {
+        "header": Colors.Red,
+        token.NUMBER: Colors.Cyan,
+        token.OP: Colors.Blue,
+        token.STRING: Colors.Blue,
+        token.COMMENT: Colors.Red,
+        token.NAME: Colors.Normal,
+        token.ERRORTOKEN: Colors.Red,
+        _KEYWORD: Colors.Green,
+        _TEXT: Colors.Blue,
+        "in_prompt": InputTermColors.Blue,
+        "in_number": InputTermColors.LightBlue,
+        "in_prompt2": InputTermColors.Blue,
+        "in_normal": InputTermColors.Normal,  # color off (usu. Colors.Normal)
+        "out_prompt": Colors.Red,
+        "out_number": Colors.LightRed,
+        "normal": Colors.Normal,  # color off (usu. Colors.Normal)
+    },
+)
 
 # Hack: the 'neutral' colours are not very visible on a dark background on
 # Windows. Since Windows command prompts have a dark background by default, and
@@ -143,29 +137,26 @@ if os.name == 'nt':
     NeutralColors = LinuxColors.copy(name='Neutral')
 
 LightBGColors = ColorScheme(
-    'LightBG',{
-    'header'         : Colors.Red,
-    token.NUMBER     : Colors.Cyan,
-    token.OP         : Colors.Blue,
-    token.STRING     : Colors.Blue,
-    tokenize.COMMENT : Colors.Red,
-    token.NAME       : Colors.Normal,
-    token.ERRORTOKEN : Colors.Red,
-
-
-    _KEYWORD         : Colors.Green,
-    _TEXT            : Colors.Blue,
-
-    'in_prompt'      : InputTermColors.Blue,
-    'in_number'      : InputTermColors.LightBlue,
-    'in_prompt2'     : InputTermColors.Blue,
-    'in_normal'      : InputTermColors.Normal,  # color off (usu. Colors.Normal)
-
-    'out_prompt'     : Colors.Red,
-    'out_number'     : Colors.LightRed,
-
-    'normal'         : Colors.Normal  # color off (usu. Colors.Normal)
-    }  )
+    "LightBG",
+    {
+        "header": Colors.Red,
+        token.NUMBER: Colors.Cyan,
+        token.OP: Colors.Blue,
+        token.STRING: Colors.Blue,
+        token.COMMENT: Colors.Red,
+        token.NAME: Colors.Normal,
+        token.ERRORTOKEN: Colors.Red,
+        _KEYWORD: Colors.Green,
+        _TEXT: Colors.Blue,
+        "in_prompt": InputTermColors.Blue,
+        "in_number": InputTermColors.LightBlue,
+        "in_prompt2": InputTermColors.Blue,
+        "in_normal": InputTermColors.Normal,  # color off (usu. Colors.Normal)
+        "out_prompt": Colors.Red,
+        "out_number": Colors.LightRed,
+        "normal": Colors.Normal,  # color off (usu. Colors.Normal)
+    },
+)
 
 # Build table of color schemes (needed by the parser)
 ANSICodeColors = ColorSchemeTable([NoColor,LinuxColors,LightBGColors, NeutralColors],


### PR DESCRIPTION
First part of a two part change I'm proposing to use tokens from the `token` module instead of `tokenize`

After Python 3.7 all tokens are available in both `token` and `tokenize` modules, it makes more sense to me to use them from the token module as tokenize is re-exporting from token. Except that token is a common variable name (e.g. `for token in tokens`) which causes shadowing with `import token` in a few places. It's certainly feels correct to fix it here now that > Python 3.7 is required.
    
in tokenize's doc
> All constants from the token module are also exported from tokenize.
    
See https://github.com/python/cpython/commit/fc354f07855a9197e71f851ad930cbf5652f9160
and https://mail.python.org/pipermail/python-dev/2017-May/148080.html