### PR TITLE
Simplify overriding selective evaluation policy settings for modules

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -222,7 +222,6 @@ from IPython.utils import generics
 from IPython.utils.PyColorize import theme_table
 from IPython.utils.decorators import sphinx_options
 from IPython.utils.dir2 import dir2, get_real_method
-from IPython.utils.docs import GENERATING_DOCUMENTATION
 from IPython.utils.path import ensure_dir_exists
 from IPython.utils.process import arg_split
 from traitlets import (
@@ -1313,14 +1312,19 @@ class Completer(Configurable):
                     ),
                 )
                 done = True
-            except Exception as e:
-                if self.debug:
-                    print("Evaluation exception", e)
+            except (SyntaxError, TypeError):
+                # TypeError can show up with something like `+ d`
+                # where `d` is a dictionary.
+
                 # trim the expression to remove any invalid prefix
                 # e.g. user starts `(d[`, so we get `expr = '(d'`,
                 # where parenthesis is not closed.
                 # TODO: make this faster by reusing parts of the computation?
                 expr = self._trim_expr(expr)
+            except Exception as e:
+                if self.debug:
+                    print("Evaluation exception", e)
+                done = True
         return obj
 
     @property
@@ -1330,6 +1334,7 @@ class Completer(Configurable):
         if not hasattr(self, "_auto_import_func"):
             self._auto_import_func = import_item(self.auto_import_method)
         return self._auto_import_func
+
 
 def get__all__entries(obj):
     """returns the strings in the __all__ attribute"""

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -139,11 +139,6 @@ def _get_external(module_name: str, access_path: Sequence[str]):
         module_path = ".".join([module_name, *access_path])
         if module_path in sys.modules:
             return sys.modules[module_path]
-        # handle objects in namespace packages
-        if len(access_path) > 1:
-            module_path = ".".join([module_name, *access_path[:-1]])
-            attr = access_path[-1]
-            return sys.modules[module_path][attr]
         raise
 
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -8,6 +8,7 @@ import os
 import pytest
 import sys
 import textwrap
+import types
 import unittest
 import random
 
@@ -1402,6 +1403,40 @@ class TestCompleter(unittest.TestCase):
         ):
             _, matches = complete(line_buffer="math.")
             self.assertNotIn(".pi", matches)
+
+    def test_completion_allow_custom_getattr_per_module(self):
+        factory_code = textwrap.dedent(
+            """
+        class ListFactory:
+            def __getattr__(self, attr):
+                return []
+        """
+        )
+
+        safe_lib = types.ModuleType("my.safe.lib")
+        sys.modules["my.safe.lib"] = safe_lib
+        exec(factory_code, safe_lib.__dict__)
+
+        unsafe_lib = types.ModuleType("my.unsafe.lib")
+        sys.modules["my.unsafe.lib"] = unsafe_lib
+        exec(factory_code, unsafe_lib.__dict__)
+
+        ip = get_ipython()
+        ip.user_ns["safe_list_factory"] = safe_lib.ListFactory()
+        ip.user_ns["unsafe_list_factory"] = unsafe_lib.ListFactory()
+        complete = ip.Completer.complete
+        with (
+            evaluation_policy(
+                "limited", allowed_getattr_external={("my", "safe", "lib")}
+            ),
+            jedi_status(False),
+        ):
+            _, matches = complete(line_buffer="safe_list_factory.example.")
+            self.assertIn(".append", matches)
+            # this also checks against https://github.com/ipython/ipython/issues/14916
+            # because removing "un" would caus this test to incorrectly pass
+            _, matches = complete(line_buffer="unsafe_list_factory.example.")
+            self.assertNotIn(".append", matches)
 
     def test_dict_key_completion_bytes(self):
         """Test handling of bytes in dict key completion"""


### PR DESCRIPTION
### References

- closes #14940
- fixes #14916

### Code changes

- allow to pass module-level allow list for attribute evaluation
- allows to pass allow-lists using dotted paths rather than tuples; this is especially helpful to avoid a common mistake of passing `("my")` where `("my", )` would have been expected before
- fixes issue with invalid prefix trimming which came up again when writing tests for this PR

### User-facing changes

It is now possible to enable eager attribute evaluation in completer on an entire package with:

```python
c.Completer.policy_overrides = {
    "allowed_getattr_external": {
        "my_trusted_library"
    }
}
```