### PR TITLE
Fix typing of `error_before_exec`, enhance `mypy` coverage

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -331,7 +331,7 @@ class InteractiveShell(SingletonConfigurable):
 
     _instance = None
     _user_ns: dict
-    _sys_modules_keys: set[str, AnyType]
+    _sys_modules_keys: set[str]
 
     inspector: oinspect.Inspector
 
@@ -1572,7 +1572,7 @@ class InteractiveShell(SingletonConfigurable):
             if isinstance(variables, str):
                 vlist = variables.split()
             else:
-                vlist = variables
+                vlist = list(variables)
             vdict = {}
             cf = sys._getframe(1)
             for name in vlist:
@@ -2196,7 +2196,7 @@ class InteractiveShell(SingletonConfigurable):
         except KeyboardInterrupt:
             print('\n' + self.get_exception_only(), file=sys.stderr)
 
-    def _showtraceback(self, etype, evalue, stb: str):
+    def _showtraceback(self, etype, evalue, stb: list[str]):
         """Actually show a traceback.
 
         Subclasses may override this method to put the traceback on a different
@@ -3599,7 +3599,7 @@ class InteractiveShell(SingletonConfigurable):
                 if mode == "exec":
                     mod = Module([node], [])
                 elif mode == "single":
-                    mod = ast.Interactive([node])  # type: ignore
+                    mod = ast.Interactive([node])  # type: ignore[assignment]
                 with compiler.extra_flags(
                     getattr(ast, "PyCF_ALLOW_TOP_LEVEL_AWAIT", 0x0)
                     if self.autoawait

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -331,7 +331,7 @@ class InteractiveShell(SingletonConfigurable):
 
     _instance = None
     _user_ns: dict
-    _sys_modules_keys: set[str, AnyType]
+    _sys_modules_keys: set[str]
 
     inspector: oinspect.Inspector
 
@@ -3599,7 +3599,7 @@ class InteractiveShell(SingletonConfigurable):
                 if mode == "exec":
                     mod = Module([node], [])
                 elif mode == "single":
-                    mod = ast.Interactive([node])  # type: ignore
+                    mod = ast.Interactive([node])  # type: ignore[assignment]
                 with compiler.extra_flags(
                     getattr(ast, "PyCF_ALLOW_TOP_LEVEL_AWAIT", 0x0)
                     if self.autoawait

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3599,7 +3599,7 @@ class InteractiveShell(SingletonConfigurable):
                 if mode == "exec":
                     mod = Module([node], [])
                 elif mode == "single":
-                    mod = ast.Interactive([node])  # type: ignore[assignment]
+                    mod = ast.Interactive([node])
                 with compiler.extra_flags(
                     getattr(ast, "PyCF_ALLOW_TOP_LEVEL_AWAIT", 0x0)
                     if self.autoawait

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,11 +177,7 @@ ignore_errors = false
 ignore_missing_imports = true
 disallow_untyped_calls = false
 disallow_incomplete_defs = false
-<<<<<<< HEAD
 check_untyped_defs = true
-=======
-check_untyped_defs = false
->>>>>>> 18f9a8bdfde45399406adcb5b5386989c04b54ea
 disallow_untyped_decorators = false
 disable_error_code = [
   "arg-type",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,12 +173,21 @@ module = [
     "IPython.core.interactiveshell",
 ]
 disallow_untyped_defs = false
-ignore_errors = true
+ignore_errors = false
 ignore_missing_imports = true
 disallow_untyped_calls = false
-disallow_incomplete_defs = true
+disallow_incomplete_defs = false
 check_untyped_defs = true
 disallow_untyped_decorators = false
+disable_error_code = [
+  "arg-type",
+  "assignment",
+  "attr-defined",
+  "index",
+  "misc",
+  "var-annotated",
+  "union-attr"
+]
 
 # gloabl ignore error
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ disable_error_code = [
   "assignment",
   "attr-defined",
   "index",
-  "misc",
   "var-annotated",
   "union-attr"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,11 +173,11 @@ module = [
     "IPython.core.interactiveshell",
 ]
 disallow_untyped_defs = false
-ignore_errors = true
+ignore_errors = false
 ignore_missing_imports = true
 disallow_untyped_calls = false
-disallow_incomplete_defs = true
-check_untyped_defs = true
+disallow_incomplete_defs = false
+check_untyped_defs = false
 disallow_untyped_decorators = false
 
 # gloabl ignore error


### PR DESCRIPTION
This PR fixes issue #14907 


Changes made:

1. `pyproject.toml` => changed ignore_error = false, so that we can catch BaseException like errors.

Drawback => Testing with mypy we see 54 errors for `ipython/IPython/core/interactiveshell.py`
Resolution => To flip certain parameter in pyproject.toml so that we get less errors and try to resolve each of them in segments to minimize review efforts.


2. `ipython/IPython/core/interactiveshell.py` =>  Upon making the best changes to `pyproject.toml` we reduce the errors to 3(we will cover the rest of them gradually, this is for starters).
Which were:
![image](https://github.com/user-attachments/assets/41d0f0eb-32cc-443c-8e5d-2b64a86ca49b)

I had resolved 2 of them :
https://github.com/ipython/ipython/blob/b854379e3b801ce812c648e95f8846a1334e3195/IPython/core/interactiveshell.py#L334
and
https://github.com/ipython/ipython/blob/b854379e3b801ce812c648e95f8846a1334e3195/IPython/core/interactiveshell.py#L3602

Which eventually results in only 1 error, with current settings:
![image](https://github.com/user-attachments/assets/d48741d4-1ee3-4fb7-9eae-709be972cc63)
