### PR TITLE
docs: Recommend `ipykernel.embed.embed_kernel()`

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -80,6 +80,11 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
     and/or you want to load full IPython configuration,
     you probably want `IPython.start_kernel()` instead.
 
+    This is deprecated alias for `ipykernel.embed.embed_kernel()`,
+    to be removed in the future.
+    You should directly import from `ipykernel.embed`; this wrapper
+    fails anyway if you don't have `ipykernel` package installed.
+
     Parameters
     ----------
     module : types.ModuleType, optional

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -80,9 +80,9 @@ def embed_kernel(module=None, local_ns=None, **kwargs):
     and/or you want to load full IPython configuration,
     you probably want `IPython.start_kernel()` instead.
 
-    This is deprecated alias for `ipykernel.embed.embed_kernel()`,
+    This is a deprecated alias for `ipykernel.embed.embed_kernel()`,
     to be removed in the future.
-    You should directly import from `ipykernel.embed`; this wrapper
+    You should import directly from `ipykernel.embed`; this wrapper
     fails anyway if you don't have `ipykernel` package installed.
 
     Parameters

--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -700,9 +700,14 @@ your Python programs for this to work (detailed examples follow later)::
 
     embed() # this call anywhere in your program will start IPython
 
-You can also embed an IPython *kernel*, for use with qtconsole, etc. via
-``IPython.embed_kernel()``. This should work the same way, but you can
-connect an external frontend (``ipython qtconsole`` or ``ipython console``),
+You can also embed an IPython *kernel*, for use with qtconsole, etc. via::
+
+    from ipykernel.embed import embed_kernel
+
+    embed_kernel()
+
+This should work the same way, but you can connect an external frontend
+(``ipython qtconsole`` or ``ipython console``),
 rather than interacting with it in the terminal.
 
 You can run embedded instances even in code which is itself being run at


### PR DESCRIPTION
Followup to #14734, cc @Carreau 

Following the current doc prints warning:
https://github.com/ipython/ipython/blob/aa25535d3765641e31f1d218537540e41b6f1a74/IPython/__init__.py#L96-L98

(which BTW sounded to me like it was deprecated since 2013 — I assume the meaning is that `ipykernel.embed` works since 2013?)

----

P.S. Mild argument against the deprecation: IMHO, it's convenient to remember one place to import both `embed` and `embed_kernel` from.  These are most useful if memorized, so one can type them without thinking, similar to how we all used to memorize `import pdb; pdb.set_trace()` — but became easier to teach with py3.7 `breakpoint()`.

There is no `ipykernel.embed.embed`, and I assume won't be, as it starts an in-process shell which is _not really a kernel_?  But both are legitimate under `IPython`.

----

There is also a question which package(s) one must install to use these forms — _and does this need documenting_?

* I see that a clean env `uvx --with ipykernel python` also drags in IPython as a dependency, so both forms work.
* OTOH `uvx --with IPython python` allows importing IPython but not ipykernel.  In such env, `IPython.embed_kernel()` is **importable but broken**:
  ```
  File "/home/beni/.cache/uv/archive-v0/_NUp3oIPKrkvaYJk8f7Nm/lib64/python3.13/site-packages/IPython/__init__.py", line 110, in embed_kernel
    from ipykernel.embed import embed_kernel as real_embed_kernel
  ModuleNotFoundError: No module named 'ipykernel'
  ```
  This was counter-intuitive, and the deprecation avoids that!  
  I guess "install what you import" is a better quality then my above concern with "easy to remember" :+1:  

  - [x] Should the API doc https://ipython.readthedocs.io/en/stable/api/generated/IPython.html#IPython.embed_kernel also mention it's deprecated?
  - [x] Should the API doc also mention it will not work without optional `ipykernel` dependency?