### PR TITLE
Remove many useless variants.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,26 +67,6 @@ doc = [
     "sphinx>=1.3",
     "sphinxcontrib-jquery",
 ]
-kernel = [
-    "ipykernel",
-]
-nbconvert = [
-    "nbconvert",
-]
-nbformat = [
-    "nbformat",
-]
-notebook = [
-    "ipywidgets",
-    "notebook",
-]
-parallel = [
-    "ipyparallel",
-]
-qtconsole = [
-    "qtconsole",
-]
-terminal = []
 test = [
     "pytest",
     "pytest-asyncio<0.22",
@@ -106,8 +86,7 @@ matplotlib = [
    "matplotlib"
 ]
 all = [
-    "ipython[black,doc,kernel,nbconvert,nbformat,notebook,parallel,qtconsole,matplotlib]",
-    "ipython[test,test_extra]",
+    "ipython[doc,matplotlib,test,test_extra]",
 ]
 
 


### PR DESCRIPTION
IPython is just terminal IPython now, so no need for those variants.

Should close #14745