### PR TITLE
Partial readd of termcolors to please ipyparallel.

### DIFF
--- a/IPython/utils/coloransi.py
+++ b/IPython/utils/coloransi.py
@@ -1,0 +1,9 @@
+# Deprecated/should be removed, but we break older version of ipyparallel
+# https://github.com/ipython/ipyparallel/pull/924
+
+
+# minimal subset of TermColors, removed from IPython
+# not for public consumption, beyond ipyparallel.
+class TermColors:
+    Normal = "\033[0m"
+    Red = "\033[0;31m"


### PR DESCRIPTION
See https://github.com/ipython/ipyparallel/pull/931 and https://github.com/ipython/ipyparallel/pull/924