### PR TITLE
Fix tab completion for subclasses of trusted classes

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -180,7 +180,10 @@ def _has_original_dunder_external(
             method = getattr(value_type, method_name, None)
             for base_class in value_type.__mro__[1:]:
                 base_module = getmodule(base_class)
-                if base_module and base_module.__name__ == member_type.__name__:
+                if base_module and (
+                    base_module.__name__ == member_type.__name__
+                    or base_module.__name__.startswith(member_type.__name__ + ".")
+                ):
                     # Check if the method comes from this trusted base class
                     base_method = getattr(base_class, method_name, None)
                     if base_method is not None and base_method == method:

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -176,6 +176,15 @@ def _has_original_dunder_external(
             member_method = getattr(member_type, method_name, None)
             if member_method == method:
                 return True
+        if isinstance(member_type, ModuleType):
+            method = getattr(value_type, method_name, None)
+            for base_class in value_type.__mro__[1:]:
+                base_module = getmodule(base_class)
+                if base_module and base_module.__name__ == member_type.__name__:
+                    # Check if the method comes from this trusted base class
+                    base_method = getattr(base_class, method_name, None)
+                    if base_method is not None and base_method == method:
+                        return True
     except (AttributeError, KeyError):
         return False
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1516,6 +1516,56 @@ class TestCompleter(unittest.TestCase):
             _, matches = complete(line_buffer="unsafe_list_factory.example.")
             self.assertNotIn(".append", matches)
 
+    def test_completion_allow_subclass_of_trusted_module(self):
+        factory_code = textwrap.dedent(
+            """
+            class ListFactory:
+                def __getattr__(self, attr):
+                    return []
+            """
+        )
+        trusted_lib = types.ModuleType("my.trusted.lib")
+        sys.modules["my.trusted.lib"] = trusted_lib
+        exec(factory_code, trusted_lib.__dict__)
+
+        ip = get_ipython()
+        # Create a subclass in __main__ (untrusted namespace)
+        subclass_code = textwrap.dedent(
+            """
+            class SubclassFactory(trusted_lib.ListFactory):
+                pass
+            """
+        )
+        ip.user_ns["trusted_lib"] = trusted_lib
+        exec(subclass_code, ip.user_ns)
+        ip.user_ns["subclass_factory"] = ip.user_ns["SubclassFactory"]()
+        complete = ip.Completer.complete
+        with (
+            evaluation_policy("limited", allowed_getattr_external={"my.trusted.lib"}),
+            jedi_status(False),
+        ):
+            _, matches = complete(line_buffer="subclass_factory.example.")
+            self.assertIn(".append", matches)
+
+        # Test that overriding __getattr__ in subclass in untrusted namespace prevents completion
+        overriding_subclass_code = textwrap.dedent(
+            """
+            class OverridingSubclass(trusted_lib.ListFactory):
+                def __getattr__(self, attr):
+                    return {}
+            """
+        )
+        exec(overriding_subclass_code, ip.user_ns)
+        ip.user_ns["overriding_factory"] = ip.user_ns["OverridingSubclass"]()
+
+        with (
+            evaluation_policy("limited", allowed_getattr_external={"my.trusted.lib"}),
+            jedi_status(False),
+        ):
+            _, matches = complete(line_buffer="overriding_factory.example.")
+            self.assertNotIn(".append", matches)
+            self.assertNotIn(".keys", matches)
+
     def test_policy_warnings(self):
         with self.assertWarns(
             UserWarning,


### PR DESCRIPTION
## Fixes #14988

## Solution
Added logic to check the MRO for base classes from trusted modules. Now trusts subclasses if:
- Any parent class comes from a trusted module
- The `__getattr__`  method is inherited (not overridden)
