### PR TITLE
Ensure local NS is dict.

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -104,7 +104,7 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
     if module is None:
         module = caller_module
     if local_ns is None:
-        local_ns = caller_locals
+        local_ns = dict(**caller_locals)
     
     # Only import .zmq when we really need it
     from ipykernel.embed import embed_kernel as real_embed_kernel


### PR DESCRIPTION
On Python 3.13 is is a frame proxy that has not clear() method.