### PR TITLE
Implement auto-import and evaluation policy overrides

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -475,7 +475,7 @@ class TerminalInteractiveShell(InteractiveShell):
         allow_none=True,
         help="""\
         Provisional:
-            This is a provisinal API in IPython 8.32, before stabilisation
+            This is a provisional API in IPython 8.32, before stabilisation
             in 9.0, it may change without warnings.
 
         class to use for the `NavigableAutoSuggestFromHistory` to request

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -1,5 +1,6 @@
 import sys
 from contextlib import contextmanager
+from importlib import import_module
 from typing import (
     Annotated,
     AnyStr,
@@ -780,3 +781,19 @@ def test_module_access():
     context = minimal(numpy=numpy)
     with pytest.raises(GuardRejection):
         guarded_eval("np.linalg.norm", context)
+
+
+def test_autoimport_module():
+    context = EvaluationContext(
+        locals={}, globals={}, evaluation="limited", auto_import=import_module
+    )
+    pi = guarded_eval("math.pi", context)
+    assert round(pi, 2) == 3.14
+
+
+def test_autoimport_deep_module():
+    context = EvaluationContext(
+        locals={}, globals={}, evaluation="limited", auto_import=import_module
+    )
+    ElementTree = guarded_eval("xml.etree.ElementTree", context)
+    assert hasattr(ElementTree, "ElementTree")

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -785,7 +785,11 @@ def test_module_access():
 
 def test_autoimport_module():
     context = EvaluationContext(
-        locals={}, globals={}, evaluation="limited", auto_import=import_module
+        locals={},
+        globals={},
+        evaluation="limited",
+        auto_import=import_module,
+        policy_overrides={"allow_auto_import": True},
     )
     pi = guarded_eval("math.pi", context)
     assert round(pi, 2) == 3.14
@@ -793,7 +797,11 @@ def test_autoimport_module():
 
 def test_autoimport_deep_module():
     context = EvaluationContext(
-        locals={}, globals={}, evaluation="limited", auto_import=import_module
+        locals={},
+        globals={},
+        evaluation="limited",
+        auto_import=import_module,
+        policy_overrides={"allow_auto_import": True},
     )
     ElementTree = guarded_eval("xml.etree.ElementTree", context)
     assert hasattr(ElementTree, "ElementTree")


### PR DESCRIPTION
- Closes #14909
- Closes #14642

The default implementation uses simply `importlib.import_module`; this is useful in multi-line code where the import is included in one of the previous lines.

Previously when jedi was disabled no completions would be offered:

![image](https://github.com/user-attachments/assets/f6a4fa52-92d4-43cd-8571-9f7c6cb4890d)

with this PR if auto-import is enabled, e.g. with:

```
ipython --Completer.policy_overrides='{"allow_auto_import": True}' --Completer.use_jedi=False
```

The completions are shown:

![image](https://github.com/user-attachments/assets/3e94d6b0-220a-4e7b-8b15-c6d79beb8368)

This already worked with jedi enabled:

![image](https://github.com/user-attachments/assets/b7230ec2-96c9-4c74-ae0b-f7e12aa2acfd)

but now it is possible to also have this behaviour with jedi disabled.

The default implementation does NOT populate the user namespace with the imported modules.