### PR TITLE
Type-guided partial evaluation for completion of unitialized variables

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1127,16 +1127,7 @@ class Completer(Configurable):
         except IndexError:
             return None
 
-    def global_matches(self, text: str):
-        """Compute matches when text is a simple name.
-
-        Return a list of all keywords, built-in functions and names currently
-        defined in self.namespace or self.global_namespace that match.
-
-        """
-        return self._global_matches(text)
-
-    def _global_matches(self, text: str, context: Optional[CompletionContext] = None):
+    def global_matches(self, text: str, context: Optional[CompletionContext] = None):
         """Compute matches when text is a simple name.
 
         Return a list of all keywords, built-in functions and names currently
@@ -2757,7 +2748,7 @@ class IPCompleter(Completer):
                 # catches <undefined attributes>.<tab>
                 return SimpleMatcherResult(completions=[], suppress=False)
         else:
-            matches = self._global_matches(context.token, context)
+            matches = self.global_matches(context.token, context=context)
             # TODO: maybe distinguish between functions, modules and just "variables"
             return SimpleMatcherResult(
                 completions=[

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2748,9 +2748,9 @@ class IPCompleter(Completer):
                 # catches <undefined attributes>.<tab>
                 return SimpleMatcherResult(completions=[], suppress=False)
         else:
-            if "context" in inspect.signature(self.global_matches).parameters:
+            try:
                 matches = self.global_matches(context.token, context=context)
-            else:
+            except TypeError:
                 matches = self.global_matches(context.token)
             # TODO: maybe distinguish between functions, modules and just "variables"
             return SimpleMatcherResult(

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2748,7 +2748,10 @@ class IPCompleter(Completer):
                 # catches <undefined attributes>.<tab>
                 return SimpleMatcherResult(completions=[], suppress=False)
         else:
-            matches = self.global_matches(context.token, context=context)
+            if "context" in inspect.signature(self.global_matches).parameters:
+                matches = self.global_matches(context.token, context=context)
+            else:
+                matches = self.global_matches(context.token)
             # TODO: maybe distinguish between functions, modules and just "variables"
             return SimpleMatcherResult(
                 completions=[

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1346,7 +1346,9 @@ class Completer(Configurable):
                     ),
                 )
                 done = True
-            except (SyntaxError, TypeError):
+            except (SyntaxError, TypeError) as e:
+                if self.debug:
+                    warnings.warn(f"Trimming because of {e}")
                 # TypeError can show up with something like `+ d`
                 # where `d` is a dictionary.
 
@@ -1357,8 +1359,10 @@ class Completer(Configurable):
                 expr = self._trim_expr(expr)
             except Exception as e:
                 if self.debug:
-                    print("Evaluation exception", e)
+                    warnings.warn(f"Evaluation exception {e}")
                 done = True
+        if self.debug:
+            warnings.warn(f"Resolved to {obj}")
         return obj
 
     @property

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1127,7 +1127,16 @@ class Completer(Configurable):
         except IndexError:
             return None
 
-    def global_matches(self, text):
+    def global_matches(self, text: str):
+        """Compute matches when text is a simple name.
+
+        Return a list of all keywords, built-in functions and names currently
+        defined in self.namespace or self.global_namespace that match.
+
+        """
+        return self._global_matches(text)
+
+    def _global_matches(self, text: str, context: Optional[CompletionContext] = None):
         """Compute matches when text is a simple name.
 
         Return a list of all keywords, built-in functions and names currently
@@ -1137,12 +1146,41 @@ class Completer(Configurable):
         matches = []
         match_append = matches.append
         n = len(text)
-        for lst in [
+
+        search_lists = [
             keyword.kwlist,
             builtin_mod.__dict__.keys(),
             list(self.namespace.keys()),
             list(self.global_namespace.keys()),
-        ]:
+        ]
+        if context and context.full_text.count("\n") > 1:
+            # try to evaluate on full buffer
+            previous_lines = "\n".join(
+                context.full_text.split("\n")[: context.cursor_line]
+            )
+            if previous_lines:
+                all_code_lines_before_cursor = (
+                    self._extract_code(previous_lines) + "\n" + text
+                )
+                context = EvaluationContext(
+                    globals=self.global_namespace,
+                    locals=self.namespace,
+                    evaluation=self.evaluation,
+                    auto_import=self._auto_import,
+                    policy_overrides=self.policy_overrides,
+                )
+                try:
+                    obj = guarded_eval(
+                        all_code_lines_before_cursor,
+                        context,
+                    )
+                except Exception as e:
+                    if self.debug:
+                        warnings.warn(f"Evaluation exception {e}")
+
+                search_lists.append(list(context.transient_locals.keys()))
+
+        for lst in search_lists:
             for word in lst:
                 if word[:n] == text and word != "__builtins__":
                     match_append(word)
@@ -1157,6 +1195,7 @@ class Completer(Configurable):
             for word in shortened.keys():
                 if word[:n] == text and word != "__builtins__":
                     match_append(shortened[word])
+
         return matches
 
     def attr_matches(self, text):
@@ -2718,7 +2757,7 @@ class IPCompleter(Completer):
                 # catches <undefined attributes>.<tab>
                 return SimpleMatcherResult(completions=[], suppress=False)
         else:
-            matches = self.global_matches(context.token)
+            matches = self._global_matches(context.token, context)
             # TODO: maybe distinguish between functions, modules and just "variables"
             return SimpleMatcherResult(
                 completions=[

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1975,6 +1975,87 @@ class TestCompleter(unittest.TestCase):
 
 
 @pytest.mark.parametrize(
+    "use_jedi,evaluation",
+    [
+        [True, "minimal"],
+        [False, "limited"],
+    ],
+)
+@pytest.mark.parametrize(
+    "code,insert_text",
+    [
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def my_method(self) -> str:",
+                    "        return 1",
+                    "my_instance = NotYetDefined()",
+                    "my_insta",
+                ]
+            ),
+            "my_instance",
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def my_method(self) -> str:",
+                    "        return 1",
+                    "instance = NotYetDefined()",
+                    "instance.",
+                ]
+            ),
+            "my_method",
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def my_method(self) -> str:",
+                    "        return 1",
+                    "my_instance = NotYetDefined()",
+                    "my_instance.my_method().",
+                ]
+            ),
+            "capitalize",
+        ],
+        [
+            "\n".join(
+                [
+                    "my_instance = 1.1",
+                    "assert my_instance.",
+                ]
+            ),
+            "as_integer_ratio",
+        ],
+        [
+            "\n".join(
+                [
+                    "def my_test() -> float:",
+                    "    pass",
+                    "my_test().",
+                ]
+            ),
+            "as_integer_ratio",
+        ],
+    ],
+)
+def test_undefined_variables(use_jedi, evaluation, code, insert_text):
+    offset = len(code)
+    ip.Completer.use_jedi = use_jedi
+    ip.Completer.evaluation = evaluation
+
+    with provisionalcompleter():
+        completions = list(ip.Completer.completions(text=code, offset=offset))
+        match = [c for c in completions if c.text.lstrip(".") == insert_text]
+        message_on_fail = (
+            f"{insert_text} not found among {[c.text for c in completions]}"
+        )
+        assert len(match) == 1, message_on_fail
+
+
+@pytest.mark.parametrize(
     "line,expected",
     [
         # Basic test cases

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -313,12 +313,17 @@ IntTypeAlias = TypeAliasType("IntTypeAlias", int)
 HeapTypeAlias = TypeAliasType("HeapTypeAlias", HeapType)
 
 
-class TestProtocol(Protocol):
+class ProtocolTest(Protocol):
     def test_method(self) -> bool:
         pass
 
 
-class TestProtocolImplementer(TestProtocol):
+class ProtocolTestImplementer(ProtocolTest):
+    def test_method(self) -> bool:
+        return True
+
+
+class TypedClass:
     def test_method(self) -> bool:
         return True
 
@@ -335,13 +340,10 @@ class SpecialTyping:
     def custom_heap_type(self) -> CustomHeapType:
         return CustomHeapType(HeapType())
 
-    # TODO: remove type:ignore comment once mypy
-    # supports explicit calls to `TypeAliasType`, see:
-    # https://github.com/python/mypy/issues/16614
-    def int_type_alias(self) -> IntTypeAlias:  # type:ignore[valid-type]
+    def int_type_alias(self) -> IntTypeAlias:
         return 1
 
-    def heap_type_alias(self) -> HeapTypeAlias:  # type:ignore[valid-type]
+    def heap_type_alias(self) -> HeapTypeAlias:
         return 1
 
     def literal(self) -> Literal[False]:
@@ -355,6 +357,9 @@ class SpecialTyping:
 
     def any_str(self, x: AnyStr) -> AnyStr:
         return x
+
+    def with_kwargs(self, a=1, b=2, c=3) -> int:
+        return a + b + c
 
     def annotated(self) -> Annotated[float, "positive number"]:
         return 1
@@ -372,8 +377,8 @@ class SpecialTyping:
     def union_str_and_int(self) -> Union[str, int]:
         return ""
 
-    def protocol(self) -> TestProtocol:
-        return TestProtocolImplementer()
+    def protocol(self) -> ProtocolTest:
+        return ProtocolTestImplementer()
 
     def typed_dict(self) -> Movie:
         return {"name": "The Matrix", "year": 1999}
@@ -403,6 +408,7 @@ class SpecialTyping:
         [SpecialTyping(), "data.literal_string()", str, False],
         [SpecialTyping(), "data.any_str('a')", str, False],
         [SpecialTyping(), "data.any_str(b'a')", bytes, False],
+        [SpecialTyping(), "data.with_kwargs(b=3)", int, False],
         [SpecialTyping(), "data.annotated()", float, False],
         [SpecialTyping(), "data.annotated_self()", SpecialTyping, False],
         [SpecialTyping(), "data.int_type_guard()", int, False],
@@ -453,6 +459,95 @@ def test_mocks_items_of_call_results(data, code, expected_items):
     for key, value in expected_items.items():
         assert isinstance(result[key], value)
         assert key in ipython_keys
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ["\n".join(["instance = TypedClass()", "instance.test_method()"]), bool],
+        ["\n".join(["def func() -> int:", "    pass", "func()"]), int],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def method(self) -> str:",
+                    "        pass",
+                    "instance = NotYetDefined()",
+                    "instance.method()",
+                ]
+            ),
+            str,
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def method(self, argument) -> int:",
+                    "        pass",
+                    "instance = NotYetDefined()",
+                    "instance.method()",
+                ]
+            ),
+            int,
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    attribute = 42",
+                    "instance = NotYetDefined()",
+                    "instance.attribute",
+                ]
+            ),
+            int,
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def any_str(self, argument: AnyStr) -> AnyStr:",
+                    "        pass",
+                    "instance = NotYetDefined()",
+                    "instance.any_str(b'test')",
+                ]
+            ),
+            bytes,
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def any_str(self, argument: AnyStr) -> AnyStr:",
+                    "        pass",
+                    "instance = NotYetDefined()",
+                    "instance.any_str('test')",
+                ]
+            ),
+            str,
+        ],
+    ],
+)
+def test_mock_class_and_func_instances(code, expected):
+    context = limited(TypedClass=TypedClass, AnyStr=AnyStr)
+    value = guarded_eval(code, context)
+    assert isinstance(value, expected)
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ["\n".join(["a = True", "a"]), bool],
+        ["\n".join(["a, b, c = 1, 'b', 3.0", "a"]), int],
+        ["\n".join(["a, b, c = 1, 'b', 3.0", "b"]), str],
+        ["\n".join(["a, b, c = 1, 'b', 3.0", "c"]), float],
+        ["\n".join(["a, *rest = 1, 'b', 3.0", "a"]), int],
+        ["\n".join(["a, *rest = 1, 'b', 3.0", "rest"]), list],
+    ],
+)
+def test_evaluates_assignments(code, expected):
+    context = limited(TypedClass=TypedClass, AnyStr=AnyStr)
+    value = guarded_eval(code, context)
+    assert isinstance(value, expected)
 
 
 @pytest.mark.parametrize(
@@ -702,12 +797,23 @@ def test_access_locals_and_globals():
 
 @pytest.mark.parametrize(
     "code",
-    ["def func(): pass", "class C: pass", "x = 1", "x += 1", "del x", "import ast"],
+    ["x += 1", "del x"],
+)
+@pytest.mark.parametrize("context", [minimal(x=1), limited(x=1), unsafe(x=1)])
+def test_does_not_modify_namespace(code, context):
+    guarded_eval(code, context)
+    assert context.locals["x"] == 1
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["def test(): pass", "class test: pass", "import ast as test"],
 )
 @pytest.mark.parametrize("context", [minimal(), limited(), unsafe()])
-def test_rejects_side_effect_syntax(code, context):
-    with pytest.raises(SyntaxError):
-        guarded_eval(code, context)
+def test_does_not_populate_namespace(code, context):
+    guarded_eval(code, context)
+    assert "test" not in context.locals
+    assert "test" not in context.globals
 
 
 def test_subscript():

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -494,6 +494,33 @@ def test_mocks_items_of_call_results(data, code, expected_items):
             "\n".join(
                 [
                     "class NotYetDefined:",
+                    "    @property",
+                    "    def my_prop(self) -> int:",
+                    "        pass",
+                    "instance = NotYetDefined()",
+                    "instance.my_prop",
+                ]
+            ),
+            int,
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    @unkown_decorator",
+                    "    @property",
+                    "    def my_prop(self) -> int:",
+                    "        pass",
+                    "instance = NotYetDefined()",
+                    "instance.my_prop",
+                ]
+            ),
+            int,
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
                     "    attribute = 42",
                     "instance = NotYetDefined()",
                     "instance.attribute",


### PR DESCRIPTION
With:

```
ipython --Completer.use_jedi=False
```

This allows for completions before executing code, such as:

<img width="847" height="360" alt="image" src="https://github.com/user-attachments/assets/d8685257-3ad4-435c-a7b6-5cce9741c5cb" />

<img width="852" height="411" alt="image" src="https://github.com/user-attachments/assets/1bce2b9a-3c0a-4e2b-ad42-03e98d2b8056" />

The body of functions is never executed, only the return types are considered.

Tagging along are two minor fixes for inference of types of:
- functions returning `bool`s
- functions called with keyword arguments

### Classes

<img width="498" height="413" alt="image" src="https://github.com/user-attachments/assets/4a7ca081-0ca3-4b6a-9693-7f52951b2c36" />

<img width="498" height="522" alt="image" src="https://github.com/user-attachments/assets/4c4ac687-3736-45d7-8921-b04e301351db" />

<img width="498" height="522" alt="image" src="https://github.com/user-attachments/assets/2f1fc654-aa17-474b-9061-9ce27a0e1b65" />

<img width="498" height="522" alt="image" src="https://github.com/user-attachments/assets/11003b92-076d-42d3-8d81-bbab55d29e58" />

`d` and `name` do not have type annotations so completion further is not possible. We could infer type from the return value but this is not currently supported.

<img width="498" height="316" alt="image" src="https://github.com/user-attachments/assets/129db02c-1972-4e87-b51a-1ad3a02c541d" />


### `AnyStr` disambiguation

<img width="418" height="205" alt="image" src="https://github.com/user-attachments/assets/f38845a7-50e8-4bd0-8327-f11ccb49521f" />

<img width="418" height="205" alt="image" src="https://github.com/user-attachments/assets/44c98638-9204-4428-abe5-99df8336c589" />


Punchlist:
- [x] add tests in guarded eval
- [x] expand guarded eval to handle multi-line and class/function definitions
- [x] implement attribute completion on full buffer, not only on the last line
- [x] add tests for completion
- [x] test with JupyterLab
- [x] test more complex cases, including composition, class variables, etc.

Out of scope for this PR but requires little effort: support completion in yield, for, and while loops.