### PR TITLE
Fix traceback logic for non-SyntaxError exceptions in plain mode.

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -363,8 +363,9 @@ class ListTB(TBTools):
                                 [(Token.Caret, s + "^"), (Token, "\n")]
                             )
                         )
-
-            s = self._some_str(value)
+                s = value.msg
+            else:
+                s = self._some_str(value)
             if s:
                 output_list.append(
                     theme_table[self._theme_name].format(

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -364,11 +364,7 @@ class ListTB(TBTools):
                             )
                         )
 
-            try:
-                assert hasattr(value, "msg")
-                s = value.msg
-            except Exception:
-                s = self._some_str(value)
+            s = self._some_str(value)
             if s:
                 output_list.append(
                     theme_table[self._theme_name].format(

--- a/tests/test_ultratb.py
+++ b/tests/test_ultratb.py
@@ -437,6 +437,20 @@ except Exception as e:
             ip.run_cell("%xmode Verbose")
 
 
+class ExceptionMessagePreferenceTest(unittest.TestCase):
+    """
+    Test that exception string representation is preferred over .msg attribute
+    for non-SyntaxError exceptions in %xmode plain.
+    """
+
+    def test_jsondecodeerror_message(self):
+        cell = "import json;json.loads('{\"a\": }')"
+        expected = "JSONDecodeError: Expecting value: line 1 column 7 (char 6)"
+        ip.run_cell("%xmode plain")
+        with tt.AssertPrints(expected):
+            ip.run_cell(cell)
+        ip.run_cell("%xmode context")
+
 # ----------------------------------------------------------------------------
 
 

--- a/tests/test_ultratb.py
+++ b/tests/test_ultratb.py
@@ -451,6 +451,7 @@ class ExceptionMessagePreferenceTest(unittest.TestCase):
             ip.run_cell(cell)
         ip.run_cell("%xmode context")
 
+
 # ----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
### Fixes #14962 

### Code changes
The .msg attribute handling is now restricted to SyntaxError exceptions only.