### PR TITLE
Fix accept invisible completions

### DIFF
--- a/IPython/terminal/shortcuts/__init__.py
+++ b/IPython/terminal/shortcuts/__init__.py
@@ -203,7 +203,7 @@ AUTO_SUGGEST_BINDINGS = [
     Binding(
         auto_suggest.accept,
         ["right"],
-        "has_suggestion & default_buffer_focused & emacs_like_insert_mode",
+        "has_suggestion & default_buffer_focused & emacs_like_insert_mode & is_cursor_at_the_end_of_line",
     ),
     Binding(
         auto_suggest.accept_word,


### PR DESCRIPTION
See `#14137`, I think there are invisible completions and when the current line is a prefix of an existing history entry, we happend to have autocompletions but they are not shown.

I need to check how this affects the multiline completions though, and we might need a more general solution.