### PR TITLE
Try to fix #14811 (crash ipdb)

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -228,7 +228,12 @@ class Pdb(OldPdb):
     }
 
     def __init__(
-        self, completekey=None, stdin=None, stdout=None, context: int = 5, **kwargs
+        self,
+        completekey=None,
+        stdin=None,
+        stdout=None,
+        context: int | None | str = 5,
+        **kwargs,
     ):
         """Create a new IPython debugger.
 
@@ -251,7 +256,11 @@ class Pdb(OldPdb):
         The possibilities are python version dependent, see the python
         docs for more info.
         """
-
+        # ipdb issue, see https://github.com/ipython/ipython/issues/14811
+        if context is None:
+            context = 5
+        if isinstance(context, str):
+            context = int(context)
         self.context = context
 
         # `kwargs` ensures full compatibility with stdlib's `pdb.Pdb`.
@@ -298,7 +307,10 @@ class Pdb(OldPdb):
         return self._context
 
     @context.setter
-    def context(self, value: int) -> None:
+    def context(self, value: int | str) -> None:
+        # ipdb issue see https://github.com/ipython/ipython/issues/14811
+        if not isinstance(value, int):
+            value = int(value)
         assert isinstance(value, int)
         assert value >= 0
         self._context = value

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -169,6 +169,7 @@ class IPythonPTCompleter(Completer):
             adjusted_text = _adjust_completion_text_based_on_context(
                 c.text, body, offset
             )
+            min_elide = 30 if self.shell is None else self.shell.min_elide
             if c.type == "function":
                 yield Completion(
                     adjusted_text,
@@ -176,7 +177,7 @@ class IPythonPTCompleter(Completer):
                     display=_elide(
                         display_text + "()",
                         body[c.start : c.end],
-                        min_elide=self.shell.min_elide,
+                        min_elide=min_elide,
                     ),
                     display_meta=c.type + c.signature,
                 )
@@ -187,7 +188,7 @@ class IPythonPTCompleter(Completer):
                     display=_elide(
                         display_text,
                         body[c.start : c.end],
-                        min_elide=self.shell.min_elide,
+                        min_elide=min_elide,
                     ),
                     display_meta=c.type,
                 )


### PR DESCRIPTION
Ideally we should try to go upstream and make sure context is passed as an int always and not a str.