### PR TITLE
reaccept non lowercase colorscheme

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -764,7 +764,9 @@ class InteractiveShell(SingletonConfigurable):
         if not new == new.lower():
             warn(
                 f"`TerminalInteractiveShell.colors` is now lowercase: `{new.lower()}`,"
-                " non lowercase, may invalid in the future."
+                " non lowercase, may be invalid in the future.",
+                DeprecationWarning,
+                stacklevel=2,
             )
         return new.lower()
 
@@ -781,7 +783,8 @@ class InteractiveShell(SingletonConfigurable):
             )
 
         try:
-            self.inspector.set_theme_name(self.colors)
+            # Deprecation in 9.0, colors should always be lower
+            self.inspector.set_theme_name(self.colors.lower())
         except Exception:
             warn(
                 "Error changing object inspector color schemes.\n%s"

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -401,7 +401,13 @@ class Inspector(Configurable):
         parent=None,
         config=None,
     ):
-        assert theme_name == theme_name.lower(), theme_name
+        if theme_name in ["Linux", "LightBG", "Neutral", "NoColor"]:
+            warnings.warn(
+                f"Theme names and color schemes are lowercase in IPython 9.0 use {theme_name.lower()} instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            theme_name = theme_name.lower()
         self._theme_name = theme_name
         super(Inspector, self).__init__(parent=parent, config=config)
         self.parser = PyColorize.Parser(out="str", theme_name=theme_name)

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -401,7 +401,13 @@ class TBTools:
                 stacklevel=2,
             )
             theme_name = color_scheme
-        assert theme_name.lower() == theme_name, theme_name
+        if theme_name in ["Linux", "LightBG", "Neutral", "NoColor"]:
+            warnings.warn(
+                f"Theme names and color schemes are lowercase in IPython 9.0 use {theme_name.lower()} instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            theme_name = theme_name.lower()
         # Whether to call the interactive pdb debugger after printing
         # tracebacks or not
         super().__init__()

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -3,6 +3,7 @@ import os
 import sys
 import token
 import tokenize
+import warnings
 from io import StringIO
 from typing import TypeAlias
 
@@ -353,7 +354,6 @@ class Parser:
         Call format() to process code.
         """
 
-
         assert theme_name is not None
 
         self.out = out
@@ -361,7 +361,13 @@ class Parser:
         self.lines = None
         self.raw = None
         if theme_name is not None:
-            assert theme_name == theme_name.lower()
+            if theme_name in ["Linux", "LightBG", "Neutral", "NoColor"]:
+                warnings.warn(
+                    f"Theme names and color schemes are lowercase in IPython 9.0 use {theme_name.lower()} instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                theme_name = theme_name.lower()
         if not theme_name:
             self.theme_name = "nocolor"
         else:

--- a/docs/source/config/intro.rst
+++ b/docs/source/config/intro.rst
@@ -68,7 +68,7 @@ Example configuration file
         'mycode.py',
         'fancy.ipy'
     ]
-    c.InteractiveShell.colors = 'LightBG'
+    c.InteractiveShell.colors = 'lightbg'
     c.InteractiveShell.xmode = 'Context'
     c.TerminalInteractiveShell.confirm_exit = False
     c.TerminalInteractiveShell.editor = 'nano'
@@ -92,7 +92,7 @@ hierarchy represents the value you would normally set on the ``c`` object of
 
     {
         "InteractiveShell": {
-            "colors": "LightBG",
+            "colors": "lightbg",
         },
         "InteractiveShellApp": {
             "extensions": [
@@ -106,7 +106,7 @@ hierarchy represents the value you would normally set on the ``c`` object of
 
 Is equivalent to the following ``ipython_config.py``::
 
-    c.InteractiveShell.colors = 'LightBG'
+    c.InteractiveShell.colors = 'lightbg'
     c.InteractiveShellApp.extensions = [
         'myextension'
     ]

--- a/docs/source/whatsnew/version9.rst
+++ b/docs/source/whatsnew/version9.rst
@@ -84,7 +84,7 @@ unicode symbol, for a more refined experience.
 New themes using colors and symbols
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All the existing themes (Linux, LightBG, Neutral and Nocolor) should not see any
+All the existing themes (Linux, LightBG, Neutral and NoColor) should not see any
 changes, but I added two new *pride themes*, that show the use of 256bits colors
 and unicode symbols. I'm not a designer, so feel free to suggest updates and new
 themes to add. 

--- a/examples/Embedding/start_ipython_config.py
+++ b/examples/Embedding/start_ipython_config.py
@@ -13,7 +13,7 @@ c.InteractiveShellApp.exec_lines = [
     'import math',
     "math"
 ]
-c.InteractiveShell.colors = 'LightBG'
+c.InteractiveShell.colors = "lightbg"
 c.InteractiveShell.confirm_exit = False
 c.TerminalIPythonApp.display_banner = False
 


### PR DESCRIPTION
This otherwise break pycharm

Plus a few other fixes.

See #14810