### PR TITLE
Fix LLM prefix including the new lines which are used as spaces

### DIFF
--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -395,7 +395,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
         request = jai_models.InlineCompletionRequest(
             number=request_number,
             prefix=prefix + buffer.document.text_before_cursor,
-            suffix="",
+            suffix=buffer.document.text_after_cursor,
             mime="text/x-python",
             stream=True,
             path=None,

--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -332,9 +332,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
             warnings.warn("No LLM provider found, cannot trigger LLM completions")
             return
         if jai_models is None:
-            warnings.warn(
-                "LLM Completion requires `jupyter_ai` to be installed"
-            )
+            warnings.warn("LLM Completion requires `jupyter_ai` to be installed")
 
         self._cancel_running_llm_task()
 

--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -174,7 +174,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
     # This is the instance of the LLM provider from jupyter-ai to which we forward the request
     # to generate inline completions.
     _llm_provider: Any | None
-    _llm_prefixer: callable = lambda self, x: "wrong"
+    _llm_prefixer: Callable = lambda self, x: "wrong"
 
     def __init__(self):
         super().__init__()
@@ -325,7 +325,6 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
         """
         # we likely want to store the current cursor position, and cancel if the cursor has moved.
         try:
-            import jupyter_ai_magics
             import jupyter_ai.completions.models as jai_models
         except ModuleNotFoundError:
             jai_models = None
@@ -334,7 +333,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
             return
         if jai_models is None:
             warnings.warn(
-                "LLM Completion requires `jupyter_ai_magics` and `jupyter_ai` to be installed"
+                "LLM Completion requires `jupyter_ai` to be installed"
             )
 
         self._cancel_running_llm_task()
@@ -365,7 +364,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
         Unlike with JupyterAi, as we do not have multiple cell, the cell id
         is always set to `None`.
 
-        We set the prefix to the current cell content, but could also inset the
+        We set the prefix to the current cell content, but could also insert the
         rest of the history or even just the non-fail history.
 
         In the same way, we do not have cell id.
@@ -378,10 +377,15 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
         providers.
         """
         try:
-            import jupyter_ai_magics
             import jupyter_ai.completions.models as jai_models
         except ModuleNotFoundError:
             jai_models = None
+
+        if not jai_models:
+            raise ValueError("jupyter-ai is not installed")
+
+        if not self._llm_provider:
+            raise ValueError("No LLM provider found, cannot trigger LLM completions")
 
         hm = buffer.history.shell.history_manager
         prefix = self._llm_prefixer(hm)
@@ -389,9 +393,10 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
 
         self._request_number += 1
         request_number = self._request_number
+
         request = jai_models.InlineCompletionRequest(
             number=request_number,
-            prefix=prefix + buffer.document.text,
+            prefix=prefix + buffer.document.text_before_cursor,
             suffix="",
             mime="text/x-python",
             stream=True,
@@ -438,7 +443,7 @@ async def llm_autosuggestion(event: KeyPressEvent):
     doc = event.current_buffer.document
     lines_to_insert = max(0, _MIN_LINES - doc.line_count + doc.cursor_position_row)
     for _ in range(lines_to_insert):
-        event.current_buffer.insert_text("\n", move_cursor=False)
+        event.current_buffer.insert_text("\n", move_cursor=False, fire_event=False)
 
     await provider._trigger_llm(event.current_buffer)
 

--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -42,7 +42,7 @@ class FibonacciCompletionProvider(BaseProvider, FakeListLLM):  # type: ignore[mi
 
         assert request.number > 0
         token = f"t{request.number}s0"
-        last_line = request.prefix.rstrip("\n").splitlines()[-1]
+        last_line = request.prefix.splitlines()[-1]
 
         if not FIBONACCI.startswith(last_line):
             return

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,4 +1,5 @@
 import pytest
+from IPython.terminal.interactiveshell import PtkHistoryAdapter
 from IPython.terminal.shortcuts.auto_suggest import (
     accept,
     accept_or_jump_to_end,
@@ -39,7 +40,7 @@ def make_event(text, cursor, suggestion):
 try:
     from .fake_llm import FIBONACCI
 except ImportError:
-    FIBONACCI = None
+    FIBONACCI = ''
 
 
 @dec.skip_without("jupyter_ai")
@@ -49,9 +50,13 @@ async def test_llm_autosuggestion():
     ip = get_ipython()
     ip.auto_suggest = provider
     ip.llm_provider_class = "tests.fake_llm.FibonacciCompletionProvider"
+    ip.history_manager.get_range = Mock(return_value=[])
     text = "def fib"
-    event = make_event(text, len(text), "")
-    event.current_buffer.history.shell.history_manager.get_range = Mock(return_value=[])
+    event = Mock()
+    event.current_buffer = Buffer(
+        history=PtkHistoryAdapter(ip),
+    )
+    event.current_buffer.insert_text(text, move_cursor=True)
     await llm_autosuggestion(event)
     assert event.current_buffer.suggestion.text == FIBONACCI[len(text) :]
 

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -40,7 +40,7 @@ def make_event(text, cursor, suggestion):
 try:
     from .fake_llm import FIBONACCI
 except ImportError:
-    FIBONACCI = ''
+    FIBONACCI = ""
 
 
 @dec.skip_without("jupyter_ai")


### PR DESCRIPTION
- [x] Make the test fail if there are spurious new lines at the end
- [x] Fix the issue by using `text_before_cursor` instead of `text` in prefix