### PR TITLE
Make `%notebook` magic notarise exported notebooks (mark as trusted)

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -559,6 +559,7 @@ Currently the magic system has the following functions:""",
         outfname = os.path.expanduser(args.filename)
 
         from nbformat import write, v4
+        from nbformat.sign import NotebookNotary
 
         cells = []
         hist = list(self.shell.history_manager.get_range())
@@ -629,6 +630,9 @@ Currently the magic system has the following functions:""",
                 },
             },
         )
+        # Sign the notebook to make it trusted
+        notary = NotebookNotary()
+        notary.sign(nb)
         with io.open(outfname, "w", encoding="utf-8") as f:
             write(nb, f, version=4)
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -632,6 +632,7 @@ Currently the magic system has the following functions:""",
         )
         # Sign the notebook to make it trusted
         notary = NotebookNotary()
+        notary.update_config(self.shell.config)
         notary.sign(nb)
         with io.open(outfname, "w", encoding="utf-8") as f:
             write(nb, f, version=4)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1004,6 +1004,7 @@ def test_notebook_export_json():
 
     _ip = get_ipython()
     _ip.history_manager.reset()  # Clear any existing history.
+    _ip.run_line_magic("config", "NotebookNotary.algorithm = 'sha384'")
     cmds = ["a=1", "def b():\n  return a**2", "print('noël, été', b())"]
     for i, cmd in enumerate(cmds, start=1):
         _ip.history_manager.store_inputs(i, cmd)
@@ -1024,7 +1025,7 @@ def test_notebook_export_json():
     assert kernelspec["language"] == "python"
 
     # Check if notebook is trusted
-    notary = sign.NotebookNotary()
+    notary = sign.NotebookNotary(algorithm="sha384")
     is_trusted = notary.check_signature(nb)
     assert is_trusted, "Exported notebook should be trusted"
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1000,6 +1000,7 @@ def test_extension():
 
 def test_notebook_export_json():
     pytest.importorskip("nbformat")
+    from nbformat import read, sign
     _ip = get_ipython()
     _ip.history_manager.reset()  # Clear any existing history.
     cmds = ["a=1", "def b():\n  return a**2", "print('noël, été', b())"]
@@ -1010,6 +1011,7 @@ def test_notebook_export_json():
         _ip.run_line_magic("notebook", "%s" % outfile)
         with open(outfile) as f:
             exported = json.load(f)
+        nb = read(outfile, as_version=4)
 
     # check metadata
     language_info = exported["metadata"]["language_info"]
@@ -1020,6 +1022,10 @@ def test_notebook_export_json():
     kernelspec = exported["metadata"]["kernelspec"]
     assert kernelspec["language"] == "python"
 
+    # Check if notebook is trusted
+    notary = sign.NotebookNotary()
+    is_trusted = notary.check_signature(nb)
+    assert is_trusted, "Exported notebook should be trusted"
 
 def test_notebook_export_json_with_output():
     """Tests if notebook export correctly captures outputs, errors, display outputs, and stream outputs."""

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1001,6 +1001,7 @@ def test_extension():
 def test_notebook_export_json():
     pytest.importorskip("nbformat")
     from nbformat import read, sign
+
     _ip = get_ipython()
     _ip.history_manager.reset()  # Clear any existing history.
     cmds = ["a=1", "def b():\n  return a**2", "print('noël, été', b())"]
@@ -1026,6 +1027,7 @@ def test_notebook_export_json():
     notary = sign.NotebookNotary()
     is_trusted = notary.check_signature(nb)
     assert is_trusted, "Exported notebook should be trusted"
+
 
 def test_notebook_export_json_with_output():
     """Tests if notebook export correctly captures outputs, errors, display outputs, and stream outputs."""


### PR DESCRIPTION
## Fixes #14992 

### Description

Mark notebooks created with %notebook magic as trusted so SVG plots and rich outputs display immediately without manual trust approval.