### PR TITLE
Fix: Add support for forward_char as a keyboard shortcut

### DIFF
--- a/IPython/terminal/shortcuts/__init__.py
+++ b/IPython/terminal/shortcuts/__init__.py
@@ -631,6 +631,7 @@ UNASSIGNED_ALLOWED_COMMANDS = [
     nc.beginning_of_buffer,
     nc.end_of_buffer,
     nc.end_of_line,
+    nc.forward_char,
     nc.forward_word,
     nc.unix_line_discard,
 ]


### PR DESCRIPTION
The `forward_char` command is used to move the cursor forward by one character in the IPython terminal. However, when trying to create a keyboard shortcut for it (e.g., binding it to `Alt + l`), the following error was raised:
```
ValueError: prompt_toolkit:named_commands.forward_char is not a known shortcut command.
```
This happened because the `forward_char` command was not registered in the system. Specifically, the registration line was missing in `IPython/terminal/shortcuts/__init__.py`.

**Fix:**
Added the missing registration line for `forward_char`. Now it can be used as a keyboard shortcut without issues.

**Impact:**
Users can now bind custom key combinations to `forward_char` without encountering errors.