### PR TITLE
fix indentation error with starting comment

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -44,7 +44,7 @@ def leading_indent(lines):
     if not lines:
         return lines
     m = _indent_re.match(lines[0])
-    if not m:
+    if not m or lines[0].strip().startswith("#"):
         return lines
     space = m.group(0)
     n = len(space)

--- a/IPython/core/tests/test_inputtransformer2_line.py
+++ b/IPython/core/tests/test_inputtransformer2_line.py
@@ -129,25 +129,32 @@ def test_leading_indent():
         ) == expected.splitlines(keepends=True)
 
 
-INDENT_SPACES_COMMENT = ("""\
+INDENT_SPACES_COMMENT = (
+    """\
     # comment
 if True:
     a = 3
-""", """\
+""",
+    """\
     # comment
 if True:
    a = 3
-""")
+""",
+)
 
-INDENT_TABS_COMMENT = ("""\
+INDENT_TABS_COMMENT = (
+    """\
 \t# comment
 if True:
 \tb = 4
-""", """\
+""",
+    """\
 \t# comment
 if True:
 \tb = 4
-""")
+""",
+)
+
 
 def test_leading_indent():
     for sample, expected in [INDENT_SPACES, INDENT_TABS]:

--- a/IPython/core/tests/test_inputtransformer2_line.py
+++ b/IPython/core/tests/test_inputtransformer2_line.py
@@ -128,6 +128,33 @@ def test_leading_indent():
             sample.splitlines(keepends=True)
         ) == expected.splitlines(keepends=True)
 
+
+INDENT_SPACES_COMMENT = ("""\
+    # comment
+if True:
+    a = 3
+""", """\
+    # comment
+if True:
+   a = 3
+""")
+
+INDENT_TABS_COMMENT = ("""\
+\t# comment
+if True:
+\tb = 4
+""", """\
+\t# comment
+if True:
+\tb = 4
+""")
+
+def test_leading_indent():
+    for sample, expected in [INDENT_SPACES, INDENT_TABS]:
+        assert ipt2.leading_indent(
+            sample.splitlines(keepends=True)
+        ) == expected.splitlines(keepends=True)
+
 LEADING_EMPTY_LINES = ("""\
     \t
 


### PR DESCRIPTION
closes #14242

This happens when executing something like:

```python
    # comment
print("hello")

for i in range(7):
    print(i)
print("goodbye")
```

for some reason this is treated wrongly.
We have to explicitly check for starting # here.

Checking for multiline comments or single line strings with ' or " is not needed as cpython does not render such input valid as well.

I also experimented with some regex like this: `^[ \t]+(?=[^'"#\t ])` to check for existance of #, ' or ", though I don't think this is helpful here.

The issue is especially weird, as the typical error message is

```python
  Cell In[1], line 5
    print("goodbye")
    ^
IndentationError: expected an indented block after 'for' statement on line 4
```
while the error is in the first line..