### PR TITLE
Fix streaming multi-byte Unicode characters in `%script` magic family

### DIFF
--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1436,7 +1436,7 @@ async def test_script_streams_continuously(capsys):
 def test_script_streams_multibyte_unicode(capsys):
     ip = get_ipython()
     # € in UTF-8 is encoded using 3 bytes
-    code = "print('€' * 1000)"
+    code = "print('€' * 1000, end='')"
     ip.run_cell_magic("script", f"{sys.executable}", code)
 
     captured = capsys.readouterr()

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1402,7 +1402,7 @@ def test_script_defaults():
 
 
 @pytest.mark.asyncio
-async def test_script_streams_continiously(capsys):
+async def test_script_streams_continuously(capsys):
     ip = get_ipython()
     # Windows is slow to start up a thread on CI
     is_windows = os.name == "nt"
@@ -1431,6 +1431,16 @@ async def test_script_streams_continiously(capsys):
     # If the streaming was line-wise or broken
     # we would get `012...`
     assert captured.out == "0.1.2."
+
+
+def test_script_streams_multibyte_unicode(capsys):
+    ip = get_ipython()
+    # € in UTF-8 is encoded using 3 bytes
+    code = "print('€' * 1000)"
+    ip.run_cell_magic("script", f"{sys.executable}", code)
+
+    captured = capsys.readouterr()
+    assert captured.out == '€' * 1000
 
 
 @magics_class

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1440,7 +1440,7 @@ def test_script_streams_multibyte_unicode(capsys):
     ip.run_cell_magic("script", f"{sys.executable}", code)
 
     captured = capsys.readouterr()
-    assert captured.out == '€' * 1000
+    assert captured.out == "€" * 1000
 
 
 @magics_class

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1424,7 +1424,7 @@ async def test_script_streams_continuously(capsys):
     thread = Thread(target=print_numbers)
     thread.start()
     sleep(step / 2)
-    ip.run_cell_magic("script", f"{sys.executable}", code)
+    ip.run_cell_magic("script", sys.executable, code)
     thread.join()
 
     captured = capsys.readouterr()
@@ -1437,7 +1437,12 @@ def test_script_streams_multibyte_unicode(capsys):
     ip = get_ipython()
     # € in UTF-8 is encoded using 3 bytes
     code = "print('€' * 1000, end='')"
-    ip.run_cell_magic("script", f"{sys.executable}", code)
+    is_windows = os.name == "nt"
+    command = sys.executable
+    if is_windows:
+        # windows does not use UTF for streams/pipes by default
+        command += " -X utf8"
+    ip.run_cell_magic("script", command, code)
 
     captured = capsys.readouterr()
     assert captured.out == "€" * 1000


### PR DESCRIPTION
- [x] Adds a test case
- [x] Fixes #14930 