### PR TITLE
Update Index.ipynb

### DIFF
--- a/examples/IPython Kernel/Index.ipynb
+++ b/examples/IPython Kernel/Index.ipynb
@@ -39,12 +39,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Cell Magics](Cell Magics.ipynb)\n",
-    "* [Script Magics](Script Magics.ipynb)\n",
-    "* [Rich Output](Rich Output.ipynb)\n",
-    "* [Custom Display Logic](Custom Display Logic.ipynb)\n",
-    "* [Plotting in the Notebook](Plotting in the Notebook.ipynb)\n",
-    "* [Capturing Output](Capturing Output.ipynb)"
+    "* [Cell Magics](Cell%20Magics.ipynb)\n",
+    "* [Script Magics](Script%20Magics.ipynb)\n",
+    "* [Rich Output](Rich%20Output.ipynb)\n",
+    "* [Custom Display Logic](Custom%20Display%20Logic.ipynb)\n",
+    "* [Plotting in the Notebook](Plotting%20in%20the%20Notebook.ipynb)\n",
+    "* [Capturing Output](Capturing%20Output.ipynb)"
    ]
   },
   {
@@ -58,11 +58,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [Background Jobs](Background Jobs.ipynb)\n",
-    "* [Trapezoid Rule](Trapezoid Rule.ipynb)\n",
+    "* [Background Jobs](Background%20Jobs.ipynb)\n",
+    "* [Trapezoid Rule](Trapezoid%20Rule.ipynb)\n",
     "* [SymPy](SymPy.ipynb)\n",
-    "* [Raw Input in the Notebook](Raw Input in the Notebook.ipynb)\n",
-    "* [Importing Notebooks](Importing Notebooks.ipynb)"
+    "* [Raw Input in the Notebook](Raw%20Input%20in%20the%20Notebook.ipynb)\n",
+    "* [Importing Notebooks](Importing%20Notebooks.ipynb)"
    ]
   },
   {

--- a/examples/Index.ipynb
+++ b/examples/Index.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [IPython Kernel](IPython Kernel/Index.ipynb): IPython's core syntax and command line features available in all frontends\n",
+    "* [IPython Kernel](IPython%20Kernel/Index.ipynb): IPython's core syntax and command line features available in all frontends\n",
     "* [Embedding](Embedding/Index.ipynb): Embedding and reusing IPython's components into other applications\n"
    ]
   }


### PR DESCRIPTION
Replaced some blank spaces with `%20` in some links, e.g., Cell Magics.ipynb, so that Markdown will render the links properly.