### PR TITLE
feat: add method to register formatters

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -30,7 +30,7 @@ We can now define our own formatter and register it:
 
     >>> llm_formatter = LLMFormatter(parent=ip.display_formatter)
 
-    >>> ip.display_formatter.formatters[LLMFormatter.format_type] = llm_formatter
+    >>> ip.display_formatter.register_formatter(llm_formatter)
 
 Now any class that define `_repr_llm_` will return a x-vendor/llm as part of
 it's display data:
@@ -145,6 +145,14 @@ class DisplayFormatter(Configurable):
             f = cls(parent=self)
             d[f.format_type] = f
         return d
+
+    def register_formatter(self, formatter):
+        if formatter.format_type in self.formatters:
+            warnings.warn(
+                f"Replacing formatter {type(self.formatters[formatter.format_type])} with {type(formatter)}",
+                FormatterWarning,
+            )
+        self.formatters[formatter.format_type] = formatter
 
     def format(self, obj, include=None, exclude=None):
         """Return a format data dict for an object.

--- a/docs/source/whatsnew/pr/formatter-registration.rst
+++ b/docs/source/whatsnew/pr/formatter-registration.rst
@@ -2,4 +2,4 @@ Formatter registration
 ======================
 
 Formatter can now be registered in an easier fashion using the new
-`DisplayFormatter.register_formatter`method.
+``DisplayFormatter.register_formatter`` method.

--- a/docs/source/whatsnew/pr/formatter-registration.rst
+++ b/docs/source/whatsnew/pr/formatter-registration.rst
@@ -1,0 +1,5 @@
+Formatter registration
+======================
+
+Formatter can now be registered in an easier fashion using the new
+`DisplayFormatter.register_formatter`method.

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -11,12 +11,14 @@ import pytest
 from IPython import get_ipython
 from traitlets.config import Config
 from IPython.core.formatters import (
+    BaseFormatter,
     PlainTextFormatter,
     HTMLFormatter,
     PDFFormatter,
     _mod_name_key,
     DisplayFormatter,
     JSONFormatter,
+    FormatterWarning,
 )
 from IPython.utils.io import capture_output
 
@@ -608,3 +610,20 @@ def test_custom_repr_namedtuple_partialmethod():
     f = PlainTextFormatter()
     assert f.pprint
     assert f(foo) == "Hello World"
+
+
+def test_formatter_registration():
+    class TestFormatter(BaseFormatter):
+        format_type = "x-vendor/test"
+        print_method = "_repr_test_"
+        _return_type = (dict, str)
+
+    f = get_ipython().display_formatter
+    formatter = TestFormatter(parent=f)
+    f.register_formatter(formatter)
+
+    assert formatter.format_type in f.formatters
+
+    with capture_output() as captured:
+        with pytest.warns(FormatterWarning):
+            result = f.register_formatter(formatter)


### PR DESCRIPTION
The new `DisplayFormatter.register_formatter`makes registering formatters more intuitive.

It also provides a centralized place for future additional checks if needed.

Fixes #14580