### PR TITLE
Fix attribute completion for expressions with comparison operators

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1137,7 +1137,9 @@ class Completer(Configurable):
     def _attr_matches(
         self, text: str, include_prefix: bool = True
     ) -> tuple[Sequence[str], str]:
-        m2 = self._ATTR_MATCH_RE.match(text)
+        # Extract only the right-hand side part of the text after '='
+        rhs_text = text.split("=")[-1]
+        m2 = self._ATTR_MATCH_RE.match(rhs_text)
         if not m2:
             return [], ""
         expr, attr = m2.group(1, 2)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1134,6 +1134,49 @@ class Completer(Configurable):
     # we simple attribute matching with normal identifiers.
     _ATTR_MATCH_RE = re.compile(r"(.+)\.(\w*)$")
 
+    def _strip_code_before_operator(self, code: str) -> str:
+        operators = ["=", "==", "!=", ">=", "<=", ">", "<"]
+        o_parens = {"(", "[", "{"}
+        c_parens = {")", "]", "}"}
+
+        # Dry-run tokenize to catch errors
+        try:
+            _ = list(tokenize.generate_tokens(iter(code.splitlines()).__next__))
+        except tokenize.TokenError:
+            # Try trimming the expression and retrying
+            trimmed_code = self._trim_expr(code)
+            try:
+                _ = list(
+                    tokenize.generate_tokens(iter(trimmed_code.splitlines()).__next__)
+                )
+                code = trimmed_code
+            except tokenize.TokenError:
+                return code
+
+        tokens = _parse_tokens(code)
+        encountered_operator = False
+        after_operator = []
+        nesting_level = 0
+
+        for t in tokens:
+            if t.type == tokenize.OP:
+                if t.string in o_parens:
+                    nesting_level += 1
+                elif t.string in c_parens:
+                    nesting_level -= 1
+                elif t.string in operators and nesting_level == 0:
+                    encountered_operator = True
+                    after_operator = []
+                    continue
+
+            if encountered_operator:
+                after_operator.append(t.string)
+
+        if encountered_operator:
+            return "".join(after_operator)
+        else:
+            return code
+
     def _attr_matches(
         self, text: str, include_prefix: bool = True
     ) -> tuple[Sequence[str], str]:
@@ -1141,13 +1184,10 @@ class Completer(Configurable):
         if not m2:
             return [], ""
         expr, attr = m2.group(1, 2)
-
-        operators = ["=", "==", "!=", ">=", "<=", ">", "<"]
-        # Split by the operator and take the right side
-        if not (expr.startswith("(") and expr.endswith(")")):
-            for op in operators:
-                if op in expr:
-                    expr = expr.split(op)[-1]
+        try:
+            expr = self._strip_code_before_operator(expr)
+        except tokenize.TokenError:
+            pass
 
         obj = self._evaluate_expr(expr)
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1135,7 +1135,6 @@ class Completer(Configurable):
     _ATTR_MATCH_RE = re.compile(r"(.+)\.(\w*)$")
 
     def _strip_code_before_operator(self, code: str) -> str:
-        operators = ["=", "==", "!=", ">=", "<=", ">", "<"]
         o_parens = {"(", "[", "{"}
         c_parens = {")", "]", "}"}
 
@@ -1164,7 +1163,7 @@ class Completer(Configurable):
                     nesting_level += 1
                 elif t.string in c_parens:
                     nesting_level -= 1
-                elif t.string in operators and nesting_level == 0:
+                elif t.string != "." and nesting_level == 0:
                     encountered_operator = True
                     after_operator = []
                     continue
@@ -1190,7 +1189,6 @@ class Completer(Configurable):
             pass
 
         obj = self._evaluate_expr(expr)
-
         if obj is not_found:
             return [], ""
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1138,11 +1138,17 @@ class Completer(Configurable):
         self, text: str, include_prefix: bool = True
     ) -> tuple[Sequence[str], str]:
         # Extract only the right-hand side part of the text after '='
-        rhs_text = text.split("=")[-1]
-        m2 = self._ATTR_MATCH_RE.match(rhs_text)
+        m2 = self._ATTR_MATCH_RE.match(text)
         if not m2:
             return [], ""
         expr, attr = m2.group(1, 2)
+
+        operators = ["=", "==", "!=", ">=", "<=", ">", "<"]
+        # Split by the operator and take the right side
+        if not (expr.startswith("(") and expr.endswith(")")):
+            for op in operators:
+                if op in expr:
+                    expr = expr.split(op)[-1]
 
         obj = self._evaluate_expr(expr)
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1137,7 +1137,6 @@ class Completer(Configurable):
     def _attr_matches(
         self, text: str, include_prefix: bool = True
     ) -> tuple[Sequence[str], str]:
-        # Extract only the right-hand side part of the text after '='
         m2 = self._ATTR_MATCH_RE.match(text)
         if not m2:
             return [], ""

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -596,6 +596,7 @@ class TestCompleter(unittest.TestCase):
         """
         ip = get_ipython()
         ip.ex("a=list(range(5))")
+        ip.ex("b,c = 1, 1.2")
         ip.ex("d = {'a b': str}")
         ip.ex("x=y='a'")
         _, c = ip.complete(".", line="a[0].")
@@ -666,7 +667,7 @@ class TestCompleter(unittest.TestCase):
                 "(x.upper() == y.",
                 16,
                 ".upper",
-                "Should have completed on `x.upper() == y.`: %s",
+                "Should have completed on `(x.upper() == y.`: %s",
                 Completion(16, 16, "upper"),
             )
             _(
@@ -682,6 +683,13 @@ class TestCompleter(unittest.TestCase):
                 ".add",
                 "Should have completed on `{'==', 'abc'}.`: %s",
                 Completion(14, 14, "add"),
+            )
+            _(
+                "b + c.",
+                6,
+                ".hex",
+                "Should have completed on `b + c.`: %s",
+                Completion(6, 6, "hex"),
             )
     def test_omit__names(self):
         # also happens to test IPCompleter as a configurable

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -663,13 +663,26 @@ class TestCompleter(unittest.TestCase):
                 Completion(15, 15, "upper"),
             )
             _(
+                "(x.upper() == y.",
+                16,
+                ".upper",
+                "Should have completed on `x.upper() == y.`: %s",
+                Completion(16, 16, "upper"),
+            )
+            _(
                 "(x.upper() == y).",
                 17,
                 ".bit_length",
                 "Should have completed on `(x.upper() == y).`: %s",
                 Completion(17, 17, "bit_length"),
             )
-
+            _(
+                "{'==', 'abc'}.",
+                14,
+                ".add",
+                "Should have completed on `{'==', 'abc'}.`: %s",
+                Completion(14, 14, "add"),
+            )
     def test_omit__names(self):
         # also happens to test IPCompleter as a configurable
         ip = get_ipython()

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -691,6 +691,7 @@ class TestCompleter(unittest.TestCase):
                 "Should have completed on `b + c.`: %s",
                 Completion(6, 6, "hex"),
             )
+
     def test_omit__names(self):
         # also happens to test IPCompleter as a configurable
         ip = get_ipython()

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -597,6 +597,7 @@ class TestCompleter(unittest.TestCase):
         ip = get_ipython()
         ip.ex("a=list(range(5))")
         ip.ex("d = {'a b': str}")
+        ip.ex("x=y='a'")
         _, c = ip.complete(".", line="a[0].")
         self.assertFalse(".real" in c, "Shouldn't have completed on a[0]: %s" % c)
 
@@ -653,6 +654,13 @@ class TestCompleter(unittest.TestCase):
                 ".append",
                 "Should have completed on `a.app`: %s",
                 Completion(2, 4, "append"),
+            )
+            _(
+                "x.upper() == y.",
+                15,
+                ".upper",
+                "Should have completed on `x.upper() == y.`: %s",
+                Completion(15, 15, "upper"),
             )
 
     def test_omit__names(self):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -662,6 +662,13 @@ class TestCompleter(unittest.TestCase):
                 "Should have completed on `x.upper() == y.`: %s",
                 Completion(15, 15, "upper"),
             )
+            _(
+                "(x.upper() == y).",
+                17,
+                ".bit_length",
+                "Should have completed on `(x.upper() == y).`: %s",
+                Completion(17, 17, "bit_length"),
+            )
 
     def test_omit__names(self):
         # also happens to test IPCompleter as a configurable


### PR DESCRIPTION
## Fixes #14897 

### Description

Modified `_attr_matches()` to check if an expression contains comparison operators `(=, ==, !=, etc.)` outside of parentheses. If so, it extracts the right-hand side of the operator for evaluation, providing appropriate completions.
For parenthesized expressions like `(x==y).<tab>`, the code preserves the entire expression to ensure it's evaluated as a bool.

Fixing completions fully is quite tricky. The current implementation still has flaws, especially in cases where comparison operators are involved. For example:
```python
{"==", "abc"}.<tab>
```
In this case, dictionary methods are not shown because the logic incorrectly separates the expression at the `"=="` operator.

While the current solution resolves some major issues, it also introduces new, albeit minor, ones.

Feedback on better approaches or alternative strategies is highly appreciated.
