### PR TITLE
Fix printing long strings in %whos magic command.

### DIFF
--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -470,9 +470,9 @@ class NamespaceMagics(Magics):
                 # Useful for DataFrames and Series
                 # Ought to work for both pandas and polars
                 print(f"Shape: {var.shape}")
-            elif hasattr(var, "__len__"):
+            elif hasattr(var, "__len__") and not isinstance(var, str):
                 ## types that can be used in len function
-                print(var if isinstance(var, str) else f"n={len(var)}")
+                print(f"n={len(var)}")
             else:
                 try:
                     vstr = str(var)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -731,22 +731,41 @@ def test_whos():
     _ip.user_ns["a"] = A()
     _ip.run_line_magic("whos", "")
 
-@pytest.mark.parametrize("input,expected",
- ( ("The quick brown fox jumps over the lazy dog", "The quick brown fox jumps over the lazy dog")
-  ,(" ".join(["The quick brown fox jumps over the lazy dog"]*2),  "The quick brown fox jumps<...>x jumps over the lazy dog")
-  ,("\nThis is \n\na long\n\nstring\n", r"\nThis is \n\na long\n\nstring\n")
-  ,("\rThis is \r\ra long\r\rstring\r", r"\rThis is \r\ra long\r\rstring\r") ## TODO (vijay): weird printing? replace with repr?
-  ## ,('\nExamples\n--------\nDefine two variables and list them with whos::\n\n  In [1]: alpha = 123\n\n  In [2]: beta = \'test\'\n\n  In [3]: df = pd.DataFrame({"a": range(10), "b": range(10,20)})\n\n  In [4]: s = df["a"]\n ', r'\nExamples\n--------\nDef<...>  In [4]: s = df["a"]\n') ## TODO (vijay): figure out why this fails...
- ))
-def test_whos_longstr(input,expected):
+
+@pytest.mark.parametrize(
+    "input,expected",
+    (
+        (
+            "The quick brown fox jumps over the lazy dog",
+            "The quick brown fox jumps over the lazy dog",
+        ),
+        (
+            " ".join(["The quick brown fox jumps over the lazy dog"] * 2),
+            "The quick brown fox jumps<...>x jumps over the lazy dog",
+        ),
+        ("\nThis is \n\na long\n\nstring\n", r"\nThis is \n\na long\n\nstring\n"),
+        (
+            "\rThis is \r\ra long\r\rstring\r",
+            r"\rThis is \r\ra long\r\rstring\r",
+        ),  ## TODO (vijay): weird printing? replace with repr?
+        ## ,('\nExamples\n--------\nDefine two variables and list them with whos::\n\n  In [1]: alpha = 123\n\n  In [2]: beta = \'test\'\n\n  In [3]: df = pd.DataFrame({"a": range(10), "b": range(10,20)})\n\n  In [4]: s = df["a"]\n ', r'\nExamples\n--------\nDef<...>  In [4]: s = df["a"]\n') ## TODO (vijay): figure out why this fails...
+    ),
+)
+def test_whos_longstr(input, expected):
     ip = get_ipython()
     ip.user_ns["input"] = input
-    ip.user_ns["expected"] =  expected
+    ip.user_ns["expected"] = expected
     with capture_output() as captured:
-        ip.run_line_magic("whos","")
+        ip.run_line_magic("whos", "")
     stdout = captured.stdout
-    from_whos = " ".join(re.split(r"\s+str\s+",[l for l in stdout.splitlines() if l.startswith('expected') ][0])[1:])
+    from_whos = " ".join(
+        re.split(
+            r"\s+str\s+",
+            [l for l in stdout.splitlines() if l.startswith("expected")][0],
+        )[1:]
+    )
     assert expected == from_whos
+
 
 def doctest_precision():
     """doctest for %precision

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -747,8 +747,7 @@ def test_whos():
         (
             "\rThis is \r\ra long\r\rstring\r",
             r"\rThis is \r\ra long\r\rstring\r",
-        ),  ## TODO (vijay): weird printing? replace with repr?
-        ## ,('\nExamples\n--------\nDefine two variables and list them with whos::\n\n  In [1]: alpha = 123\n\n  In [2]: beta = \'test\'\n\n  In [3]: df = pd.DataFrame({"a": range(10), "b": range(10,20)})\n\n  In [4]: s = df["a"]\n ', r'\nExamples\n--------\nDef<...>  In [4]: s = df["a"]\n') ## TODO (vijay): figure out why this fails...
+        ),
     ),
 )
 def test_whos_longstr(input, expected):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -731,6 +731,20 @@ def test_whos():
     _ip.user_ns["a"] = A()
     _ip.run_line_magic("whos", "")
 
+def test_whos1():
+    ip = get_ipython()
+    ip.user_ns["shortstr"] = "The quick brown fox jumps over the lazy dog"
+    ip.user_ns["longstr"] =  " ".join(["The quick brown fox jumps over the lazy dog"]*2)
+    expected_short = ip.user_ns["shortstr"]
+    expected_long = "The quick brown fox jumps<...>x jumps over the lazy dog"
+    with capture_output() as captured:
+        ip.run_line_magic("whos","")
+    stdout = captured.stdout
+    ## s = " ".join([l for l in stdout.splitlines() if l.startswith('longstr') ][0].split()[2:])
+    long = " ".join(re.split(r"\s+str\s+",[l for l in stdout.splitlines() if l.startswith('longstr') ][0])[1:])
+    short = " ".join(re.split(r"\s+str\s+",[l for l in stdout.splitlines() if l.startswith('shortstr') ][0])[1:])
+    assert long == expected_long
+    assert short == expected_short
 
 def doctest_precision():
     """doctest for %precision

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -731,20 +731,22 @@ def test_whos():
     _ip.user_ns["a"] = A()
     _ip.run_line_magic("whos", "")
 
-def test_whos1():
+@pytest.mark.parametrize("input,expected",
+ ( ("The quick brown fox jumps over the lazy dog", "The quick brown fox jumps over the lazy dog")
+  ,(" ".join(["The quick brown fox jumps over the lazy dog"]*2),  "The quick brown fox jumps<...>x jumps over the lazy dog")
+  ,("\nThis is \n\na long\n\nstring\n", r"\nThis is \n\na long\n\nstring\n")
+  ,("\rThis is \r\ra long\r\rstring\r", r"\rThis is \r\ra long\r\rstring\r") ## TODO (vijay): weird printing? replace with repr?
+  ## ,('\nExamples\n--------\nDefine two variables and list them with whos::\n\n  In [1]: alpha = 123\n\n  In [2]: beta = \'test\'\n\n  In [3]: df = pd.DataFrame({"a": range(10), "b": range(10,20)})\n\n  In [4]: s = df["a"]\n ', r'\nExamples\n--------\nDef<...>  In [4]: s = df["a"]\n') ## TODO (vijay): figure out why this fails...
+ ))
+def test_whos_longstr(input,expected):
     ip = get_ipython()
-    ip.user_ns["shortstr"] = "The quick brown fox jumps over the lazy dog"
-    ip.user_ns["longstr"] =  " ".join(["The quick brown fox jumps over the lazy dog"]*2)
-    expected_short = ip.user_ns["shortstr"]
-    expected_long = "The quick brown fox jumps<...>x jumps over the lazy dog"
+    ip.user_ns["input"] = input
+    ip.user_ns["expected"] =  expected
     with capture_output() as captured:
         ip.run_line_magic("whos","")
     stdout = captured.stdout
-    ## s = " ".join([l for l in stdout.splitlines() if l.startswith('longstr') ][0].split()[2:])
-    long = " ".join(re.split(r"\s+str\s+",[l for l in stdout.splitlines() if l.startswith('longstr') ][0])[1:])
-    short = " ".join(re.split(r"\s+str\s+",[l for l in stdout.splitlines() if l.startswith('shortstr') ][0])[1:])
-    assert long == expected_long
-    assert short == expected_short
+    from_whos = " ".join(re.split(r"\s+str\s+",[l for l in stdout.splitlines() if l.startswith('expected') ][0])[1:])
+    assert expected == from_whos
 
 def doctest_precision():
     """doctest for %precision


### PR DESCRIPTION
In trying to improve printing for dataframe and series objects, in pull request #14926, i inadvertently messed up printing of long strings...sorry!

This change fixes that issue.

```python
## Does not mess up long strings
In [1]: sunday_qry = """
   ...: with
   ...:     df as (select unnest(generate_series(date '1900-01-01',date '2100-12-31',interval 1 day)) as dt)
   ...:   select * from df where extract(dayofweek from dt)=0;
   ...: """
   ...:

In [2]: df = pd.DataFrame({"a": range(10), "b": range(10,20),"c":list(string.ascii_letters[:10])})
In [3]: %whos
Variable     Type         Data/Info
-----------------------------------
df           DataFrame    Shape: (10, 3)
sunday_qry   str          \nwith\n    df as (select<...>t(dayofweek from dt)=0;\n
In [4]:
"""
```

Compare this to what it currently does.
```python
## inadvertently messed up in #14926 
In [1]: sunday_qry = """
   ...: with
   ...:     df as (select unnest(generate_series(date '1900-01-01',date '2100-12-31',interval 1 day)) as dt)
   ...:   select * from df where extract(dayofweek from dt)=0;
   ...: """
   ...:

In [2]: df = pd.DataFrame({"a": range(10), "b": range(10,20),"c":list(string.ascii_letters[:10])})
In [3]: %whos
Variable      Type             Data/Info
----------------------------------------
df            DataFrame        Shape: (10, 3)
sunday_qry    str
with
    df as (select unnest(generate_series(date '1900-01-01',date '2100-12-31',interval 1 day)) as dt)
  select * from df where extract(dayofweek from dt)=0;

In [4]:
```