### PR TITLE
Remove deprecated magic function

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2528,40 +2528,6 @@ class InteractiveShell(SingletonConfigurable):
         Returns None if the magic isn't found."""
         return self.magics_manager.magics[magic_kind].get(magic_name)
 
-    def magic(self, arg_s):
-        """
-        DEPRECATED
-
-        Deprecated since IPython 0.13 (warning added in
-        8.1), use run_line_magic(magic_name, parameter_s).
-
-        Call a magic function by name.
-
-        Input: a string containing the name of the magic function to call and
-        any additional arguments to be passed to the magic.
-
-        magic('name -opt foo bar') is equivalent to typing at the ipython
-        prompt:
-
-        In[1]: %name -opt foo bar
-
-        To call a magic without arguments, simply use magic('name').
-
-        This provides a proper Python function to call IPython's magics in any
-        valid Python code you can type at the interpreter, including loops and
-        compound statements.
-        """
-        warnings.warn(
-            "`magic(...)` is deprecated since IPython 0.13 (warning added in "
-            "8.1), use run_line_magic(magic_name, parameter_s).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # TODO: should we issue a loud deprecation warning here?
-        magic_name, _, magic_arg_s = arg_s.partition(' ')
-        magic_name = magic_name.lstrip(prefilter.ESC_MAGIC)
-        return self.run_line_magic(magic_name, magic_arg_s, _stack_depth=2)
-
     #-------------------------------------------------------------------------
     # Things related to macros
     #-------------------------------------------------------------------------


### PR DESCRIPTION
This has been deprecated since IPython 0.13 (warning added in 8.1) it is time to remove it, it is likely to break and we can re-introduce it in 9.1