### PR TITLE
Fix exceptions in `whos` magic command

### DIFF
--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -361,8 +361,7 @@ class NamespaceMagics(Magics):
           - For numpy arrays, a summary with shape, number of
             elements, typecode and size in memory.
 
-          - For objects that have shape attribute, primarily dataframe and series like
-            objects, will print the shape.
+          - For DataFrame and Series types: their shape.
 
           - Everything else: a string representation, snipping their middle if
             too long.
@@ -450,7 +449,9 @@ class NamespaceMagics(Magics):
         Mb = 1048576  # kb**2
         for vname,var,vtype in zip(varnames,varlist,typelist):
             print(vformat.format(vname, vtype, varwidth=varwidth, typewidth=typewidth), end=' ')
-            if vtype == ndarray_type:
+            if vtype in seq_types:
+                print("n="+str(len(var)))
+            elif vtype == ndarray_type:
                 vshape = str(var.shape).replace(',','').replace(' ','x')[1:-1]
                 if vtype==ndarray_type:
                     # numpy
@@ -465,14 +466,11 @@ class NamespaceMagics(Magics):
                     if vbytes < Mb:
                         print('(%s kb)' % (vbytes/kb,))
                     else:
-                        print("(%s Mb)" % (vbytes / Mb,))
-            elif hasattr(var, "shape"):
+                        print('(%s Mb)' % (vbytes/Mb,))
+            elif vtype in ['DataFrame', 'Series']:
                 # Useful for DataFrames and Series
                 # Ought to work for both pandas and polars
                 print(f"Shape: {var.shape}")
-            elif hasattr(var, "__len__") and not isinstance(var, str):
-                ## types that can be used in len function
-                print(f"n={len(var)}")
             else:
                 try:
                     vstr = str(var)

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -464,9 +464,9 @@ class NamespaceMagics(Magics):
                 else:
                     print(aformat % (vshape, vsize, vdtype, vbytes), end=' ')
                     if vbytes < Mb:
-                        print("(%s kb)" % (vbytes/kb,))
+                        print("(%s kb)" % (vbytes / kb,))
                     else:
-                        print("(%s Mb)" % (vbytes/Mb,))
+                        print("(%s Mb)" % (vbytes / Mb,))
             elif vtype in ["DataFrame", "Series"]:
                 # Useful for DataFrames and Series
                 # Ought to work for both pandas and polars

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -464,10 +464,10 @@ class NamespaceMagics(Magics):
                 else:
                     print(aformat % (vshape, vsize, vdtype, vbytes), end=' ')
                     if vbytes < Mb:
-                        print('(%s kb)' % (vbytes/kb,))
+                        print("(%s kb)" % (vbytes/kb,))
                     else:
-                        print('(%s Mb)' % (vbytes/Mb,))
-            elif vtype in ['DataFrame', 'Series']:
+                        print("(%s Mb)" % (vbytes/Mb,))
+            elif vtype in ["DataFrame", "Series"]:
                 # Useful for DataFrames and Series
                 # Ought to work for both pandas and polars
                 print(f"Shape: {var.shape}")


### PR DESCRIPTION
Correction for handling for Pandas and Polars DataFrame and Series types for the %whos magic command. This small change reverts the most recent changes to **namespace.py**, and relative to IPython version 8.26.0 (from my Python 3.12 install), simply adds a two-line **elif** clause to specifically handle the case of **DataFrame** and **Series** types, as found in Pandas and Polars. The existing code looks too generally for variables with 'shape' and '\_\_len\_\_' attributes, which unintentionally catches some modules and other items, and causes exceptions. It also unintentionally hijacks correct 'default' handling of strings and other types.

The change here is focused directly and only on the **DataFrame** and **Series** types, and if found, shows their shape attribute. Processing of all other types is left unchanged from 8.26.0.

Please see discussion at Issue #14952.

Note, this is my first real GitHub pull request, so please let me know if I've done anything incorrectly, or left out any steps, as I would like to learn from this experience!