### PR TITLE
Use AST token constants from token module.

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -189,6 +189,7 @@ import os
 import re
 import string
 import sys
+import token
 import tokenize
 import time
 import unicodedata
@@ -1310,16 +1311,16 @@ class Completer(Configurable):
             name_turn = True
 
             parts = []
-            for token in rev_tokens:
-                if token.type in skip_over:
+            for tok in rev_tokens:
+                if tok.type in skip_over:
                     continue
-                if token.type == tokenize.NAME and name_turn:
-                    parts.append(token.string)
+                if tok.type == tokenize.NAME and name_turn:
+                    parts.append(tok.string)
                     name_turn = False
                 elif (
-                    token.type == tokenize.OP and token.string == "." and not name_turn
+                    tok.type == token.OP and tok.string == "." and not name_turn
                 ):
-                    parts.append(token.string)
+                    parts.append(tok.string)
                     name_turn = True
                 else:
                     # short-circuit if not empty nor name token
@@ -1455,23 +1456,23 @@ def _match_number_in_dict_key_prefix(prefix: str) -> Union[str, None]:
         return None
     tokens = _parse_tokens(prefix)
     rev_tokens = reversed(tokens)
-    skip_over = {tokenize.ENDMARKER, tokenize.NEWLINE}
+    skip_over = {token.ENDMARKER, token.NEWLINE}
     number = None
-    for token in rev_tokens:
-        if token.type in skip_over:
+    for tok in rev_tokens:
+        if tok.type in skip_over:
             continue
         if number is None:
-            if token.type == tokenize.NUMBER:
-                number = token.string
+            if tok.type == token.NUMBER:
+                number = tok.string
                 continue
             else:
                 # we did not match a number
                 return None
-        if token.type == tokenize.OP:
-            if token.string == ",":
+        if tok.type == tokenize.OP:
+            if tok.string == ",":
                 break
-            if token.string in {"+", "-"}:
-                number = token.string + number
+            if tok.string in {"+", "-"}:
+                number = tok.string + number
         else:
             return None
     return number
@@ -2928,10 +2929,10 @@ class IPCompleter(Completer):
         iterTokens = reversed(tokens)
         openPar = 0
 
-        for token in iterTokens:
-            if token == ')':
+        for tok in iterTokens:
+            if tok == ')':
                 openPar -= 1
-            elif token == '(':
+            elif tok == '(':
                 openPar += 1
                 if openPar > 0:
                     # found the last unclosed parenthesis
@@ -2957,10 +2958,10 @@ class IPCompleter(Completer):
         # them again
         usedNamedArgs = set()
         par_level = -1
-        for token, next_token in zip(tokens, tokens[1:]):
-            if token == '(':
+        for tok, next_token in zip(tokens, tokens[1:]):
+            if tok == '(':
                 par_level += 1
-            elif token == ')':
+            elif tok == ')':
                 par_level -= 1
 
             if par_level != 0:
@@ -2969,7 +2970,7 @@ class IPCompleter(Completer):
             if next_token != '=':
                 continue
 
-            usedNamedArgs.add(token)
+            usedNamedArgs.add(tok)
 
         argMatches = []
         try:

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -10,6 +10,7 @@ This defines a callable class that IPython uses for `sys.displayhook`.
 import builtins as builtin_mod
 import sys
 import io as _io
+import token
 import tokenize
 
 from traitlets.config.configurable import Configurable
@@ -103,10 +104,10 @@ class DisplayHook(Configurable):
         sio = _io.StringIO(expression)
         tokens = list(tokenize.generate_tokens(sio.readline))
 
-        for token in reversed(tokens):
-            if token[0] in (tokenize.ENDMARKER, tokenize.NL, tokenize.NEWLINE, tokenize.COMMENT):
+        for tok in reversed(tokens):
+            if tok[0] in (token.ENDMARKER, token.NL, token.NEWLINE, token.COMMENT):
                 continue
-            if (token[0] == tokenize.OP) and (token[1] == ';'):
+            if (tok[0] == token.OP) and (tok[1] == ';'):
                 return True
             else:
                 return False


### PR DESCRIPTION
I'm lukewarm on this change, it's nice for all the constants to use the same namespace but it's ugly to have to change the `for token in tokens` loops.

--- 

After Python 3.7 all tokens are available in both `token` and `tokenize` modules

in tokenize's doc
> All constants from the token module are also exported from tokenize.

See https://github.com/python/cpython/commit/fc354f07855a9197e71f851ad930cbf5652f9160 and https://mail.python.org/pipermail/python-dev/2017-May/148080.html

