### PR TITLE
Fix `%notebook` magic creating multiple `display_data` outputs for single widgets

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -572,7 +572,7 @@ Currently the magic system has the following functions:""",
             cell = v4.new_code_cell(execution_count=execution_count, source=source)
 
             for output in outputs[execution_count]:
-                if output.output_type == "out_stream":
+                if output.output_type in {"out_stream", "err_stream"}:
                     text_data = []
                     for mime_type, data in output.bundle.items():
                         if isinstance(data, list):
@@ -589,27 +589,10 @@ Currently the magic system has the following functions:""",
                             normalized_text.append(line + "\n")
                         elif line:  # Last line only if it's not empty
                             normalized_text.append(line + "\n")
-                    cell.outputs.append(v4.new_output("stream", text=normalized_text))
-
-                elif output.output_type == "err_stream":
-                    text_data = []
-                    for mime_type, data in output.bundle.items():
-                        if isinstance(data, list):
-                            text_data.extend(data)
-                        else:
-                            text_data.append(data)
-                    full_text = "".join(text_data)
-                    full_text = full_text.replace("\\n", "\n")
-                    normalized_text = []
-                    lines = full_text.split("\n")
-                    for i, line in enumerate(lines):
-                        if i < len(lines) - 1:
-                            normalized_text.append(line + "\n")
-                        elif line:
-                            normalized_text.append(line + "\n")
-                    err_output = v4.new_output("stream", text=normalized_text)
-                    err_output.name = "stderr"
-                    cell.outputs.append(err_output)
+                    stream_output = v4.new_output("stream", text=normalized_text)
+                    if output.output_type == "err_stream":
+                        err_output.name = "stderr"
+                    cell.outputs.append(stream_output)
 
                 elif output.output_type == "execute_result":
                     data_dict = {}

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -567,35 +567,75 @@ Currently the magic system has the following functions:""",
 
         if(len(hist)<=1):
             raise ValueError('History is empty, cannot export')
+
         for session, execution_count, source in hist[:-1]:
             cell = v4.new_code_cell(execution_count=execution_count, source=source)
+
             for output in outputs[execution_count]:
-                for mime_type, data in output.bundle.items():
-                    if output.output_type == "out_stream":
-                        text = data if isinstance(data, list) else [data]
-                        cell.outputs.append(v4.new_output("stream", text=text))
-                    elif output.output_type == "err_stream":
-                        text = data if isinstance(data, list) else [data]
-                        err_output = v4.new_output("stream", text=text)
-                        err_output.name = "stderr"
-                        cell.outputs.append(err_output)
-                    elif output.output_type == "execute_result":
-                        cell.outputs.append(
-                            v4.new_output(
-                                "execute_result",
-                                data={mime_type: data},
-                                execution_count=execution_count,
-                            )
+                if output.output_type == "out_stream":
+                    text_data = []
+                    for mime_type, data in output.bundle.items():
+                        if isinstance(data, list):
+                            text_data.extend(data)
+                        else:
+                            text_data.append(data)
+                    full_text = "".join(text_data)
+                    # Replace literal \n with actual newlines
+                    full_text = full_text.replace("\\n", "\n")
+                    normalized_text = []
+                    lines = full_text.split("\n")
+                    for i, line in enumerate(lines):
+                        if i < len(lines) - 1:
+                            normalized_text.append(line + "\n")
+                        elif line:  # Last line only if it's not empty
+                            normalized_text.append(line + "\n")
+                    cell.outputs.append(v4.new_output("stream", text=normalized_text))
+
+                elif output.output_type == "err_stream":
+                    text_data = []
+                    for mime_type, data in output.bundle.items():
+                        if isinstance(data, list):
+                            text_data.extend(data)
+                        else:
+                            text_data.append(data)
+                    full_text = "".join(text_data)
+                    full_text = full_text.replace("\\n", "\n")
+                    normalized_text = []
+                    lines = full_text.split("\n")
+                    for i, line in enumerate(lines):
+                        if i < len(lines) - 1:
+                            normalized_text.append(line + "\n")
+                        elif line:
+                            normalized_text.append(line + "\n")
+                    err_output = v4.new_output("stream", text=normalized_text)
+                    err_output.name = "stderr"
+                    cell.outputs.append(err_output)
+
+                elif output.output_type == "execute_result":
+                    data_dict = {}
+                    for mime_type, data in output.bundle.items():
+                        data_dict[mime_type] = data
+                    cell.outputs.append(
+                        v4.new_output(
+                            "execute_result",
+                            data=data_dict,
+                            execution_count=execution_count,
                         )
-                    elif output.output_type == "display_data":
-                        cell.outputs.append(
-                            v4.new_output(
-                                "display_data",
-                                data={mime_type: data},
-                            )
+                    )
+
+                elif output.output_type == "display_data":
+                    # Collect all MIME types for this display_data into a single output
+                    data_dict = {}
+                    for mime_type, data in output.bundle.items():
+                        data_dict[mime_type] = data
+                    cell.outputs.append(
+                        v4.new_output(
+                            "display_data",
+                            data=data_dict,
                         )
-                    else:
-                        raise ValueError(f"Unknown output type: {output.output_type}")
+                    )
+                else:
+                    raise ValueError(f"Unknown output type: {output.output_type}")
 
             # Check if this execution_count is in exceptions (current session)
             if execution_count in exceptions:

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -591,7 +591,7 @@ Currently the magic system has the following functions:""",
                             normalized_text.append(line + "\n")
                     stream_output = v4.new_output("stream", text=normalized_text)
                     if output.output_type == "err_stream":
-                        err_output.name = "stderr"
+                        stream_output.name = "stderr"
                     cell.outputs.append(stream_output)
 
                 elif output.output_type == "execute_result":

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -567,75 +567,35 @@ Currently the magic system has the following functions:""",
 
         if(len(hist)<=1):
             raise ValueError('History is empty, cannot export')
-
         for session, execution_count, source in hist[:-1]:
             cell = v4.new_code_cell(execution_count=execution_count, source=source)
-
             for output in outputs[execution_count]:
-                if output.output_type == "out_stream":
-                    text_data = []
-                    for mime_type, data in output.bundle.items():
-                        if isinstance(data, list):
-                            text_data.extend(data)
-                        else:
-                            text_data.append(data)
-                    full_text = "".join(text_data)
-                    # Replace literal \n with actual newlines
-                    full_text = full_text.replace("\\n", "\n")
-                    normalized_text = []
-                    lines = full_text.split("\n")
-                    for i, line in enumerate(lines):
-                        if i < len(lines) - 1:
-                            normalized_text.append(line + "\n")
-                        elif line:  # Last line only if it's not empty
-                            normalized_text.append(line + "\n")
-                    cell.outputs.append(v4.new_output("stream", text=normalized_text))
-
-                elif output.output_type == "err_stream":
-                    text_data = []
-                    for mime_type, data in output.bundle.items():
-                        if isinstance(data, list):
-                            text_data.extend(data)
-                        else:
-                            text_data.append(data)
-                    full_text = "".join(text_data)
-                    full_text = full_text.replace("\\n", "\n")
-                    normalized_text = []
-                    lines = full_text.split("\n")
-                    for i, line in enumerate(lines):
-                        if i < len(lines) - 1:
-                            normalized_text.append(line + "\n")
-                        elif line:
-                            normalized_text.append(line + "\n")
-                    err_output = v4.new_output("stream", text=normalized_text)
-                    err_output.name = "stderr"
-                    cell.outputs.append(err_output)
-
-                elif output.output_type == "execute_result":
-                    data_dict = {}
-                    for mime_type, data in output.bundle.items():
-                        data_dict[mime_type] = data
-                    cell.outputs.append(
-                        v4.new_output(
-                            "execute_result",
-                            data=data_dict,
-                            execution_count=execution_count,
+                for mime_type, data in output.bundle.items():
+                    if output.output_type == "out_stream":
+                        text = data if isinstance(data, list) else [data]
+                        cell.outputs.append(v4.new_output("stream", text=text))
+                    elif output.output_type == "err_stream":
+                        text = data if isinstance(data, list) else [data]
+                        err_output = v4.new_output("stream", text=text)
+                        err_output.name = "stderr"
+                        cell.outputs.append(err_output)
+                    elif output.output_type == "execute_result":
+                        cell.outputs.append(
+                            v4.new_output(
+                                "execute_result",
+                                data={mime_type: data},
+                                execution_count=execution_count,
+                            )
                         )
-                    )
-
-                elif output.output_type == "display_data":
-                    # Collect all MIME types for this display_data into a single output
-                    data_dict = {}
-                    for mime_type, data in output.bundle.items():
-                        data_dict[mime_type] = data
-                    cell.outputs.append(
-                        v4.new_output(
-                            "display_data",
-                            data=data_dict,
+                    elif output.output_type == "display_data":
+                        cell.outputs.append(
+                            v4.new_output(
+                                "display_data",
+                                data={mime_type: data},
+                            )
                         )
-                    )
-                else:
-                    raise ValueError(f"Unknown output type: {output.output_type}")
+                    else:
+                        raise ValueError(f"Unknown output type: {output.output_type}")
 
             # Check if this execution_count is in exceptions (current session)
             if execution_count in exceptions:

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1094,7 +1094,7 @@ def test_notebook_export_single_display():
     _ip.history_manager.reset()
 
     try:
-        execution_count = _ip.execution_count
+        execution_count = _ip.execution_count = 1
         _ip.run_cell("'test'", store_history=True, silent=False)
 
         # Mock display output with multiple MIME types

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -35,6 +35,7 @@ from IPython.core.magic import (
     register_line_magic,
 )
 from IPython.core.magics import code, execution, logging, osm, script
+from IPython.core.history import HistoryOutput
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
 from IPython.utils.io import capture_output
@@ -1083,6 +1084,50 @@ def test_notebook_export_json_with_output():
             ), f"Outputs do not match for cell {i+1} with source {command!r}"
     finally:
         _ip.colors = "nocolor"
+
+
+def test_notebook_export_single_display():
+    """Test that multiple MIME types create a single display_data output, not multiple."""
+    pytest.importorskip("nbformat")
+
+    _ip = get_ipython()
+    _ip.history_manager.reset()
+
+    try:
+        execution_count = _ip.execution_count
+        _ip.run_cell("'test'", store_history=True, silent=False)
+
+        # Mock display output with multiple MIME types
+        test_display_history = HistoryOutput(
+            output_type="display_data",
+            bundle={"text/plain": "test", "text/html": "<div>test</div>"},
+        )
+        _ip.history_manager.outputs[execution_count] = [test_display_history]
+
+        with TemporaryDirectory() as td:
+            outfile = f"{td}/test.ipynb"
+            _ip.run_cell(f"%notebook {outfile}", store_history=True, silent=False)
+
+            # Verify single display_data output with both MIME types
+            with open(outfile, "r") as f:
+                nb = json.load(f)
+
+        cell = nb["cells"][0]
+        display_outputs = [
+            out for out in cell["outputs"] if out["output_type"] == "display_data"
+        ]
+
+        assert (
+            len(display_outputs) == 1
+        ), f"Expected 1 display_data output, got {len(display_outputs)}"
+
+        output_data = display_outputs[0]["data"]
+        assert set(output_data.keys()) == {"text/plain", "text/html"}
+        assert output_data["text/plain"] == ["test"]
+        assert output_data["text/html"] == ["<div>test</div>"]
+
+    finally:
+        _ip.history_manager.reset()
 
 
 class TestEnv(TestCase):

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1091,6 +1091,8 @@ def test_notebook_export_single_display():
     pytest.importorskip("nbformat")
 
     _ip = get_ipython()
+    orig_outputs = _ip.history_manager.outputs.copy()
+    orig_execution_count = _ip.execution_count
     _ip.history_manager.reset()
 
     try:
@@ -1127,7 +1129,8 @@ def test_notebook_export_single_display():
         assert output_data["text/html"] == ["<div>test</div>"]
 
     finally:
-        _ip.history_manager.reset()
+        _ip.history_manager.outputs = orig_outputs
+        _ip.execution_count = orig_execution_count
 
 
 class TestEnv(TestCase):


### PR DESCRIPTION
## Fixes #14989

### Description
The `%notebook` magic was incorrectly creating separate `display_data` outputs for each MIME type from a single widget, resulting in duplicate plots and widgets in exported notebooks.
The fix collects all MIME types from a single `display_data` output into one data dictionary, ensuring that widgets with multiple representations (`text/plain`, `text/html`, `image/png`, etc.) are exported as a single `display_data` entry in the notebook.

*Before*
```json
{
  "outputs": [
    {
      "output_type": "display_data",
      "data": {"text/plain": "test"},
      "metadata": {}
    },
    {
      "output_type": "display_data", 
      "data": {"text/html": "<div>test</div>"},
      "metadata": {}
    }
  ]
}
```
*After*
```json
{
  "outputs": [
    {
      "output_type": "display_data",
      "data": {
        "text/plain": "test",
        "text/html": "<div>test</div>"
      },
      "metadata": {}
    }
  ]
}
```

This resolves the multiple plots issue and makes the exported notebook structure match the expected format where all MIME types for a single output are grouped together.