### PR TITLE
IPython now does not include the current working dir in sys.path, when PYTHONSAFEPATH is set or -P is used

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -260,7 +260,7 @@ class InteractiveShellApp(Configurable):
         .. versionchanged:: X.X
             Respect sys.flags.safe_path (PYTHONSAFEPATH and -P flag)
         """
-        if '' in sys.path or self.ignore_cwd or sys.flags.safe_path:
+        if "" in sys.path or self.ignore_cwd or sys.flags.safe_path:
             return
         for idx, path in enumerate(sys.path):
             parent, last_part = os.path.split(path)

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -247,6 +247,8 @@ class InteractiveShellApp(Configurable):
     def init_path(self):
         """Add current working directory, '', to sys.path
 
+        Unless disabled by ignore_cwd config or sys.flags.safe_path.
+
         Unlike Python's default, we insert before the first `site-packages`
         or `dist-packages` directory,
         so that it is after the standard library.
@@ -255,8 +257,10 @@ class InteractiveShellApp(Configurable):
             Try to insert after the standard library, instead of first.
         .. versionchanged:: 8.0
             Allow optionally not including the current directory in sys.path
+        .. versionchanged:: X.X
+            Respect sys.flags.safe_path (PYTHONSAFEPATH and -P flag)
         """
-        if '' in sys.path or self.ignore_cwd:
+        if '' in sys.path or self.ignore_cwd or sys.flags.safe_path:
             return
         for idx, path in enumerate(sys.path):
             parent, last_part = os.path.split(path)

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -257,7 +257,7 @@ class InteractiveShellApp(Configurable):
             Try to insert after the standard library, instead of first.
         .. versionchanged:: 8.0
             Allow optionally not including the current directory in sys.path
-        .. versionchanged:: X.X
+        .. versionchanged:: 9.7
             Respect sys.flags.safe_path (PYTHONSAFEPATH and -P flag)
         """
         if "" in sys.path or self.ignore_cwd or sys.flags.safe_path:

--- a/docs/source/whatsnew/pr/respect-pythonsafepath.rst
+++ b/docs/source/whatsnew/pr/respect-pythonsafepath.rst
@@ -1,0 +1,14 @@
+Respect PYTHONSAFEPATH
+======================
+
+IPython now respects the value of Python's flag ``sys.flags.safe_path``, a flag which is most often set by the ``PYTHONSAFEPATH`` environment variable. Setting this causes Python not to automatically include the current working directory in the sys.path.
+
+IPython can already be configured to do this via the ``--ignore_cwd`` command-line flag or by setting ``c.InteractiveShellApp.ignore_cwd=True``. Now, IPython can also be configured by setting ``PYTHONSAFEPATH=1`` or by calling python with ``-P``.
+
+The behavior of ``safe_path`` was described in `what's new in 3.11`_ and in `PyConfig docs`_.
+
+
+.. _what's new in 3.11: https://docs.python.org/3/whatsnew/3.11.html#whatsnew311-pythonsafepath
+.. _PyConfig docs: https://docs.python.org/3/c-api/init_config.html#c.PyConfig.safe_path
+
+


### PR DESCRIPTION
This updates IPython so that it respects the value of the Python flag `sys.flags.safe_path`, which is usually controlled by the environment variable PYTHONSAFEPATH, and which stops Python from adding the current working directory to the `sys.path`.

So now a user can do this by relying on that standard Python env var, or Python's `-P` command line flag, rather than relying on IPython's own `--ignore_cwd` command line flag.