### PR TITLE
Respect `DisplayFormatter.active_types` trait configuration

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -765,8 +765,13 @@ class TerminalInteractiveShell(InteractiveShell):
 
     def init_display_formatter(self):
         super(TerminalInteractiveShell, self).init_display_formatter()
-        # terminal only supports plain text
-        self.display_formatter.active_types = ["text/plain"]
+        # terminal only supports plain text if not explicitly configured
+        config = self.display_formatter._trait_values["config"]
+        if not (
+            "DisplayFormatter" in config
+            and "active_types" in config["DisplayFormatter"]
+        ):
+            self.display_formatter.active_types = ["text/plain"]
 
     def init_prompt_toolkit_cli(self):
         if self.simple_prompt:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -56,6 +56,21 @@ def foo_printer(obj, pp, cycle):
     pp.text("foo")
 
 
+def test_display_formatter_active_types_config():
+    ip = get_ipython()
+    prev_active_types = getattr(ip.config.DisplayFormatter, "active_types", None)
+    ip.config.DisplayFormatter.active_types = ["text/plain", "image/png"]
+    try:
+        ip.init_display_formatter()
+        active_types = ip.display_formatter.active_types
+        assert "text/plain" in active_types
+        assert "image/png" in active_types
+    finally:
+        if prev_active_types is not None:
+            ip.config.DisplayFormatter.active_types = prev_active_types
+        else:
+            del ip.config.DisplayFormatter.active_types
+
 def test_pretty():
     f = PlainTextFormatter()
     f.for_type(A, foo_printer)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -57,19 +57,24 @@ def foo_printer(obj, pp, cycle):
 
 
 def test_display_formatter_active_types_config():
-    ip = get_ipython()
-    prev_active_types = getattr(ip.config.DisplayFormatter, "active_types", None)
-    ip.config.DisplayFormatter.active_types = ["text/plain", "image/png"]
+    from IPython.terminal.interactiveshell import TerminalInteractiveShell
+    from IPython.core.history import HistoryManager
+    from traitlets.config import Config
+
+    # Clear HistoryManager instances to bypass singleton limit before creating new shell
+    HistoryManager._instances.clear()
+
     try:
-        ip.init_display_formatter()
+        c = Config()
+        c.DisplayFormatter.active_types = ["text/plain", "image/png"]
+
+        ip = TerminalInteractiveShell(config=c)
+
         active_types = ip.display_formatter.active_types
         assert "text/plain" in active_types
         assert "image/png" in active_types
     finally:
-        if prev_active_types is not None:
-            ip.config.DisplayFormatter.active_types = prev_active_types
-        else:
-            del ip.config.DisplayFormatter.active_types
+        HistoryManager._instances.clear()
 
 
 def test_pretty():

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -71,6 +71,7 @@ def test_display_formatter_active_types_config():
         else:
             del ip.config.DisplayFormatter.active_types
 
+
 def test_pretty():
     f = PlainTextFormatter()
     f.for_type(A, foo_printer)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -62,6 +62,7 @@ def test_display_formatter_active_types_config():
     from traitlets.config import Config
 
     # Clear HistoryManager instances to bypass singleton limit before creating new shell
+    prev_instances = HistoryManager._instances.copy()
     HistoryManager._instances.clear()
 
     try:
@@ -73,8 +74,13 @@ def test_display_formatter_active_types_config():
         active_types = ip.display_formatter.active_types
         assert "text/plain" in active_types
         assert "image/png" in active_types
+
+        # Ensure only the expected types are active
+        assert set(active_types) == {"text/plain", "image/png"}
     finally:
+        # Clean up the new instance and restore previous state
         HistoryManager._instances.clear()
+        HistoryManager._instances.update(prev_instances)
 
 
 def test_pretty():

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -60,29 +60,18 @@ def test_display_formatter_active_types_config():
     from IPython.terminal.interactiveshell import TerminalInteractiveShell
     from IPython.core.history import HistoryManager
     from traitlets.config import Config
-    import tempfile
-    import shutil
-    import atexit
 
     # Clear HistoryManager instances to bypass singleton limit before creating new shell
     prev_instances = HistoryManager._instances.copy()
     HistoryManager._instances.clear()
 
-    temp_dir = tempfile.mkdtemp()
     try:
         c = Config()
         c.DisplayFormatter.active_types = ["text/plain", "image/png"]
-        # Use isolated history file
-        c.HistoryManager.hist_file = f"{temp_dir}/history.sqlite"
+        # Disable history
+        c.HistoryManager.enabled = False
 
         ip = TerminalInteractiveShell(config=c)
-
-        # Remove atexit handler immediately after creation
-        if hasattr(ip, "atexit_operations"):
-            try:
-                atexit.unregister(ip.atexit_operations)
-            except ValueError:
-                pass
 
         active_types = ip.display_formatter.active_types
         assert "text/plain" in active_types
@@ -95,10 +84,6 @@ def test_display_formatter_active_types_config():
         # Clean up the new instance and restore previous state
         HistoryManager._instances.clear()
         HistoryManager._instances.update(prev_instances)
-
-        # Clean up temporary directory
-        if temp_dir:
-            shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 def test_pretty():


### PR DESCRIPTION
## Fixes #14991 

### Description
If `DisplayFormatter.active_types` is set via config, avoid overriding it with `["text/plain"]` in `TerminalInteractiveShell`. 

This allows users to include `"image/png"` in `active_types`, ensuring that plot images are properly published for later export with the `%notebook` magic.
