### PR TITLE
Fix matplotlib plots displaying in wrong cells during `%notebook` export

### DIFF
--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -43,6 +43,7 @@ class DisplayPublisher(Configurable):
     def __init__(self, shell=None, *args, **kwargs):
         self.shell = shell
         self._is_publishing = False
+        self._setup_execution_tracking()
         super().__init__(*args, **kwargs)
 
     def _validate_data(self, data, metadata=None):
@@ -61,6 +62,20 @@ class DisplayPublisher(Configurable):
         if metadata is not None:
             if not isinstance(metadata, dict):
                 raise TypeError("metadata must be a dict, got: %r" % data)
+
+    def _setup_execution_tracking(self):
+        """Set up hooks to track execution state"""
+        self._in_post_execute = False
+        self.shell.events.register("post_execute", self._on_post_execute)
+        self.shell.events.register("pre_execute", self._on_pre_execute)
+
+    def _on_post_execute(self):
+        """Called at start of post_execute phase"""
+        self._in_post_execute = True
+
+    def _on_pre_execute(self):
+        """Called at start of pre_execute phase"""
+        self._in_post_execute = False
 
     # use * to indicate transient, update are keyword-only
     def publish(
@@ -133,7 +148,13 @@ class DisplayPublisher(Configurable):
 
         outputs = self.shell.history_manager.outputs
 
-        outputs[self.shell.execution_count].append(
+        target_execution_count = self.shell.execution_count
+        if self._in_post_execute:
+            # We're in post_execute, so this is likely a matplotlib flush
+            # Use execution_count - 1 to associate with the cell that created the plot
+            target_execution_count = self.shell.execution_count - 1
+
+        outputs[target_execution_count].append(
             HistoryOutput(output_type="display_data", bundle=data)
         )
 

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -43,7 +43,9 @@ class DisplayPublisher(Configurable):
     def __init__(self, shell=None, *args, **kwargs):
         self.shell = shell
         self._is_publishing = False
-        self._setup_execution_tracking()
+        self._in_post_execute = False
+        if self.shell:
+            self._setup_execution_tracking()
         super().__init__(*args, **kwargs)
 
     def _validate_data(self, data, metadata=None):
@@ -65,7 +67,6 @@ class DisplayPublisher(Configurable):
 
     def _setup_execution_tracking(self):
         """Set up hooks to track execution state"""
-        self._in_post_execute = False
         self.shell.events.register("post_execute", self._on_post_execute)
         self.shell.events.register("pre_execute", self._on_pre_execute)
 

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -215,52 +215,63 @@ def test_set_matplotlib_formats_kwargs():
         cfg.print_figure_kwargs.clear()
 
 
-# @dec.skip_without("matplotlib")
-# def test_matplotlib_positioning():
-#     _ip = get_ipython()
-#     _ip.history_manager.reset()
-#     prev_active_types = _ip.display_formatter.active_types
-#     _ip.display_formatter.active_types = ["text/plain", "image/png"]
+@dec.skip_without("matplotlib")
+def test_matplotlib_positioning():
+    _ip = get_ipython()
 
-#     _ip.run_cell("import matplotlib")
-#     prev_mpl_backend = _ip.run_cell("matplotlib.get_backend()").result
-#     try:
-#         _ip.run_line_magic("matplotlib", "inline")
-#         _ip.execution_count = 1
-#         _ip.run_cell("'no plot here'", store_history=True)
+    prev_active_types = _ip.display_formatter.active_types.copy()
+    prev_execution_count = _ip.execution_count
+    prev_user_ns_underscore = _ip.user_ns.get("_", None)
 
-#         # Cell 2: No manual flush
-#         _ip.run_cell(
-#             "import matplotlib.pyplot as plt;plt.plot([0, 1])", store_history=True
-#         )
+    _ip.history_manager.reset()
+    _ip.display_formatter.active_types = ["text/plain", "image/png"]
 
-#         _ip.run_cell("'no plot here'", store_history=True)
+    _ip.run_cell("import matplotlib")
+    prev_mpl_backend = _ip.run_cell("matplotlib.get_backend()").result
 
-#         # Cell 4: Manual flush
-#         _ip.run_cell("plt.plot([1, 0])\nplt.show()", store_history=True)
+    try:
+        _ip.run_line_magic("matplotlib", "inline")
+        _ip.execution_count = 1
+        _ip.run_cell("'no plot here'", store_history=True)
 
-#         _ip.run_cell("'no plot here'", store_history=True)
+        # Cell 2: No manual flush
+        _ip.run_cell(
+            "import matplotlib.pyplot as plt;plt.plot([0, 1])", store_history=True
+        )
 
-#         outputs = _ip.history_manager.outputs
+        _ip.run_cell("'no plot here'", store_history=True)
 
-#         # Only cells 2 and 4 should have plots
-#         for cell_num in [1, 3, 5]:
-#             assert not any(
-#                 "image/png" in out.bundle for out in outputs.get(cell_num, [])
-#             ), f"Cell {cell_num} should not have plot"
+        # Cell 4: Manual flush
+        _ip.run_cell("plt.plot([1, 0])\nplt.show()", store_history=True)
 
-#         cell_2_has_plot = any("image/png" in out.bundle for out in outputs.get(2, []))
-#         cell_4_has_plot = any("image/png" in out.bundle for out in outputs.get(4, []))
+        _ip.run_cell("'no plot here'", store_history=True)
 
-#         assert cell_2_has_plot, "Cell 2 should have plot (auto-flush)"
-#         assert cell_4_has_plot, "Cell 4 should have plot (manual flush)"
+        outputs = _ip.history_manager.outputs
 
-#     finally:
-#         _ip.run_cell("plt.close('all')")
-#         _ip.run_line_magic("matplotlib", prev_mpl_backend)
-#         _ip.history_manager.reset()
-#         _ip.display_formatter.active_types = prev_active_types
-#         _ip.displayhook.flush()
+        # Only cells 2 and 4 should have plots
+        for cell_num in [1, 3, 5]:
+            assert not any(
+                "image/png" in out.bundle for out in outputs.get(cell_num, [])
+            ), f"Cell {cell_num} should not have plot"
+
+        cell_2_has_plot = any("image/png" in out.bundle for out in outputs.get(2, []))
+        cell_4_has_plot = any("image/png" in out.bundle for out in outputs.get(4, []))
+
+        assert cell_2_has_plot, "Cell 2 should have plot (auto-flush)"
+        assert cell_4_has_plot, "Cell 4 should have plot (manual flush)"
+
+    finally:
+        _ip.run_cell("plt.close('all')")
+        _ip.run_line_magic("matplotlib", prev_mpl_backend)
+        _ip.history_manager.reset()
+        _ip.display_formatter.active_types = prev_active_types
+        _ip.displayhook.flush()
+
+        _ip.execution_count = prev_execution_count
+        if prev_user_ns_underscore is not None:
+            _ip.user_ns["_"] = prev_user_ns_underscore
+        elif "_" in _ip.user_ns:
+            del _ip.user_ns["_"]
 
 
 def test_display_available():

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -263,7 +263,6 @@ def test_matplotlib_positioning():
         _ip.displayhook.flush()
 
 
-
 def test_display_available():
     """
     Test that display is available without import

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -215,52 +215,52 @@ def test_set_matplotlib_formats_kwargs():
         cfg.print_figure_kwargs.clear()
 
 
-@dec.skip_without("matplotlib")
-def test_matplotlib_positioning():
-    _ip = get_ipython()
-    _ip.history_manager.reset()
-    prev_active_types = _ip.display_formatter.active_types
-    _ip.display_formatter.active_types = ["text/plain", "image/png"]
+# @dec.skip_without("matplotlib")
+# def test_matplotlib_positioning():
+#     _ip = get_ipython()
+#     _ip.history_manager.reset()
+#     prev_active_types = _ip.display_formatter.active_types
+#     _ip.display_formatter.active_types = ["text/plain", "image/png"]
 
-    _ip.run_cell("import matplotlib")
-    prev_mpl_backend = _ip.run_cell("matplotlib.get_backend()").result
-    try:
-        _ip.run_line_magic("matplotlib", "inline")
-        _ip.execution_count = 1
-        _ip.run_cell("'no plot here'", store_history=True)
+#     _ip.run_cell("import matplotlib")
+#     prev_mpl_backend = _ip.run_cell("matplotlib.get_backend()").result
+#     try:
+#         _ip.run_line_magic("matplotlib", "inline")
+#         _ip.execution_count = 1
+#         _ip.run_cell("'no plot here'", store_history=True)
 
-        # Cell 2: No manual flush
-        _ip.run_cell(
-            "import matplotlib.pyplot as plt;plt.plot([0, 1])", store_history=True
-        )
+#         # Cell 2: No manual flush
+#         _ip.run_cell(
+#             "import matplotlib.pyplot as plt;plt.plot([0, 1])", store_history=True
+#         )
 
-        _ip.run_cell("'no plot here'", store_history=True)
+#         _ip.run_cell("'no plot here'", store_history=True)
 
-        # Cell 4: Manual flush
-        _ip.run_cell("plt.plot([1, 0])\nplt.show()", store_history=True)
+#         # Cell 4: Manual flush
+#         _ip.run_cell("plt.plot([1, 0])\nplt.show()", store_history=True)
 
-        _ip.run_cell("'no plot here'", store_history=True)
+#         _ip.run_cell("'no plot here'", store_history=True)
 
-        outputs = _ip.history_manager.outputs
+#         outputs = _ip.history_manager.outputs
 
-        # Only cells 2 and 4 should have plots
-        for cell_num in [1, 3, 5]:
-            assert not any(
-                "image/png" in out.bundle for out in outputs.get(cell_num, [])
-            ), f"Cell {cell_num} should not have plot"
+#         # Only cells 2 and 4 should have plots
+#         for cell_num in [1, 3, 5]:
+#             assert not any(
+#                 "image/png" in out.bundle for out in outputs.get(cell_num, [])
+#             ), f"Cell {cell_num} should not have plot"
 
-        cell_2_has_plot = any("image/png" in out.bundle for out in outputs.get(2, []))
-        cell_4_has_plot = any("image/png" in out.bundle for out in outputs.get(4, []))
+#         cell_2_has_plot = any("image/png" in out.bundle for out in outputs.get(2, []))
+#         cell_4_has_plot = any("image/png" in out.bundle for out in outputs.get(4, []))
 
-        assert cell_2_has_plot, "Cell 2 should have plot (auto-flush)"
-        assert cell_4_has_plot, "Cell 4 should have plot (manual flush)"
+#         assert cell_2_has_plot, "Cell 2 should have plot (auto-flush)"
+#         assert cell_4_has_plot, "Cell 4 should have plot (manual flush)"
 
-    finally:
-        _ip.run_cell("plt.close('all')")
-        _ip.run_line_magic("matplotlib", prev_mpl_backend)
-        _ip.history_manager.reset()
-        _ip.display_formatter.active_types = prev_active_types
-        _ip.displayhook.flush()
+#     finally:
+#         _ip.run_cell("plt.close('all')")
+#         _ip.run_line_magic("matplotlib", prev_mpl_backend)
+#         _ip.history_manager.reset()
+#         _ip.display_formatter.active_types = prev_active_types
+#         _ip.displayhook.flush()
 
 
 def test_display_available():

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -220,38 +220,34 @@ def test_matplotlib_positioning():
     _ip.display_formatter.active_types = ["text/plain", "image/png"]
 
     try:
-        _ip.execution_count = 0
+        _ip.execution_count = 1
         _ip.run_cell("'no plot here'", store_history=True)
 
-        # Cell 1: No manual flush
-        _ip.execution_count = 1
+        # Cell 2: No manual flush
         _ip.run_cell(
             "import matplotlib.pyplot as plt;plt.plot([0, 1])", store_history=True
         )
 
-        _ip.execution_count = 2
         _ip.run_cell("'no plot here'", store_history=True)
 
-        # Cell 3: Manual flush
-        _ip.execution_count = 3
+        # Cell 4: Manual flush
         _ip.run_cell("plt.plot([1, 0])\nplt.show()", store_history=True)
 
-        _ip.execution_count = 4
         _ip.run_cell("'no plot here'", store_history=True)
 
         outputs = _ip.history_manager.outputs
 
-        # Only cells 1 and 3 should have plots
-        for cell_num in [0, 2, 4]:
+        # Only cells 2 and 4 should have plots
+        for cell_num in [1, 3, 5]:
             assert not any(
                 "image/png" in out.bundle for out in outputs.get(cell_num, [])
             ), f"Cell {cell_num} should not have plot"
 
-        cell_1_has_plot = any("image/png" in out.bundle for out in outputs.get(1, []))
-        cell_3_has_plot = any("image/png" in out.bundle for out in outputs.get(3, []))
+        cell_2_has_plot = any("image/png" in out.bundle for out in outputs.get(2, []))
+        cell_4_has_plot = any("image/png" in out.bundle for out in outputs.get(4, []))
 
-        assert cell_1_has_plot, "Cell 1 should have plot (auto-flush)"
-        assert cell_3_has_plot, "Cell 3 should have plot (manual flush)"
+        assert cell_2_has_plot, "Cell 2 should have plot (auto-flush)"
+        assert cell_4_has_plot, "Cell 4 should have plot (manual flush)"
 
     finally:
         import matplotlib.pyplot as plt

--- a/tests/test_displayhook.py
+++ b/tests/test_displayhook.py
@@ -31,6 +31,7 @@ def test_output_quiet():
 
 
 def test_underscore_no_overwrite_user():
+    ip.displayhook.flush()
     ip.run_cell("_ = 42", store_history=True)
     ip.run_cell("1+1", store_history=True)
 

--- a/tests/test_displayhook.py
+++ b/tests/test_displayhook.py
@@ -31,7 +31,6 @@ def test_output_quiet():
 
 
 def test_underscore_no_overwrite_user():
-    ip.displayhook.flush()
     ip.run_cell("_ = 42", store_history=True)
     ip.run_cell("1+1", store_history=True)
 


### PR DESCRIPTION
## Fixes #14990

**Problem:** When using `%notebook` magic to export IPython sessions, auto flushed matplotlib plots appeared one cell later than where they were created. This happened because matplotlib's `flush_figures()` runs during the `post_execute` event, after the cell's output capture phase.

**Solution:** Added execution state tracking to the display publisher:
- Track when we're in `post_execute` phase vs normal execution
- When in `post_execute`: use `execution_count - 1` (associate with originating cell)
- When in normal execution: use current `execution_count` (for explicit `plt.show()`)

**Result:** 
- Plots without `plt.show()` now appear in the correct cell
- Plots with explicit `plt.show()` continue to work correctly
- No breaking changes to existing behavior

**Testing:** Added test to verify both auto-flush and manual-flush scenarios place plots in the correct cells.