### PR TITLE
Test pyflyby on CI as a downstream project

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -81,7 +81,8 @@ jobs:
         git clone https://github.com/deshaw/pyflyby
         cd pyflyby
         pip install -e .
-        pip install 'pytest<=8'
+        # TODO: use [test] group instead once available
+        pip install 'pytest<=8' requests
         cd ..
     - name: Test pyflyby (IPython integration only)
       run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -87,4 +87,4 @@ jobs:
     - name: Test pyflyby (IPython integration only)
       run: |
         cd ../pyflyby
-        pytest tests/test_interactive.py
+        pytest tests/test_interactive.py -k 'not test_timeit_complete_autoimport_member_1'

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -75,3 +75,14 @@ jobs:
         # cd ../sage/
         # # From https://github.com/sagemath/sage/blob/develop/pkgs/sagemath-repl/tox.ini
         # sage-runtests -p --environment=sage.all__sagemath_repl --baseline-stats-path=pkgs/sagemath-repl/known-test-failures.json --initial --optional=sage src/sage/repl src/sage/doctest src/sage/misc/sage_input.py src/sage/misc/sage_eval.py
+    - name: Install pyflyby
+      run: |
+        cd ..
+        git clone https://github.com/deshaw/pyflyby
+        cd pyflyby
+        pip install -e .[test]
+        cd ..
+    - name: Test pyflyby (IPython integration only)
+      run: |
+        cd ../pyflyby
+        pytest tests/test_interactive.py

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -80,7 +80,8 @@ jobs:
         cd ..
         git clone https://github.com/deshaw/pyflyby
         cd pyflyby
-        pip install -e .[test]
+        pip install -e .
+        pip install 'pytest<=8'
         cd ..
     - name: Test pyflyby (IPython integration only)
       run: |


### PR DESCRIPTION
`pyflyby` includes an extension to IPython which integrates tightly with a substantial part of the IPython API.

Previous IPython releases broke `pyflyby` functionality; this may be acceptable if it happens in major releases, but there were instances were minor releases introduced incompatibilities which lead to downstream breakages.

This PR includes a single `pyflyby` test file that verifies the IPython-related integration in the downstream testing job. This is meant to serve as a canary test for breaking API changes in the completer, interactive help, and debug magics, all covered in the `pyflyby` test suite.

Should we decide that this is no longer needed, or that it introduces too much noise, this PR could be reverted in the future, but as of now it makes releasing new versions much easier as it alleviates the worry about breaking downstream functionality.

Before merging https://github.com/deshaw/pyflyby/pull/398:

```
======= 5 failed, 114 passed, 30 skipped, 5 xfailed in 193.70s (0:03:13) =======
```

After:

```
======= 8 failed, 134 passed, 14 skipped, 2 xfailed in 344.92s (0:05:44) =======
```