### PR TITLE
fix for deduperreload global env in case of function decorator from imported module

### DIFF
--- a/IPython/extensions/deduperreload/deduperreload.py
+++ b/IPython/extensions/deduperreload/deduperreload.py
@@ -432,16 +432,7 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
                     func_code = "class __autoreload_class__:\n" + textwrap.indent(
                         func_code, "    "
                     )
-                global_env = namespace_to_check.__dict__
-                if hasattr(to_patch_to, "__globals__"):
-                    global_env = to_patch_to.__globals__
-                elif isinstance(to_patch_to, property):
-                    if to_patch_to.fget is not None:
-                        global_env = to_patch_to.fget.__globals__
-                    elif to_patch_to.fset is not None:
-                        global_env = to_patch_to.fset.__globals__
-                    elif to_patch_to.fdel is not None:
-                        global_env = to_patch_to.fdel.__globals__
+                global_env = ns.__dict__
                 if not isinstance(global_env, dict):
                     global_env = dict(global_env)
                 exec(func_code, global_env, local_env)  # type: ignore[arg-type]


### PR DESCRIPTION
## What changes are proposed in this pull request?

In deduperreload, if the function we're patching is decorated by a function coming from another file, we don't want to use the `__globals__` of that function coming from the other file when we exec code, since it won't have the same references as the function we're trying to patch. Actually, I think we always should be using the module's `__dict__` as globals regardless for this case -- so I think we can just delete some code that was trying to be clever around setting the global env.

## How is this tested?
Tested with existing unit tests + added a new one that only passes with the new changes in this PR