### PR TITLE
Update Index.ipynb

### DIFF
--- a/examples/Index.ipynb
+++ b/examples/Index.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* [IPython Kernel](IPython Kernel/Index.ipynb): IPython's core syntax and command line features available in all frontends\n",
+    "* <a href='IPython Kernel/Index.ipynb' target='_blank'>IPython Kernel</a>: IPython's core syntax and command line features available in all frontends\n",
     "* [Embedding](Embedding/Index.ipynb): Embedding and reusing IPython's components into other applications\n"
    ]
   }


### PR DESCRIPTION
Code for `IPython Kernel` changed to HTML `<a>` tag instead of `[Label](URL)`