### PR TITLE
Mask issue caused by `langchain-core` release `0.3.52`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ test = [
 test_extra = [
     "ipython[test]",
     "curio",
+    # mask https://github.com/langchain-ai/langchain/pull/30769
+    "langchain-core<0.3.52",
     "jupyter_ai",
     "matplotlib!=3.2.0",
     "nbformat",


### PR DESCRIPTION
Workaround for #14878 until langchain-core is fixed (or we find a better workaround).