### PR TITLE
Eliminate startup delay when slow-starting LLM completion provider is configured

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -507,13 +507,16 @@ class TerminalInteractiveShell(InteractiveShell):
         elif provider == "NavigableAutoSuggestFromHistory":
             # LLM stuff are all Provisional in 8.32
             if self._llm_provider_class:
-                llm_provider_constructor = import_item(self._llm_provider_class)
-                llm_provider = llm_provider_constructor(**self.llm_constructor_kwargs)
+
+                def init_llm_provider():
+                    llm_provider_constructor = import_item(self._llm_provider_class)
+                    return llm_provider_constructor(**self.llm_constructor_kwargs)
+
             else:
-                llm_provider = None
+                init_llm_provider = None
             self.auto_suggest = NavigableAutoSuggestFromHistory()
             # Provisinal in 8.32
-            self.auto_suggest._llm_provider = llm_provider
+            self.auto_suggest._init_llm_provider = init_llm_provider
 
             name = self.llm_prefix_from_history
 

--- a/examples/auto_suggest_llm.py
+++ b/examples/auto_suggest_llm.py
@@ -68,13 +68,13 @@ import asyncio
 import textwrap
 from typing import Any, AsyncIterable, AsyncIterator
 
-from jupyter_ai.completions.models import (
+from jupyter_ai_magics.models.completion import (
     InlineCompletionList,
     InlineCompletionReply,
     InlineCompletionRequest,
     InlineCompletionStreamChunk,
 )
-from jupyter_ai_magics import BaseProvider
+from jupyter_ai_magics.providers import BaseProvider
 from langchain_community.llms import FakeListLLM
 
 

--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -1,4 +1,5 @@
 import asyncio
+from time import sleep
 
 try:
     from jupyter_ai_magics import BaseProvider
@@ -87,3 +88,16 @@ class FibonacciCompletionProvider(BaseProvider, FakeListLLM):  # type: ignore[mi
             reply_to=request_number,
             done=True,
         )
+
+
+class SlowStartingCompletionProvider(BaseProvider, FakeListLLM):  # type: ignore[misc, valid-type]
+    id = "slow_provider"
+    name = "Slow Provider"
+    model_id_key = "model"
+    models = ["model_a"]
+
+    def __init__(self, **kwargs):
+        kwargs["responses"] = ["This fake response will be used for completion"]
+        kwargs["model_id"] = "model_a"
+        sleep(10)
+        super().__init__(**kwargs)

--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -2,7 +2,7 @@ import asyncio
 from time import sleep
 
 try:
-    from jupyter_ai_magics import BaseProvider
+    from jupyter_ai_magics.providers import BaseProvider
     from langchain_community.llms import FakeListLLM
 except ImportError:
 

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from IPython.terminal.interactiveshell import PtkHistoryAdapter
 from IPython.terminal.shortcuts.auto_suggest import (
     accept,
@@ -59,6 +60,17 @@ async def test_llm_autosuggestion():
     event.current_buffer.insert_text(text, move_cursor=True)
     await llm_autosuggestion(event)
     assert event.current_buffer.suggestion.text == FIBONACCI[len(text) :]
+
+
+def test_slow_llm_provider_should_not_block_init():
+    ip = get_ipython()
+    provider = NavigableAutoSuggestFromHistory()
+    ip.auto_suggest = provider
+    start = time.perf_counter()
+    ip.llm_provider_class = "tests.fake_llm.SlowStartingCompletionProvider"
+    end = time.perf_counter()
+    elapsed = end - start
+    assert elapsed < 0.1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] Add a failing test
- [x] Delay LLM loading to the first invocation
- [x] Update recommended import paths

Results with `ExampleCompletionProvider`:

| Before | After |
|--|--|
| 2.189 s ±  0.019 s | 623.9 ms ±  14.7 ms |


<details>

Before

```bash
Benchmark 1: ipython --TerminalInteractiveShell.llm_provider_class=examples.auto_suggest_llm.ExampleCompletionProvider -c exit
  Time (mean ± σ):      2.189 s ±  0.019 s    [User: 3.848 s, System: 0.286 s]
  Range (min … max):    2.171 s …  2.226 s    10 runs
```


After

```bash
Benchmark 1: ipython --TerminalInteractiveShell.llm_provider_class=examples.auto_suggest_llm.ExampleCompletionProvider -c exit
  Time (mean ± σ):     623.9 ms ±  14.7 ms    [User: 480.7 ms, System: 130.6 ms]
  Range (min … max):   600.0 ms … 650.6 ms    10 runs

```

</details>