### PR TITLE
Add module ignoring functionality to debugger

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -1107,6 +1107,21 @@ class Pdb(OldPdb):
                         ]
                     )
                 )
+        if self.skip and self.is_skipped_module(frame.f_globals.get("__name__", "")):
+            print(
+                self.theme.format(
+                    [
+                        (
+                            Token.ExcName,
+                            "    [... skipped 1 ignored module(s)]",
+                        ),
+                        (Token, "\n"),
+                    ]
+                )
+            )
+
+            return False
+
         return super().stop_here(frame)
 
     def do_up(self, arg):

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -1114,10 +1114,10 @@ class Pdb(OldPdb):
         Move the current frame count (default one) levels up in the
         stack trace (to an older frame).
 
-        Will skip hidden frames.
+        Will skip hidden frames and ignored modules.
         """
         # modified version of upstream that skips
-        # frames with __tracebackhide__
+        # frames with __tracebackhide__ and ignored modules
         if self.curindex == 0:
             self.error("Oldest frame")
             return
@@ -1126,15 +1126,27 @@ class Pdb(OldPdb):
         except ValueError:
             self.error("Invalid frame count (%s)" % arg)
             return
-        skipped = 0
+
+        hidden_skipped = 0
+        module_skipped = 0
+
         if count < 0:
             _newframe = 0
         else:
             counter = 0
             hidden_frames = self.hidden_frames(self.stack)
+
             for i in range(self.curindex - 1, -1, -1):
-                if hidden_frames[i] and self.skip_hidden:
-                    skipped += 1
+                should_skip_hidden = hidden_frames[i] and self.skip_hidden
+                should_skip_module = self.skip and self.is_skipped_module(
+                    self.stack[i][0].f_globals.get("__name__", "")
+                )
+
+                if should_skip_hidden or should_skip_module:
+                    if should_skip_hidden:
+                        hidden_skipped += 1
+                    if should_skip_module:
+                        module_skipped += 1
                     continue
                 counter += 1
                 if counter >= count:
@@ -1142,19 +1154,21 @@ class Pdb(OldPdb):
             else:
                 # if no break occurred.
                 self.error(
-                    "all frames above hidden, use `skip_hidden False` to get get into those."
+                    "all frames above skipped (hidden frames and ignored modules). Use `skip_hidden False` for hidden frames or unignore_module for ignored modules."
                 )
                 return
 
             _newframe = i
         self._select_frame(_newframe)
-        if skipped:
+
+        total_skipped = hidden_skipped + module_skipped
+        if total_skipped:
             print(
                 self.theme.format(
                     [
                         (
                             Token.ExcName,
-                            f"    [... skipped {skipped} hidden frame(s)]",
+                            f"    [... skipped {total_skipped} frame(s): {hidden_skipped} hidden frames + {module_skipped} ignored modules]",
                         ),
                         (Token, "\n"),
                     ]
@@ -1166,7 +1180,7 @@ class Pdb(OldPdb):
         Move the current frame count (default one) levels down in the
         stack trace (to a newer frame).
 
-        Will skip hidden frames.
+        Will skip hidden frames and ignored modules.
         """
         if self.curindex + 1 == len(self.stack):
             self.error("Newest frame")
@@ -1180,28 +1194,39 @@ class Pdb(OldPdb):
             _newframe = len(self.stack) - 1
         else:
             counter = 0
-            skipped = 0
+            hidden_skipped = 0
+            module_skipped = 0
             hidden_frames = self.hidden_frames(self.stack)
+
             for i in range(self.curindex + 1, len(self.stack)):
-                if hidden_frames[i] and self.skip_hidden:
-                    skipped += 1
+                should_skip_hidden = hidden_frames[i] and self.skip_hidden
+                should_skip_module = self.skip and self.is_skipped_module(
+                    self.stack[i][0].f_globals.get("__name__", "")
+                )
+
+                if should_skip_hidden or should_skip_module:
+                    if should_skip_hidden:
+                        hidden_skipped += 1
+                    if should_skip_module:
+                        module_skipped += 1
                     continue
                 counter += 1
                 if counter >= count:
                     break
             else:
                 self.error(
-                    "all frames below hidden, use `skip_hidden False` to get get into those."
+                    "all frames below skipped (hidden frames and ignored modules). Use `skip_hidden False` for hidden frames or unignore_module for ignored modules."
                 )
                 return
 
-            if skipped:
+            total_skipped = hidden_skipped + module_skipped
+            if total_skipped:
                 print(
                     self.theme.format(
                         [
                             (
                                 Token.ExcName,
-                                f"    [... skipped {skipped} hidden frame(s)]",
+                                f"    [... skipped {total_skipped} frame(s): {hidden_skipped} hidden frames + {module_skipped} ignored modules]",
                             ),
                             (Token, "\n"),
                         ]
@@ -1213,6 +1238,63 @@ class Pdb(OldPdb):
 
     do_d = do_down
     do_u = do_up
+
+    def _show_ignored_modules(self):
+        """Display currently ignored modules."""
+        if self.skip:
+            print(f"Currently ignored modules: {sorted(self.skip)}")
+        else:
+            print("No modules are currently ignored.")
+
+    def do_ignore_module(self, arg):
+        """ignore_module <module_name>
+
+        Add a module to the list of modules to skip when navigating frames.
+        When a module is ignored, the debugger will automatically skip over
+        frames from that module.
+
+        Supports wildcard patterns using fnmatch syntax:
+
+        Usage:
+            ignore_module threading     # Skip threading module frames
+            ignore_module asyncio.\\*    # Skip all asyncio submodules
+            ignore_module \\*.tests      # Skip all test modules
+            ignore_module               # List currently ignored modules
+        """
+
+        if self.skip is None:
+            self.skip = set()
+
+        module_name = arg.strip()
+
+        if not module_name:
+            self._show_ignored_modules()
+            return
+
+        self.skip.add(module_name)
+
+    def do_unignore_module(self, arg):
+        """unignore_module <module_name>
+
+        Remove a module from the list of modules to skip when navigating frames.
+        This will allow the debugger to step into frames from the specified module.
+
+        Usage:
+            unignore_module threading   # Stop ignoring threading module frames
+            unignore_module asyncio.\\*  # Remove asyncio.* pattern
+            unignore_module             # List currently ignored modules
+        """
+
+        if self.skip is None:
+            self.skip = set()
+
+        module_name = arg.strip()
+
+        if not module_name:
+            self._show_ignored_modules()
+            return
+
+        self.skip.remove(module_name)
 
     def do_context(self, context: str):
         """context number_of_lines

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -1294,7 +1294,11 @@ class Pdb(OldPdb):
             self._show_ignored_modules()
             return
 
-        self.skip.remove(module_name)
+        try:
+            self.skip.remove(module_name)
+        except KeyError:
+            print(f"Module {module_name} is not currently ignored")
+            self._show_ignored_modules()
 
     def do_context(self, context: str):
         """context number_of_lines

--- a/docs/source/interactive/reference.rst
+++ b/docs/source/interactive/reference.rst
@@ -820,6 +820,65 @@ And less context on shallower Stack Trace:
     <ipython-input-5-7baadc3d1465>(5)foo()
     ----> 5     return 1/x+foo(x-1)
 
+Module Ignoring Commands
+------------------------
+
+IPython's debugger provides commands to ignore specific modules when navigating
+through stack frames. This is particularly useful when debugging applications
+that use frameworks or libraries where you want to skip over their internal
+code and focus on your application logic.
+
+The module ignoring system supports wildcard patterns using Python's ``fnmatch``
+syntax, allowing you to ignore groups of related modules with a single pattern.
+
+ignore_module <module_name>
+++++++++++++++++++++++++++++
+
+Add a module to the list of modules to skip when navigating frames. When a module
+is ignored, the debugger will automatically skip over frames from that module when
+using the ``next``, ``step``, ``continue``, ``up`` and ``down`` commands.
+
+**Usage:**
+
+.. code::
+
+    ipdb> ignore_module threading
+    ipdb> ignore_module __main__
+    ipdb> ignore_module asyncio.*      # Ignore all asyncio submodules
+    ipdb> ignore_module *.tests        # Ignore all test modules
+    ipdb> ignore_module django.*       # Ignore all django modules
+    ipdb> ignore_module  # List currently ignored modules
+    Currently ignored modules: ['__main__', 'asyncio.*', 'django.*', 'threading']
+
+**Wildcard Pattern Examples:**
+
+- ``asyncio.*`` - Matches ``asyncio.tasks``, ``asyncio.events``, etc.
+- ``*.tests`` - Matches ``myapp.tests``, ``utils.tests``, etc.
+- ``test_*`` - Matches ``test_models``, ``test_views``, etc.
+- ``django.*`` - Matches all Django framework modules
+- ``*pytest*`` - Matches any module containing "pytest"
+
+**Common use cases:**
+
+- Ignore framework code (e.g., ``django.*``, ``flask.*``, ``asyncio.*``)
+- Skip standard library modules (e.g., ``threading``, ``multiprocessing``, ``logging.*``)
+- Hide main module frames (``__main__``) to focus on function implementations
+- Skip test framework internals (``*pytest*``, ``unittest.*``)
+
+unignore_module <module_name>
++++++++++++++++++++++++++++++
+
+Remove a module from the list of modules to skip when navigating frames. This
+allows the debugger to step into frames from the specified module again.
+
+**Usage:**
+
+.. code::
+
+    ipdb> unignore_module threading
+    ipdb> unignore_module asyncio.*    # Remove the pattern
+    ipdb> unignore_module  # List currently ignored modules
+    Currently ignored modules: ['__main__']
 
 Post-mortem debugging
 ---------------------

--- a/tests/test_debug_magic.py
+++ b/tests/test_debug_magic.py
@@ -75,7 +75,7 @@ def test_debug_magic_passes_through_generators():
     child.expect(ipdb_prompt)
     child.sendline("u")
     child.expect_exact(
-        "*** all frames above hidden, use `skip_hidden False` to get get into those."
+        "*** all frames above skipped (hidden frames and ignored modules). Use `skip_hidden False` for hidden frames or unignore_module for ignored modules."
     )
 
     child.expect(ipdb_prompt)

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -7,8 +7,9 @@ import builtins
 import os
 import sys
 import platform
+from pathlib import Path
 
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -625,3 +626,314 @@ def test_where_erase_value():
     child.expect("ipdb>")
 
     child.close()
+
+
+@skip_win32
+def test_ignore_module_basic_functionality():
+    """Test basic ignore/unignore functionality and error handling."""
+    import pexpect
+
+    env = os.environ.copy()
+    env["IPY_TEST_SIMPLE_PROMPT"] = "1"
+
+    with TemporaryDirectory() as temp_dir:
+        main_path = create_test_modules(temp_dir)
+
+        child = pexpect.spawn(sys.executable, [main_path], env=env, cwd=temp_dir)
+        child.timeout = 15 * IPYTHON_TESTING_TIMEOUT_SCALE
+        child.expect("ipdb>")
+
+        # Test listing modules when none are ignored
+        child.sendline("ignore_module")
+        child.expect_exact("No modules are currently ignored.")
+        child.expect("ipdb>")
+
+        # Test ignoring a module
+        child.sendline("ignore_module level2_module")
+        child.expect("ipdb>")
+
+        # Test listing ignored modules
+        child.sendline("ignore_module")
+        child.expect_exact("Currently ignored modules: ['level2_module']")
+        child.expect("ipdb>")
+
+        # Test wildcard pattern
+        child.sendline("ignore_module testpkg.*")
+        child.expect("ipdb>")
+
+        child.sendline("ignore_module")
+        child.expect_exact("Currently ignored modules: ['level2_module', 'testpkg.*']")
+        child.expect("ipdb>")
+
+        # Test error handling - removing non-existent module
+        child.sendline("unignore_module nonexistent")
+        child.expect_exact("Module nonexistent is not currently ignored")
+        child.expect("ipdb>")
+
+        # Test successful removal
+        child.sendline("unignore_module level2_module")
+        child.expect("ipdb>")
+
+        child.sendline("ignore_module")
+        child.expect_exact("Currently ignored modules: ['testpkg.*']")
+        child.expect("ipdb>")
+
+        # Test removing already removed module
+        child.sendline("unignore_module level2_module")
+        child.expect_exact("Module level2_module is not currently ignored")
+        child.expect("ipdb>")
+
+        # Remove wildcard pattern
+        child.sendline("unignore_module testpkg.*")
+        child.expect("ipdb>")
+
+        child.sendline("ignore_module")
+        child.expect_exact("No modules are currently ignored.")
+        child.expect("ipdb>")
+
+        child.sendline("continue")
+        child.close()
+
+
+# Helper function for creating temporary modules
+def create_test_modules(temp_dir):
+    """Create a comprehensive module hierarchy for testing all debugger commands."""
+
+    temp_path = Path(temp_dir)
+
+    # Create package structure for wildcard testing
+    package_dir = temp_path / "testpkg"
+    package_dir.mkdir()
+
+    # Package __init__.py
+    (package_dir / "__init__.py").write_text("# Test package")
+
+    # testpkg/submod1.py
+    (package_dir / "submod1.py").write_text(
+        dedent(
+            """
+        def submod1_func():
+            x = 1
+            y = 2
+            return x + y
+        """
+        )
+    )
+
+    # testpkg/submod2.py
+    (package_dir / "submod2.py").write_text(
+        dedent(
+            """
+        def submod2_func():
+            z = 10
+            return z * 2
+        """
+        )
+    )
+
+    # Level 1 (top level module)
+    (temp_path / "level1_module.py").write_text(
+        dedent(
+            """
+        from level2_module import level2_func
+
+        def level1_func():
+            return level2_func()
+        """
+        )
+    )
+
+    # Level 2 (middle level module)
+    (temp_path / "level2_module.py").write_text(
+        dedent(
+            """
+        from level3_module import level3_func
+        from testpkg.submod1 import submod1_func
+        from testpkg.submod2 import submod2_func
+
+        def level2_func():
+            # Call package functions for step/next testing
+            result1 = submod1_func()
+            result2 = submod2_func()
+            return level3_func() + result1 + result2
+        """
+        )
+    )
+
+    # Level 3 (bottom level with debugger)
+    (temp_path / "level3_module.py").write_text(
+        dedent(
+            """
+        from level4_module import level4_func
+
+        from IPython.core.debugger import set_trace
+
+        def level3_func():
+            set_trace()
+            pass
+            result = level4_func()
+            return result
+        """
+        )
+    )
+
+    # Level 4 (bottom level with debugger)
+    (temp_path / "level4_module.py").write_text(
+        dedent(
+            """
+        def level4_func():
+            a = 70
+            b = 30
+            return a + b
+        """
+        )
+    )
+
+    # Main runner
+    main_path = temp_path / "main_runner.py"
+    main_path.write_text(
+        dedent(
+            """
+        import sys
+        sys.path.insert(0, '.')
+        from level1_module import level1_func
+
+        if __name__ == "__main__":
+            result = level1_func()
+            print(f"Final result: {result}")
+        """
+        )
+    )
+
+    return str(main_path)
+
+
+@skip_win32
+def test_ignore_module_all_commands():
+    """Comprehensive test for all debugger commands (up/down/step/next) with ignore functionality."""
+    import pexpect
+
+    env = os.environ.copy()
+    env["IPY_TEST_SIMPLE_PROMPT"] = "1"
+
+    with TemporaryDirectory() as temp_dir:
+        main_path = create_test_modules(temp_dir)
+
+        # Test UP and DOWN commands
+        child = pexpect.spawn(sys.executable, [main_path], env=env, cwd=temp_dir)
+        child.timeout = 15 * IPYTHON_TESTING_TIMEOUT_SCALE
+        child.expect("ipdb>")
+
+        # Test up without ignores (baseline)
+        child.sendline("up")
+        child.expect("ipdb>")
+        child.sendline("__name__")
+        child.expect_exact("level2_module")
+        child.expect("ipdb>")
+
+        # Reset position
+        child.sendline("down")
+        child.expect("ipdb>")
+
+        # Test up with single module ignore
+        child.sendline("ignore_module level2_module")
+        child.expect("ipdb>")
+        child.sendline("up")
+        child.expect_exact(
+            "[... skipped 1 frame(s): 0 hidden frames + 1 ignored modules]"
+        )
+        child.expect("ipdb>")
+        child.sendline("__name__")
+        child.expect_exact("level1_module")
+        child.expect("ipdb>")
+
+        # Test up with wildcard ignore
+        child.sendline("down")
+        child.expect_exact(
+            "[... skipped 1 frame(s): 0 hidden frames + 1 ignored modules]"
+        )
+        child.expect("ipdb>")
+        child.sendline("unignore_module level2_module")
+        child.expect("ipdb>")
+        child.sendline("ignore_module level*")
+        child.expect("ipdb>")
+        child.sendline("up")
+        child.expect_exact(
+            "[... skipped 2 frame(s): 0 hidden frames + 2 ignored modules]"
+        )
+        child.expect("ipdb>")
+        child.sendline("__name__")
+        child.expect_exact("__main__")
+        child.expect("ipdb>")
+
+        child.sendline("continue")
+        child.close()
+
+        # Test STEP command
+        child = pexpect.spawn(sys.executable, [main_path], env=env, cwd=temp_dir)
+        child.timeout = 15 * IPYTHON_TESTING_TIMEOUT_SCALE
+        child.expect("ipdb>")
+
+        # Test step without ignores (should step into module)
+        child.sendline("until 9")
+        child.expect("ipdb>")
+        child.sendline("step")
+        child.expect("ipdb>")
+        child.sendline("__name__")
+        child.expect_exact("level4_module")
+        child.expect("ipdb>")
+
+        child.sendline("continue")
+        child.close()
+
+        # Test step with single module ignore
+        child = pexpect.spawn(sys.executable, [main_path], env=env, cwd=temp_dir)
+        child.timeout = 15 * IPYTHON_TESTING_TIMEOUT_SCALE
+        child.expect("ipdb>")
+
+        child.sendline("ignore_module level4_module")
+        child.expect("ipdb>")
+        child.sendline("until 9")
+        child.expect("ipdb>")
+        child.sendline("step")
+        child.expect_exact("[... skipped 1 ignored module(s)]")
+        child.expect("ipdb>")
+        child.sendline("__name__")
+        child.expect_exact("level3_module")
+        child.expect("ipdb>")
+
+        child.sendline("continue")
+        child.close()
+
+        # Test NEXT command
+        child = pexpect.spawn(sys.executable, [main_path], env=env, cwd=temp_dir)
+        child.timeout = 15 * IPYTHON_TESTING_TIMEOUT_SCALE
+        child.expect("ipdb>")
+
+        # Test next without ignores
+        child.sendline("until 9")
+        child.expect("ipdb>")
+        child.sendline("next")
+        child.expect("ipdb>")
+        child.sendline("__name__")
+        child.expect_exact("level3_module")
+        child.expect("ipdb>")
+
+        child.sendline("continue")
+        child.close()
+
+        # Test next with module ignore
+        child = pexpect.spawn(sys.executable, [main_path], env=env, cwd=temp_dir)
+        child.timeout = 15 * IPYTHON_TESTING_TIMEOUT_SCALE
+        child.expect("ipdb>")
+
+        child.sendline("ignore_module level2_module")
+        child.expect("ipdb>")
+        child.sendline("return")
+        child.expect("ipdb>")
+        child.sendline("next")
+        child.expect_exact("[... skipped 1 ignored module(s)]")
+        child.expect("ipdb>")
+
+        child.sendline("continue")
+        child.close()


### PR DESCRIPTION
 This PR adds two new commands to ignore (and unignore) specific modules when navigating frames in the IPython debugger, similar to how the debugger already skips hidden frames. It will work with all the commands that implies moving between frames like `up`, `down`, `step` and `next`.
It is useful when you don't want the debugger to enter third party code.

Closes https://github.com/ipython/ipython/issues/1665