### PR TITLE
feat: Gruvbox Dark theme with same colours in exception tracebacks

### DIFF
--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -331,6 +331,40 @@ pridel_theme = Theme(
     symbols={"arrow_body": "\u2500", "arrow_head": "\u25b6", "top_line": "\u2500"},
 )
 
+GRUVBOX_VAL_EM = "#D79921"
+GRUVBOX_V_NAME = "#83A598"
+GRUVBOX_FILENAME = "#FBF1C7"
+GRUVBOX_EXCEPTION_NAME = "#FB4934"
+GRUVBOX_TOPLINE = "#CC241D"
+GRUVBOX_BREAKPOINT_ENABLED = "#FB4934"
+GRUVBOX_BREAKPOINT_DISABLED = "#CC241D"
+GRUVBOX_PROMPT = "#689D6A"
+GRUVBOX_PROMPT_NUM = "#8EC07C"
+GRUVBOX_OUT_PROMPT = "#B16286"
+GRUVBOX_OUT_PROMPT_NUM = "#D3869B"
+gruvbox_dark_theme = Theme(
+    "gruvbox-dark",
+    "gruvbox-dark",
+    {
+        Token.Lineno: GRUVBOX_PROMPT_NUM,
+        Token.LinenoEm: f"{GRUVBOX_PROMPT_NUM} bold",
+        Token.ValEm: f"{GRUVBOX_VAL_EM} bold",
+        Token.VName: GRUVBOX_V_NAME,
+        Token.Caret: "",
+        Token.Filename: GRUVBOX_FILENAME,
+        Token.FilenameEm: f"{GRUVBOX_FILENAME} bold",
+        Token.ExcName: f"{GRUVBOX_EXCEPTION_NAME} bold",
+        Token.Topline: GRUVBOX_TOPLINE,
+        Token.Breakpoint.Enabled: GRUVBOX_BREAKPOINT_ENABLED,
+        Token.Breakpoint.Disabled: GRUVBOX_BREAKPOINT_DISABLED,
+        Token.Prompt: GRUVBOX_PROMPT,
+        Token.PromptNum: f"{GRUVBOX_PROMPT_NUM} bold",
+        Token.OutPrompt: GRUVBOX_OUT_PROMPT,
+        Token.OutPromptNum: f"{GRUVBOX_OUT_PROMPT_NUM} bold",
+    },
+    symbols={"arrow_body": "\u2500", "arrow_head": "\u25b6", "top_line": "\u2500"},
+)
+
 theme_table: dict[str, Theme] = {
     "nocolor": nocolors_theme,
     "linux": linux_theme,
@@ -340,6 +374,7 @@ theme_table: dict[str, Theme] = {
     "lightbg": lightbg_theme,
     "pride": pride_theme,
     "pride:l": pridel_theme,
+    "gruvbox-dark": gruvbox_dark_theme,
 }
 
 

--- a/docs/source/config/details.rst
+++ b/docs/source/config/details.rst
@@ -222,7 +222,7 @@ To reflect this, the  ``--colors`` flag now is also aliased to ``--theme``.
 
 The default themes included are the same, except lowercase, for ease of typing. 
 
-``'nocolor', 'neutral', 'linux', 'lightbg'``, with the addition of ``'pride'``
+``'nocolor', 'neutral', 'linux', 'lightbg', 'gruvbox-dark'``, with the addition of ``'pride'``
 to celebrate the inclusively of this project (I welcome update to the pride
 theme as I'm not a designer myself). 
 

--- a/docs/source/whatsnew/pr/gruvbox-dark-theme.rst
+++ b/docs/source/whatsnew/pr/gruvbox-dark-theme.rst
@@ -1,0 +1,4 @@
+Gruvbox Dark Theme
+==================
+
+Gruvbox Dark is now available as a terminal syntax theme for IPython.


### PR DESCRIPTION
I hope this is allowed; the documentation does say that users are encouraged to contribute themes!

#### Gruvbox Dark Theme

This theme was available in older versions of IPython, but the exception tracebacks used colours from another theme. This change adds the theme and also uses the colours from it in tracebacks.

![ipython-gruvbox-dark-demo-1](https://github.com/user-attachments/assets/71b4d008-ea00-4359-9c1a-36249052c263)

#### Other Information

* The colour used to highlight the source of the exception can make the text unreadable, but a solution for the same has been proposed in https://github.com/ipython/ipython/issues/14863#issuecomment-2780603046.
* Although all lines in `docs/source/config/details.rst` are 80 characters or shorter in length, I didn't break the line I changed because that would affect the Git blame for the lines below.
* The names of the variables used to store colour codes for the existing themes in `IPython/utils/PyColorize.py` are actually names of the colours; I used the names of the tokens instead just as a matter of semantics. If you'd like that the names of the colours be used, I can make the change.