### PR TITLE
Ensure tests are available in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,8 +9,10 @@ include .flake8
 include .pre-commit-config.yaml
 include long_description.rst
 
+recursive-include tests *
+
 recursive-exclude tools *
-recursive-exclude tests *
+
 exclude tools
 exclude CONTRIBUTING.md
 exclude .editorconfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,7 +371,8 @@ license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.setuptools.packages.find]
-exclude = ["setupext"]
+include = ["IPython*"]
+exclude = ["setupext", "tests*"]
 namespaces = false
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
This restores the `tests` folder for the built `sdist` tarball.