### PR TITLE
Try to close more resouce on windows in system command

### DIFF
--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -114,7 +114,7 @@ def process_handler(
                 p.kill()
             except OSError:
                 pass
-        # p.stdin / p.stderr / p.stdin are not the values passes to Pope, They
+        # p.stdin / p.stderr / p.stdin are not the values passes to `Popen`, They
         # are proxy reader/writer, and this is usually  close in the context
         # manager, but the __exit__ does self.wait(), and we can't
         # afford this (see comment below),

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -139,9 +139,8 @@ class SubProcessTestCase(tt.TempFileMixin):
             # Success!
             pass
         end = time.time()
-        self.assertTrue(
-            end - start < 2, "Process didn't die quickly: %s" % (end - start)
-        )
+        delta = end - start
+        assert delta < 2, "Process didn't die quickly (in less than 2s): %s" % delta
         return result
 
     def test_system_interrupt(self):


### PR DESCRIPTION
There is a resource leak spotted in ipython/ipykernel#1291, that only
affects windows, this try to properly close the BufferReader/writrers.

I find it weird to have to close things we did not set on the
subprocess, I guess this is because it is supposed ot be used as a
context manager, unfortunately the CM does .wait(), and we don't want to
wait here.