### PR TITLE
Fix Tab Completion Context Detection

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2383,6 +2383,13 @@ class IPCompleter(Completer):
                 # Recursively determine the context of the expression
                 return self._determine_completion_context(expr)
 
+        # Match tuples followed by a dot (e.g., (a, b).index)
+        tuple_attr_match = re.search(
+            r"\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*(,\s*[a-zA-Z_][a-zA-Z0-9_]*\s*)+\)\.$", line
+        )
+        if tuple_attr_match:
+            return self._CompletionContextType.ATTRIBUTE
+
         # Match for number literals should come first
         # Handle plain number literals - should be global context
         if re.search(r"^[-+]?\d+\.(\d+)?$", line):
@@ -2391,7 +2398,7 @@ class IPCompleter(Completer):
         # Match numeric literals in parentheses followed by dot
         # Handles cases like (3).to_
         numeric_paren_attr_match = re.search(
-            r"\([-+]?\d+(\.\d*)?\)\.([a-zA-Z_][a-zA-Z0-9_]*)?$", line
+            r"\([-+]?\d+(\.\d*)?\)(\.([a-zA-Z_][a-zA-Z0-9_]*)?)?$", line
         )
         if numeric_paren_attr_match:
             return self._CompletionContextType.ATTRIBUTE

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2360,25 +2360,29 @@ class IPCompleter(Completer):
             else:
                 return iter([])
 
+    class _CompletionContextType(enum.Enum):
+        ATTRIBUTE = "attribute"  # For attribute completion
+        GLOBAL = "global"  # For global completion
+
     def _determine_completion_context(self, line):
         """
         Determine whether the cursor is in an attribute or global completion context.
         """
         if self._is_in_string_or_comment(line):
-            return "global"
+            return self._CompletionContextType.GLOBAL
         if line.endswith("."):
-            return "attribute"
+            return self._CompletionContextType.ATTRIBUTE
 
         last_token_match = re.search(r"([\w\d_]+)$", line)
         if not last_token_match:
-            return "global"
+            return self._CompletionContextType.GLOBAL
 
         prefix = line[: last_token_match.start()]
         chain_match = re.search(r"([\w\d_.]+)\.$", prefix.rstrip())
         if chain_match:
-            return "attribute"
+            return self._CompletionContextType.ATTRIBUTE
 
-        return "global"
+        return self._CompletionContextType.GLOBAL
 
     def _is_in_string_or_comment(self, text):
         # Check for comments
@@ -2467,7 +2471,7 @@ class IPCompleter(Completer):
         """Match attributes or global python names"""
         text = context.line_with_cursor
         completion_type = self._determine_completion_context(text)
-        if completion_type == "attribute":
+        if completion_type == self._CompletionContextType.ATTRIBUTE:
             try:
                 matches, fragment = self._attr_matches(text, include_prefix=False)
                 if text.endswith(".") and self.omit__names:

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2481,40 +2481,21 @@ class IPCompleter(Completer):
                     i += 1
                     continue
 
+            in_triple_quote = in_triple_single or in_triple_double
+
             # Handle quotes - also reset template string when closing quotes are encountered
-            if (
-                text[i] == '"'
-                and not in_single_quote
-                and not in_triple_single
-                and not in_triple_double
-            ):
+            if text[i] == '"' and not in_single_quote and not in_triple_quote:
                 in_double_quote = not in_double_quote
-                if (
-                    not in_double_quote
-                    and not in_triple_double
-                    and not in_triple_single
-                ):
+                if not in_double_quote and not in_triple_quote:
                     in_template_string = False
-            elif (
-                text[i] == "'"
-                and not in_double_quote
-                and not in_triple_double
-                and not in_triple_single
-            ):
+            elif text[i] == "'" and not in_double_quote and not in_triple_quote:
                 in_single_quote = not in_single_quote
-                if (
-                    not in_single_quote
-                    and not in_triple_single
-                    and not in_triple_double
-                ):
+                if not in_single_quote and not in_triple_quote:
                     in_template_string = False
 
             # Check for comment
             if text[i] == "#" and not (
-                in_single_quote
-                or in_double_quote
-                or in_triple_single
-                or in_triple_double
+                in_single_quote or in_double_quote or in_triple_quote
             ):
                 return True, False
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2373,12 +2373,12 @@ class IPCompleter(Completer):
         if line.endswith("."):
             return self._CompletionContextType.ATTRIBUTE
 
-        last_token_match = re.search(r"([\w\d_]+)$", line)
+        last_token_match = re.search(r"([\w]+)$", line)
         if not last_token_match:
             return self._CompletionContextType.GLOBAL
 
         prefix = line[: last_token_match.start()]
-        chain_match = re.search(r"([\w\d_.]+)\.$", prefix.rstrip())
+        chain_match = re.search(r"(.*)\.(\w*)$", prefix.rstrip())
         if chain_match:
             return self._CompletionContextType.ATTRIBUTE
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2374,17 +2374,12 @@ class IPCompleter(Completer):
 
         # Match 'anything-dot-word' at end for attribute context.
         # Ex: 'obj.', 'np.random.ran'.
-        chain_match = re.search(r"(.+)\.(\w*)$", line)
+        chain_match = re.search(r"([a-zA-Z_].*)\.([a-zA-Z_][a-zA-Z0-9_]*)?$", line)
         if chain_match:
-            prefix = chain_match.group(1)
-            # If prefix is a number → GLOBAL (no attributes).
-            # Ex: '3.', '-42.5.'.
-            if re.fullmatch(r"[-+]?\d*\.?\d+", prefix):
-                return self._CompletionContextType.GLOBAL
             return self._CompletionContextType.ATTRIBUTE
 
         # No attribute pattern → GLOBAL.
-        # Ex: 'var', ''.
+        # Ex: 'var', '', '3.', '-42.5.'
         return self._CompletionContextType.GLOBAL
 
     def _is_in_string_or_comment(self, text):

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1137,7 +1137,7 @@ class Completer(Configurable):
     def _attr_matches(
         self, text: str, include_prefix: bool = True
     ) -> tuple[Sequence[str], str]:
-        m2 = self._ATTR_MATCH_RE.match(self.line_buffer)
+        m2 = self._ATTR_MATCH_RE.match(text)
         if not m2:
             return [], ""
         expr, attr = m2.group(1, 2)

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1793,6 +1793,7 @@ class TestCompleter(unittest.TestCase):
         ("np.random.rand(np.random.ran", "attribute"),
         ("np.random.rand(n", "global"),
         ("d['k.e.y.'](ran", "global"),
+        ("d[0].k", "attribute"),
         ("a = { 'a': np.ran", "attribute"),
         ("n", "global"),
         ("", "global"),

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1785,7 +1785,7 @@ def test_completion_context(line, expected):
     ip = get_ipython()
     get_context = ip.Completer._determine_completion_context
     result = get_context(line)
-    assert result == expected, f"Failed on input: '{line}'"
+    assert result.value == expected, f"Failed on input: '{line}'"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -626,7 +626,6 @@ class TestCompleter(unittest.TestCase):
                 "Should have completed on a[0].r: %s",
                 Completion(5, 6, "real"),
             )
-
             _(
                 "a[0].from_",
                 10,
@@ -745,6 +744,16 @@ class TestCompleter(unittest.TestCase):
 
         words = completer.get__all__entries(A())
         self.assertEqual(words, [])
+
+    def test_completes_globals_as_args_of_methods(self):
+        ip = get_ipython()
+        c = ip.Completer
+        c.use_jedi = False
+        ip.ex("long_variable_name = 1")
+        ip.ex("a = []")
+        s, matches = c.complete(None, "a.sort(lo")
+        self.assertIn("long_variable_name", matches)
+
 
     def test_func_kw_completions(self):
         ip = get_ipython()

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1748,6 +1748,47 @@ class TestCompleter(unittest.TestCase):
 
 
 @pytest.mark.parametrize(
+    "line,expected",
+    [
+        # Basic test cases
+        ("np.ran", "attribute"),
+        ("np.random.rand(np.random.ran", "attribute"),
+        ("np.random.rand(n", "global"),
+        ("d['k.e.y.'](ran", "global"),
+        ("a = { 'a': np.ran", "attribute"),
+        ("n", "global"),
+        ("", "global"),
+        # Dots in string literals
+        ('some_var = "this is a string with a dot.', "global"),
+        ("text = 'another string with a dot.", "global"),
+        # Backslash escapes in strings
+        ('var = "string with \\"escaped quote and a dot.', "global"),
+        ("escaped = 'single \\'quote\\' with a dot.", "global"),
+        # Multi-line strings
+        ('multi = """This is line one\nwith a dot.', "global"),
+        ("multi_single = '''Another\nmulti-line\nwith a dot.", "global"),
+        # Inline comments with dots
+        ("x = 5  # This is a comment with a dot.", "global"),
+        ("y = obj.method()  # Comment after dot.method", "global"),
+        # Nested parentheses with dots
+        ("complex_expr = (func((obj.method(param.attr", "attribute"),
+        ("multiple_nesting = {key: [value.attr", "attribute"),
+        # Additional cases
+        ('str_with_code = "x.attr', "global"),
+        ('f"formatted {obj.attr', "attribute"),
+        ('f"formatted {obj.attr}', "global"),
+        ("dict_with_dots = {'key.with.dots': value.attr", "attribute"),
+    ],
+)
+def test_completion_context(line, expected):
+    """Test completion context"""
+    ip = get_ipython()
+    get_context = ip.Completer._determine_completion_context
+    result = get_context(line)
+    assert result == expected, f"Failed on input: '{line}'"
+
+
+@pytest.mark.parametrize(
     "setup,code,expected,not_expected",
     [
         ('a="str"; b=1', "(a, b.", [".bit_count", ".conjugate"], [".count"]),

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -754,6 +754,35 @@ class TestCompleter(unittest.TestCase):
         s, matches = c.complete(None, "a.sort(lo")
         self.assertIn("long_variable_name", matches)
 
+    def test_completes_attributes_in_fstring_expressions(self):
+        ip = get_ipython()
+        c = ip.Completer
+        c.use_jedi = False
+        ip.ex("import numpy as np")
+
+        # Test completion inside f-string expressions
+        s, matches = c.complete(None, "f'{np.ran")
+        self.assertIn(".random", matches)
+
+        # Test nested attribute completion in f-string
+        s, matches = c.complete(None, "f'{np.random.ran")
+        self.assertIn(".randint", matches)
+
+    def test_completes_in_dict_expressions(self):
+        ip = get_ipython()
+        c = ip.Completer
+        c.use_jedi = False
+        ip.ex("class Test: pass")
+        ip.ex("test_obj = Test()")
+        ip.ex("test_obj.attribute = 'value'")
+
+        # Test completion in dictionary expressions
+        s, matches = c.complete(None, "d = {'key': test_obj.attr")
+        self.assertIn(".attribute", matches)
+
+        # Test global completion in dictionary expressions with dots
+        s, matches = c.complete(None, "d = {'k.e.y': Te")
+        self.assertIn("Test", matches)
 
     def test_func_kw_completions(self):
         ip = get_ipython()

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1801,18 +1801,26 @@ class TestCompleter(unittest.TestCase):
         # Dots in string literals
         ('some_var = "this is a string with a dot.', "global"),
         ("text = 'another string with a dot.", "global"),
+        ('f"greeting {user.na', "attribute"),  # Cursor in f-string expression
+        ('t"welcome {guest.na', "attribute"),  # Cursor in t-string expression
+        ('f"hello {name} worl', "global"),  # Cursor in f-string outside expression
         # Backslash escapes in strings
         ('var = "string with \\"escaped quote and a dot.', "global"),
         ("escaped = 'single \\'quote\\' with a dot.", "global"),
         # Multi-line strings
         ('multi = """This is line one\nwith a dot.', "global"),
         ("multi_single = '''Another\nmulti-line\nwith a dot.", "global"),
-        # Inline comments with dots
-        ("x = 5  # This is a comment with a dot.", "global"),
+        # Inline comments
+        ("x = 5  # This is a comment", "global"),
         ("y = obj.method()  # Comment after dot.method", "global"),
+        # Hash symbol within string literals should not be treated as comments
+        ("d['#'] = np.", "attribute"),
         # Nested parentheses with dots
         ("complex_expr = (func((obj.method(param.attr", "attribute"),
         ("multiple_nesting = {key: [value.attr", "attribute"),
+        # Numbers
+        ("3.", "global"),
+        ("-42.14", "global"),
         # Additional cases
         ('str_with_code = "x.attr', "global"),
         ('f"formatted {obj.attr', "attribute"),

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -758,15 +758,16 @@ class TestCompleter(unittest.TestCase):
         ip = get_ipython()
         c = ip.Completer
         c.use_jedi = False
-        ip.ex("import numpy as np")
+
+        class CustomClass:
+            def method_one(self):
+                pass
+
+        ip.user_ns["custom_obj"] = CustomClass()
 
         # Test completion inside f-string expressions
-        s, matches = c.complete(None, "f'{np.ran")
-        self.assertIn(".random", matches)
-
-        # Test nested attribute completion in f-string
-        s, matches = c.complete(None, "f'{np.random.ran")
-        self.assertIn(".randint", matches)
+        s, matches = c.complete(None, "f'{custom_obj.meth")
+        self.assertIn(".method_one", matches)
 
     def test_completes_in_dict_expressions(self):
         ip = get_ipython()

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1827,10 +1827,30 @@ class TestCompleter(unittest.TestCase):
         ('f"formatted {obj.attr', "attribute"),
         ('f"formatted {obj.attr}', "global"),
         ("dict_with_dots = {'key.with.dots': value.attr", "attribute"),
+        ("d[f'{a}']['{a.", "global"),
+        ("3.", "global"),
+        ("3.1.", "attribute"),
+        ("-3.1.", "attribute"),
+        ("(3).", "attribute"),
     ],
 )
 def test_completion_context(line, expected):
     """Test completion context"""
+    ip = get_ipython()
+    get_context = ip.Completer._determine_completion_context
+    result = get_context(line)
+    assert result.value == expected, f"Failed on input: '{line}'"
+
+
+@pytest.mark.xfail(reason="Completion context not yet supported")
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        ("f'{f'a.", "global"),
+    ],
+)
+def test_unsupported_completion_context(line, expected):
+    """Test unsupported completion context"""
     ip = get_ipython()
     get_context = ip.Completer._determine_completion_context
     result = get_context(line)

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1805,6 +1805,8 @@ class TestCompleter(unittest.TestCase):
         ('f"greeting {user.na', "attribute"),  # Cursor in f-string expression
         ('t"welcome {guest.na', "attribute"),  # Cursor in t-string expression
         ('f"hello {name} worl', "global"),  # Cursor in f-string outside expression
+        ('f"hello {{a.', "global"),
+        ('f"hello {{{a.', "attribute"),
         # Backslash escapes in strings
         ('var = "string with \\"escaped quote and a dot.', "global"),
         ("escaped = 'single \\'quote\\' with a dot.", "global"),
@@ -1821,17 +1823,21 @@ class TestCompleter(unittest.TestCase):
         ("multiple_nesting = {key: [value.attr", "attribute"),
         # Numbers
         ("3.", "global"),
+        ("3.14", "global"),
         ("-42.14", "global"),
+        ("x = func(3.14", "global"),
+        ("x = func(a3.", "attribute"),
+        ("x = func(a3.12", "global"),
+        ("3.1.", "attribute"),
+        ("-3.1.", "attribute"),
+        ("(3).", "attribute"),
         # Additional cases
+        ("", "global"),
         ('str_with_code = "x.attr', "global"),
         ('f"formatted {obj.attr', "attribute"),
         ('f"formatted {obj.attr}', "global"),
         ("dict_with_dots = {'key.with.dots': value.attr", "attribute"),
         ("d[f'{a}']['{a.", "global"),
-        ("3.", "global"),
-        ("3.1.", "attribute"),
-        ("-3.1.", "attribute"),
-        ("(3).", "attribute"),
     ],
 )
 def test_completion_context(line, expected):
@@ -1846,7 +1852,9 @@ def test_completion_context(line, expected):
 @pytest.mark.parametrize(
     "line, expected",
     [
-        ("f'{f'a.", "global"),
+        ("f'{f'a.", "global"),  # Nested f-string
+        ("3a.", "global"),  # names starting with numbers or other symbols
+        ("$).", "global"),  # random things with dot at end
     ],
 )
 def test_unsupported_completion_context(line, expected):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1790,6 +1790,7 @@ class TestCompleter(unittest.TestCase):
     "line,expected",
     [
         # Basic test cases
+        ("np.", "attribute"),
         ("np.ran", "attribute"),
         ("np.random.rand(np.random.ran", "attribute"),
         ("np.random.rand(n", "global"),


### PR DESCRIPTION
### Fixes #14836 

This PR resolves the issue with IPython tab completion incorrectly triggering attribute completion when a dot (`.`) appears in the line. Instead of just checking for '.', I've added a new function, `_determine_completion_context`, to accurately determine whether the cursor is in an attribute or global completion context. 

The solution has been tested against multiple edge cases (e.g., nested expressions, strings, comments) and handles them all correctly. Please review the changes and let me know if you have any feedback or suggestions!