### PR TITLE
Do not always import * with autoreload3

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3282,9 +3282,9 @@ class InteractiveShell(SingletonConfigurable):
             if store_history:
                 if self.history_manager:
                     # Store formatted traceback and error details
-                    self.history_manager.exceptions[
-                        self.execution_count
-                    ] = self._format_exception_for_storage(value)
+                    self.history_manager.exceptions[self.execution_count] = (
+                        self._format_exception_for_storage(value)
+                    )
                 self.execution_count += 1
             result.error_before_exec = value
             self.last_execution_succeeded = False
@@ -3398,9 +3398,9 @@ class InteractiveShell(SingletonConfigurable):
             exec_count = self.execution_count
             if result.error_in_exec:
                 # Store formatted traceback and error details
-                self.history_manager.exceptions[
-                    exec_count
-                ] = self._format_exception_for_storage(result.error_in_exec)
+                self.history_manager.exceptions[exec_count] = (
+                    self._format_exception_for_storage(result.error_in_exec)
+                )
 
             # Each cell is a *single* input, regardless of how many lines it has
             self.execution_count += 1

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -259,7 +259,13 @@ class ExecutionInfo:
     cell_id = None
 
     def __init__(
-        self, raw_cell, store_history, silent, shell_futures, cell_id, transformed_cell=None
+        self,
+        raw_cell,
+        store_history,
+        silent,
+        shell_futures,
+        cell_id,
+        transformed_cell=None,
     ):
         self.raw_cell = raw_cell
         self.transformed_cell = transformed_cell
@@ -275,7 +281,7 @@ class ExecutionInfo:
         )
         transformed_cell = (
             (self.transformed_cell[:50] + "..")
-            if transformed_cell and len(self.transformed_cell) > 50
+            if self.transformed_cell and len(self.transformed_cell) > 50
             else self.transformed_cell
         )
         return (
@@ -3263,7 +3269,12 @@ class InteractiveShell(SingletonConfigurable):
         .. versionadded:: 7.0
         """
         info = ExecutionInfo(
-            raw_cell, store_history, silent, shell_futures, cell_id, transformed_cell=transformed_cell
+            raw_cell,
+            store_history,
+            silent,
+            shell_futures,
+            cell_id,
+            transformed_cell=transformed_cell,
         )
         result = ExecutionResult(info)
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -259,7 +259,7 @@ class ExecutionInfo:
     cell_id = None
 
     def __init__(
-        self, raw_cell, transformed_cell, store_history, silent, shell_futures, cell_id
+        self, raw_cell, store_history, silent, shell_futures, cell_id, transformed_cell=None
     ):
         self.raw_cell = raw_cell
         self.transformed_cell = transformed_cell
@@ -275,7 +275,7 @@ class ExecutionInfo:
         )
         transformed_cell = (
             (self.transformed_cell[:50] + "..")
-            if len(self.transformed_cell) > 50
+            if transformed_cell and len(self.transformed_cell) > 50
             else self.transformed_cell
         )
         return (
@@ -3167,11 +3167,11 @@ class InteractiveShell(SingletonConfigurable):
             try:
                 info = ExecutionInfo(
                     raw_cell,
-                    transformed_cell,
                     store_history,
                     silent,
                     shell_futures,
                     cell_id,
+                    transformed_cell=transformed_cell,
                 )
                 result = ExecutionResult(info)
                 result.error_in_exec = e
@@ -3263,7 +3263,7 @@ class InteractiveShell(SingletonConfigurable):
         .. versionadded:: 7.0
         """
         info = ExecutionInfo(
-            raw_cell, transformed_cell, store_history, silent, shell_futures, cell_id
+            raw_cell, store_history, silent, shell_futures, cell_id, transformed_cell=transformed_cell
         )
         result = ExecutionResult(info)
 

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -89,7 +89,7 @@ imports are tracked. This approach handles edge cases such as:
 
 When conflicts occur:
 
-- If you first do ``from X import Y as Z`` then later ``from X import Z``, 
+- If you first do ``from X import Y as Z`` then later ``from X import Z``,
   the extension will switch to reloading ``Z`` instead of ``Y`` under the name ``Z``.
 
 - Similarly, if you first do ``from X import Z`` then later ``from X import Y as Z``,
@@ -485,7 +485,9 @@ class ImportFromTracker:
         else:
             self.symbol_map = symbol_map or {}
 
-    def add_import(self, module_name: str, original_name: str, resolved_name: str) -> None:
+    def add_import(
+        self, module_name: str, original_name: str, resolved_name: str
+    ) -> None:
         """Add an import, handling conflicts with existing imports.
 
         This method is called after successful code execution, so we know the import is valid.

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -470,7 +470,7 @@ mod_attrs = [
 
 
 class ImportFromTracker:
-    def __init__(self, imports_froms, symbol_map):
+    def __init__(self, imports_froms: dict, symbol_map: dict):
         self.imports_froms = imports_froms
         # symbol_map maps original_name -> list of resolved_names
         self.symbol_map = {}
@@ -485,7 +485,7 @@ class ImportFromTracker:
         else:
             self.symbol_map = symbol_map or {}
 
-    def add_import(self, module_name, original_name, resolved_name):
+    def add_import(self, module_name: str, original_name: str, resolved_name: str) -> None:
         """Add an import, handling conflicts with existing imports.
 
         This method is called after successful code execution, so we know the import is valid.
@@ -870,7 +870,7 @@ class AutoreloadMagics(Magics):
 
         self.loaded_modules.update(newly_loaded_modules)
 
-    def _track_imports_from_code(self, code):
+    def _track_imports_from_code(self, code: str) -> None:
         """Track import statements from executed code"""
         try:
             tree = ast.parse(code)


### PR DESCRIPTION
Fixes #14839 

Previously, `%autoreload 3` always had the effect of `from module import *` on reloads. This PR fixes this functionality to the expected utility: if users specifically import some symbols from a module (for example `from X import Y` or `from X import Y as Z`), only those symbols are reloaded. 

Unit tests are added to demonstrate the new behavior as well. 