### PR TITLE
Add sys.last_exc

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2060,6 +2060,8 @@ class InteractiveShell(SingletonConfigurable):
         sys.last_type = etype
         sys.last_value = value
         sys.last_traceback = tb
+        if sys.version_info >= (3, 12):
+            sys.last_exc = value
 
         return etype, value, tb
 


### PR DESCRIPTION
New feature in Python 3.12. This allows pdb.pm() to work there

https://docs.python.org/3/library/sys.html#sys.last_exc