### PR TITLE
Update pyflyby downstream test to use `[test]` dependencies group

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -80,7 +80,7 @@ jobs:
         cd ..
         git clone https://github.com/deshaw/pyflyby
         cd pyflyby
-        pip install -e .[test] 'pytest<=8'
+        pip install .[test] 'pytest<=8'
         cd ..
     - name: Test pyflyby (IPython integration only)
       run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -80,7 +80,7 @@ jobs:
         cd ..
         git clone https://github.com/deshaw/pyflyby
         cd pyflyby
-        pip install .[test]
+        pip install -e .[test] 'pytest<=8'
         cd ..
     - name: Test pyflyby (IPython integration only)
       run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -80,9 +80,7 @@ jobs:
         cd ..
         git clone https://github.com/deshaw/pyflyby
         cd pyflyby
-        pip install -e .
-        # TODO: use [test] group instead once available
-        pip install 'pytest<=8' requests
+        pip install .[test]
         cd ..
     - name: Test pyflyby (IPython integration only)
       run: |

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -80,7 +80,10 @@ jobs:
         cd ..
         git clone https://github.com/deshaw/pyflyby
         cd pyflyby
-        pip install .[test] 'pytest<=8'
+        pip install meson-python meson ninja pybind11>=2.10.4
+        pip install setuptools wheel # needed for epydoc
+        pip install --no-build-isolation -ve .[test]
+        pip install 'pytest<=8'
         cd ..
     - name: Test pyflyby (IPython integration only)
       run: |


### PR DESCRIPTION
Uses the `[test]` group which was recently added, fixes CI.