### PR TITLE
Support data frames, series and objects with `__len__` in the `%whos` magic

### DIFF
--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -472,7 +472,7 @@ class NamespaceMagics(Magics):
                 print(f"Shape: {var.shape}")
             elif hasattr(var, "__len__"):
                 ## types that can be used in len function
-                print(f"Iterable with n={len(var)}")
+                print(var if isinstance(var, str) else f"n={len(var)}")
             else:
                 try:
                     vstr = str(var)

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -361,6 +361,9 @@ class NamespaceMagics(Magics):
           - For numpy arrays, a summary with shape, number of
             elements, typecode and size in memory.
 
+          - For objects that have shape attribute, primarily dataframe and series like
+            objects, will print the shape.
+
           - Everything else: a string representation, snipping their middle if
             too long.
 

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -458,8 +458,8 @@ class NamespaceMagics(Magics):
                     if vbytes < Mb:
                         print('(%s kb)' % (vbytes/kb,))
                     else:
-                        print('(%s Mb)' % (vbytes/Mb,))
-            elif hasattr(var,'shape'):
+                        print("(%s Mb)" % (vbytes / Mb,))
+            elif hasattr(var, "shape"):
                 # Useful for DataFrames and Series
                 # Ought to work for both pandas and polars
                 print(f"Shape: {var.shape}")

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -372,11 +372,17 @@ class NamespaceMagics(Magics):
 
           In [2]: beta = 'test'
 
-          In [3]: %whos
+          In [3]: df = pd.DataFrame({"a": range(10), "b": range(10,20)})
+
+          In [4]: s = df["a"]
+
+          In [5]: %whos
           Variable   Type        Data/Info
           --------------------------------
           alpha      int         123
           beta       str         test
+          df         DataFrame   Shape: (10, 2)
+          s          Series      Shape: (10, )
         """
 
         varnames = self.who_ls(parameter_s)

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -459,6 +459,10 @@ class NamespaceMagics(Magics):
                         print('(%s kb)' % (vbytes/kb,))
                     else:
                         print('(%s Mb)' % (vbytes/Mb,))
+            elif hasattr(var,'shape'):
+                # Useful for DataFrames and Series
+                # Ought to work for both pandas and polars
+                print(f"Shape: {var.shape}")
             else:
                 try:
                     vstr = str(var)

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -450,9 +450,7 @@ class NamespaceMagics(Magics):
         Mb = 1048576  # kb**2
         for vname,var,vtype in zip(varnames,varlist,typelist):
             print(vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth), end=' ')
-            if vtype in seq_types:
-                print("n="+str(len(var)))
-            elif vtype == ndarray_type:
+            if vtype == ndarray_type:
                 vshape = str(var.shape).replace(',','').replace(' ','x')[1:-1]
                 if vtype==ndarray_type:
                     # numpy
@@ -472,6 +470,9 @@ class NamespaceMagics(Magics):
                 # Useful for DataFrames and Series
                 # Ought to work for both pandas and polars
                 print(f"Shape: {var.shape}")
+            elif hasattr(var, "__len__"):
+                ## types that can be used in len function
+                print(f"Iterable with n={len(var)}")
             else:
                 try:
                     vstr = str(var)


### PR DESCRIPTION
This modification shows the shape of dataframe and series objects instead of printing the dataframe/series objects.

```python
## With this slight modification
[1] a,b,c = 1,2,3
[2] df = pd.DataFrame({"a":range(10),"b":range(10,20)})
[3] s = df["a"]
[4] %whos
Variable   Type         Data/Info
---------------------------------
a          int          1
b          int          2
c          int          3
df         DataFrame    Shape: (10, 2)
s          Series       Shape: (10,)
```

Compare the above to the way it currently prints the output:

```python
## current way 
[1] a,b,c = 1,2,3
[2] df = pd.DataFrame({"a":range(10),"b":range(10,20)})
[3] s = df["a"]
[4] %whos
Variable   Type         Data/Info
---------------------------------
a          int          1
b          int          2
c          int          3
df         DataFrame        a   b\n0   0  10\n1  <...>\n\n[10 rows x 2 columns]
s          Series       0    0\n1    1\n2    2\n <...> Length: 10, dtype: int64
```