### PR TITLE
HistoryManager cleanup.

### DIFF
--- a/IPython/conftest.py
+++ b/IPython/conftest.py
@@ -81,6 +81,12 @@ def inject():
     from .core import page
 
     page.pager_page = nopage
+
+    from IPython.core.history import HistoryManager
+
+    # ensure we don't leak History managers
+    if os.name != "nt":
+        HistoryManager._max_inst = 1
     # yield
 
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1333,14 +1333,15 @@ class InteractiveShell(SingletonConfigurable):
         ns = {}
 
         # make global variables for user access to the histories
-        ns['_ih'] = self.history_manager.input_hist_parsed
-        ns['_oh'] = self.history_manager.output_hist
-        ns['_dh'] = self.history_manager.dir_hist
+        if self.history_manager is not None:
+            ns["_ih"] = self.history_manager.input_hist_parsed
+            ns["_oh"] = self.history_manager.output_hist
+            ns["_dh"] = self.history_manager.dir_hist
 
-        # user aliases to input and output histories.  These shouldn't show up
-        # in %who, as they can have very large reprs.
-        ns['In']  = self.history_manager.input_hist_parsed
-        ns['Out'] = self.history_manager.output_hist
+            # user aliases to input and output histories.  These shouldn't show up
+            # in %who, as they can have very large reprs.
+            ns["In"] = self.history_manager.input_hist_parsed
+            ns["Out"] = self.history_manager.output_hist
 
         # Store myself as the public api!!!
         ns['get_ipython'] = self.get_ipython
@@ -1377,8 +1378,8 @@ class InteractiveShell(SingletonConfigurable):
         If new_session is True, a new history session will be opened.
         """
         # Clear histories
-        assert self.history_manager is not None
-        self.history_manager.reset(new_session)
+        if self.history_manager is not None:
+            self.history_manager.reset(new_session)
         # Reset counter used to index all histories
         if new_session:
             self.execution_count = 1
@@ -3889,8 +3890,9 @@ class InteractiveShell(SingletonConfigurable):
             # Close the history session (this stores the end time and line count)
             # this must be *before* the tempfile cleanup, in case of temporary
             # history db
-            self.history_manager.end_session()
-            self.history_manager = None
+            if self.history_manager is not None:
+                self.history_manager.end_session()
+                self.history_manager = None
 
     #-------------------------------------------------------------------------
     # Things related to IPython exiting

--- a/IPython/terminal/tests/test_embed.py
+++ b/IPython/terminal/tests/test_embed.py
@@ -78,6 +78,8 @@ def test_nest_embed():
     child.expect(ipy_prompt)
     child.timeout = 5 * IPYTHON_TESTING_TIMEOUT_SCALE
     child.sendline("import IPython")
+    child.sendline("from IPython.core.history import HistoryManager")
+    child.sendline("HistoryManager._max_inst = 3")
     child.expect(ipy_prompt)
     child.sendline("ip0 = get_ipython()")
     #enter first nested embed


### PR DESCRIPTION
Right now the cleanup was mostly done at process exit time,
but this leads to issues in downstream test that start to have dozen
of threads blocking, and make finding deadlocks harder

This PR try to cleanup the cleaning logic.

  - Try to seprate saving thread from history manager
  - Make sure to not keep reference to history manager in multiple places.
  - att a utility to refuse to create more then N
  concurrent history manager HistorySavingThread
  instances.
  - default to 1 in conftest.py
  - allow to set it to N via pytest fixture.

Some of this should likely be either context managers, or finalisers.
