### PR TITLE
Add what's new for IPython 8.36

### DIFF
--- a/docs/source/whatsnew/version8.rst
+++ b/docs/source/whatsnew/version8.rst
@@ -2,6 +2,17 @@
  8.x Series
 ============
 
+.. _version 8.36:
+
+IPython 8.36
+============
+
+This is a small release with minor changes in the context passed to the LLM completion
+provider and a fix for interruption of execution magics:
+
+- :ghpull:`14890` Fixed interruption of ``%%time`` and ``%%debug`` magics
+- :ghpull:`14877` Removed spurious empty lines from ``prefix`` passed to LLM, and separated part after cursor into the ``suffix``
+
 .. _version 8.35:
 
 IPython 8.35


### PR DESCRIPTION
Backport of the 8.x part of https://github.com/ipython/ipython/pull/14892