### PR TITLE
Prevent trusting modules with matching prefix

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -165,7 +165,10 @@ def _has_original_dunder_external(
             value_module = getmodule(value_type)
             if not value_module or not value_module.__name__:
                 return False
-            if value_module.__name__.startswith(member_type.__name__):
+            if (
+                value_module.__name__ == member_type.__name__
+                or value_module.__name__.startswith(member_type.__name__ + ".")
+            ):
                 return True
         if method_name == "__getattribute__":
             # we have to short-circuit here due to an unresolved issue in

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1481,9 +1481,14 @@ class TestCompleter(unittest.TestCase):
         sys.modules["my.unsafe.lib"] = unsafe_lib
         exec(factory_code, unsafe_lib.__dict__)
 
+        fake_safe_lib = types.ModuleType("my_fake_lib")
+        sys.modules["my_fake_lib"] = fake_safe_lib
+        exec(factory_code, fake_safe_lib.__dict__)
+
         ip = get_ipython()
         ip.user_ns["safe_list_factory"] = safe_lib.ListFactory()
         ip.user_ns["unsafe_list_factory"] = unsafe_lib.ListFactory()
+        ip.user_ns["fake_safe_factory"] = fake_safe_lib.ListFactory()
         complete = ip.Completer.complete
         with (
             evaluation_policy("limited", allowed_getattr_external={"my.safe.lib"}),
@@ -1506,6 +1511,8 @@ class TestCompleter(unittest.TestCase):
             self.assertIn(".append", matches)
             _, matches = complete(line_buffer="unsafe_list_factory.example.")
             self.assertIn(".append", matches)
+            _, matches = complete(line_buffer="fake_safe_factory.example.")
+            self.assertNotIn(".append", matches)
 
         with (
             evaluation_policy("limited"),


### PR DESCRIPTION
### Fixes #15021 

Modified module trust validation to require exact name match or proper submodule notation (with dot separator), preventing modules like `my_fake` from being trusted when only `my` is in the allowlist.