### PR TITLE
Unpin `langchain-core` now that 0.3.54 fixed `__getattr__` issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,6 @@ test = [
 test_extra = [
     "ipython[test]",
     "curio",
-    # mask https://github.com/langchain-ai/langchain/pull/30769
-    "langchain-core<0.3.52",
     "jupyter_ai",
     "matplotlib!=3.2.0",
     "nbformat",


### PR DESCRIPTION
[`langchain-core==0.3.54`](https://github.com/langchain-ai/langchain/releases/tag/langchain-core%3D%3D0.3.54) includes https://github.com/langchain-ai/langchain/pull/30905 which closes #14878. 