### PR TITLE
The --config option with absolute paths will be loaded only once.

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -360,11 +360,14 @@ class BaseIPythonApplication(Application):
                 continue
             self.log.debug("Attempting to load config file: %s" %
                            self.config_file_name)
+            config_file_paths = self.config_file_paths
+            if Path(config_file_name).is_absolute():
+                config_file_paths = None
             try:
                 Application.load_config_file(
                     self,
                     config_file_name,
-                    path=self.config_file_paths
+                    path=config_file_paths
                 )
             except ConfigFileNotFound:
                 # Only warn if the default config file was NOT being used.


### PR DESCRIPTION
Implements #14723

The --config option with absolute paths will be loaded only once.

It may not be necessary, but I hope I contributed!
This is my first contribution to this project, so please let me know if I am missing anything.