### PR TITLE
Bump minimum version (spec-0) and whitespace update.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Reporting a Vulnerability
 
-All IPython and Jupyter security are handled via security@ipython.org. 
+All IPython and Jupyter security are handled via security@ipython.org.
 You can find more information on the Jupyter website. https://jupyter.org/security
 
 ## Tidelift
 
-You can report security concerns for IPython via the [Tidelift platform](https://tidelift.com/security). 
+You can report security concerns for IPython via the [Tidelift platform](https://tidelift.com/security).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,8 @@ doc = [
     "exceptiongroup",
     "intersphinx_registry",
     "ipykernel",
-    "ipython[test]",
-    "matplotlib",
-    "setuptools>=18.5",
+    "ipython[test,matplotlib]",
+    "setuptools>=61.2",
     "sphinx_toml==0.0.4",
     "sphinx-rtd-theme",
     "sphinx>=1.3",
@@ -78,16 +77,16 @@ test_extra = [
     "ipython[test]",
     "curio",
     "jupyter_ai",
-    "matplotlib!=3.2.0",
+    "ipython[matplotlib]",
     "nbformat",
     "nbclient",
     "ipykernel",
-    "numpy>=1.23",
-    "pandas",
+    "numpy>=1.25",
+    "pandas>2.0",
     "trio",
 ]
 matplotlib = [
-   "matplotlib"
+   "matplotlib>3.7"
 ]
 all = [
     "ipython[doc,matplotlib,test,test_extra]",


### PR DESCRIPTION
Note that I'm moving from listing some optional
dependencies explicitely to refering to
`ipython[optional_group]` in `pyproject.toml`.
This avoid redundancies, but I'm unsure about the
support in all tools.