### PR TITLE
Remove pytest-asyncio pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         python -m pip install --only-binary ':all:' --upgrade pip setuptools wheel build
         python -m pip install --only-binary ':all:' --no-binary curio --upgrade -e .[${{ matrix.deps }}]
-        python -m pip install --only-binary ':all:' --upgrade check-manifest pytest-cov  'pytest<8'
+        python -m pip install --only-binary ':all:' --upgrade check-manifest pytest-cov pytest
     - name: Install and update Python dependencies (dev?)
       if: ${{ contains( matrix.python-version, 'dev' ) }}
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ doc = [
 ]
 test = [
     "pytest",
-    "pytest-asyncio<0.22",
+    "pytest-asyncio",
     "testpath",
     "packaging",
 ]


### PR DESCRIPTION
The downstream `ipykernel` tests using the recent changes on the `main` branch there are failing here with
```bash
ERROR tests/inprocess/test_kernel.py::test_do_execute - DeprecationWarning: pytest-asyncio detected an unclosed event loop when tearing down the event_loop
fixture: <_UnixSelectorEventLoop running=False closed=False debug=False>
pytest-asyncio will close the event loop for you, but future versions of the
library will no longer do so. In order to ensure compatibility with future
versions, please make sure that:
    1. Any custom "event_loop" fixture properly closes the loop after yielding it
    2. The scopes of your custom "event_loop" fixtures do not overlap
    3. Your code does not modify the event loop in async fixtures or tests
=========================== 184 passed, 19 skipped, 1 warning, 1 error in 102.33s (0:01:42) ============================
```

Currently we pin `pytest-asyncio<0.22` here whereas in `ipykernel` we use `pytest-asyncio>=0.23.5` so the two pins are not compatible. Both projects do not pin `pytest` so use `8.4.1`.

According to the `pytest-asyncio` [changelog](https://pytest-asyncio.readthedocs.io/en/stable/reference/changelog.html#id40) for compatibility with `pytest>=8` we need at least `pytest-asyncio>=0.23.5`.

If I remove the `pytest-asyncio` pin locally then all tests pass on both Ubuntu and macOS, so this PR is seeing what happens without the pin on the full CI matrix.