### PR TITLE
fix: transform inputs with dedent

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -17,6 +17,7 @@ import sys
 import tokenize
 from typing import List, Tuple, Optional, Any
 import warnings
+from textwrap import dedent
 
 from IPython.utils import tokenutil
 
@@ -38,18 +39,11 @@ def leading_empty_lines(lines):
 def leading_indent(lines):
     """Remove leading indentation.
 
-    If the first line starts with a spaces or tabs, the same whitespace will be
-    removed from each following line in the cell.
+    Removes the minimum common leading indentation from all lines.
     """
     if not lines:
         return lines
-    m = _indent_re.match(lines[0])
-    if not m or lines[0].strip().startswith("#"):
-        return lines
-    space = m.group(0)
-    n = len(space)
-    return [l[n:] if l.startswith(space) else l
-            for l in lines]
+    return dedent("".join(lines)).splitlines(keepends=True)
 
 class PromptStripper:
     """Remove matching input prompts from a block of input.

--- a/tests/test_inputtransformer2_line.py
+++ b/tests/test_inputtransformer2_line.py
@@ -4,6 +4,8 @@ Line-based transformers are the simpler ones; token-based transformers are
 more complex. See test_inputtransformer2 for tests for token-based transformers.
 """
 
+import pytest
+
 from IPython.core import inputtransformer2 as ipt2
 
 CELL_MAGIC = (
@@ -196,11 +198,14 @@ print(x)
 )
 
 
-def test_leading_indent_comment():
-    for sample, expected in [INDENT_SPACES_COMMENT, INDENT_TABS_COMMENT, INDENTED_CODE_WITH_ALIGNED_COMMENT]:
-        assert ipt2.leading_indent(
-            sample.splitlines(keepends=True)
-        ) == expected.splitlines(keepends=True)
+@pytest.mark.parametrize(
+    "sample, expected",
+    [INDENT_SPACES_COMMENT, INDENT_TABS_COMMENT, INDENTED_CODE_WITH_ALIGNED_COMMENT],
+)
+def test_leading_indent_comment(sample, expected):
+    assert ipt2.leading_indent(sample.splitlines(keepends=True)) == expected.splitlines(
+        keepends=True
+    )
 
 
 LEADING_EMPTY_LINES = (

--- a/tests/test_inputtransformer2_line.py
+++ b/tests/test_inputtransformer2_line.py
@@ -164,7 +164,7 @@ if True:
     """\
     # comment
 if True:
-   a = 3
+    a = 3
 """,
 )
 
@@ -182,8 +182,22 @@ if True:
 )
 
 
-def test_leading_indent():
-    for sample, expected in [INDENT_SPACES, INDENT_TABS]:
+INDENTED_CODE_WITH_ALIGNED_COMMENT = (
+    """\
+    # comment
+    x = 1
+    print(x)
+""",
+    """\
+# comment
+x = 1
+print(x)
+""",
+)
+
+
+def test_leading_indent_comment():
+    for sample, expected in [INDENT_SPACES_COMMENT, INDENT_TABS_COMMENT, INDENTED_CODE_WITH_ALIGNED_COMMENT]:
         assert ipt2.leading_indent(
             sample.splitlines(keepends=True)
         ) == expected.splitlines(keepends=True)


### PR DESCRIPTION
fixes: https://github.com/ipython/ipython/issues/14818

The `leading_indent` function in IPython/core/inputtransformer2.py had an issue in that it checked to see if the first line had a comment anywhere in it, and if it did, then it just would ignore checking if the rest of the input could possibly need to have indentation removed.

The main issue is that it looks like the function assumes you can just check the first line, but that is not the case. You need to check the indentation level of every line in the input and remove the minimum (in terms of length) indentation common to all lines. 

I'm not sure why this function isn't just using `textwrap.dedent`, which seems like it does exactly what we want to be doing. I just switched the function to use this.

For the tests, it turns out that there was a test cases that wasn't even being checked. I fixed that as well and added the sample I noted in #14818 as a 3rd test case.

While working on this, I wrote a more involved test, which didn't really fit with the style of the other tests, but I'll put it here in case you want to include it.

<details>

```python
def test_regression_14818():
    from IPython.core import inputtransformer2 as ipt2
    from textwrap import dedent

    def indent(text, prefix='    '):
        """Indents a block of text"""
        return prefix + text.replace('\n', '\n' + prefix)

    targets = {}
    targets['two_statements'] = dedent(
        """
        x = 1
        print(x)
        """
    ).strip()
    targets['aligned_comment_and_two_statements'] = dedent(
        """
        # This is a comment
        x = 1
        print(x)
        """
    ).strip()
    targets['misaligned_comment_and_two_statements'] = dedent(
        """
            # This is a misaligned comment
        x = 1
        print(x)
        """
    ).strip()

    # Check that all of the targets are valid python
    for target_name, target_code in targets.items():
        exec(target_code, {}, {})

    # Modify the target text to test that ipt2.leading_indent can undo the
    # modifications.
    cases = []
    for target_name, target_code in targets.items():
        cases.append({
            'name': target_name + '_space',
            'sample': indent(target_code, prefix='    '),
            'target': target_code,
        })
        cases.append({
            'name': target_name + '_tab',
            'sample': indent(target_code, prefix='\t'),
            'target': target_code,
        })

    for case in cases:
        case_name = case['name']
        lines = case['sample'].splitlines(keepends=True)
        recon_lines = ipt2.leading_indent(lines)
        reconstructed = ''.join(recon_lines)
        assert reconstructed == case['target'], f'failed case {case_name}'
```

</details>