### PR TITLE
Enhance `%%time` Magic with `--no-raise-error` Flag 

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1338,12 +1338,14 @@ class ExecutionMagics(Magics):
                 Wall time: 0.00 s
                 Compiler : 0.78 s
         """
+        line_present = False
         # Try to parse --no-raise-error if present, else ignore unrecognized args
         try:
             args = magic_arguments.parse_argstring(self.time, line)
         except UsageError as e:
             # Only ignore UsageError if caused by unrecognized arguments
             # We'll manually check for --no-raise-error and remove it from line
+            line_present = True
             tokens = shlex.split(line)
             no_raise_error = False
             filtered_tokens = []
@@ -1363,6 +1365,9 @@ class ExecutionMagics(Magics):
         else:
             if not hasattr(args, "no_raise_error"):
                 args.no_raise_error = False
+
+        if line_present and cell:
+            raise UsageError("Can't use statement directly after '%%time'!")
 
         if cell:
             expr = self.shell.transform_cell(cell)

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -64,7 +64,6 @@ from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, shellglob
 from IPython.utils.timing import clock, clock2
 from IPython.core.magics.ast_mod import ReplaceCodeTransformer
-import shlex
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1346,22 +1346,21 @@ class ExecutionMagics(Magics):
             # Only ignore UsageError if caused by unrecognized arguments
             # We'll manually check for --no-raise-error and remove it from line
             line_present = True
-            tokens = shlex.split(line)
-            no_raise_error = False
-            filtered_tokens = []
-            for t in tokens:
-                if t == "--no-raise-error":
-                    no_raise_error = True
-                else:
-                    filtered_tokens.append(t)
+
+            # Check if --no-raise-error is present
+            no_raise_error = "--no-raise-error" in line
+
+            if no_raise_error:
+                # Remove --no-raise-error while preserving the rest of the line structure
+                line = re.sub(r"\s*--no-raise-error\s*", " ", line).strip()
+                # Clean up any double spaces
+                line = re.sub(r"\s+", " ", line)
 
             class Args:
                 def __init__(self, no_raise_error):
                     self.no_raise_error = no_raise_error
 
             args = Args(no_raise_error)
-            # Rebuild line without --no-raise-error
-            line = " ".join(filtered_tokens)
         else:
             if not hasattr(args, "no_raise_error"):
                 args.no_raise_error = False

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1691,11 +1691,12 @@ def test_timeit_arguments():
 def test_time_raise_on_interrupt():
     ip = get_ipython()
 
-    with pytest.raises(KeyboardInterrupt):
+    with pytest.raises(SystemExit) as excinfo:
         thread = Thread(target=_interrupt_after_1s)
         thread.start()
         ip.run_cell_magic("time", "", "from time import sleep; sleep(2)")
         thread.join()
+    assert excinfo.value.code == signal.SIGINT
 
 
 MINIMAL_LAZY_MAGIC = """

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1691,12 +1691,11 @@ def test_timeit_arguments():
 def test_time_raise_on_interrupt():
     ip = get_ipython()
 
-    with pytest.raises(SystemExit) as excinfo:
+    with pytest.raises(KeyboardInterrupt):
         thread = Thread(target=_interrupt_after_1s)
         thread.start()
         ip.run_cell_magic("time", "", "from time import sleep; sleep(2)")
         thread.join()
-    assert excinfo.value.code == signal.SIGINT
 
 
 MINIMAL_LAZY_MAGIC = """


### PR DESCRIPTION
## Fixes #14896 

### Summary of Changes:

This PR modifies the behavior of the `%%time` magic to support better execution flow by adding `--no-raise-error` flag.

### New Behavior Introduced:

**Default Behavior (no flag):**

- On keyboard interrupt or exception, the timing up to the interruption is printed.
- Error Traceback is printed
- Execution does not continue to the cells below.

**With `--no-raise-error` Flag:**

- On keyboard interrupt: Same as default—timing and traceback are printed, execution stops. (as it is used by stop button)

- On other exceptions:
   - The timing up to the exception is printed.
   - No traceback is shown.
   - Execution continues to the cells below.

Looking for feedback on whether this behavior is intuitive and desirable before proceeding to add tests.