### PR TITLE
Fix `%time` magic on windows

### DIFF
--- a/IPython/core/magic_arguments.py
+++ b/IPython/core/magic_arguments.py
@@ -164,7 +164,7 @@ class MagicArgumentParser(argparse.ArgumentParser):
     def parse_argstring(self, argstring, *, partial=False):
         """ Split a string into an argument list and parse that argument list.
         """
-        argv = arg_split(argstring)
+        argv = arg_split(argstring, strict=not partial)
         if partial:
             return self.parse_known_args(argv)
         return self.parse_args(argv)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -441,7 +441,7 @@ def test_time():
     with tt.AssertPrints("a space"):
         with tt.AssertPrints("Wall time: ", suppress=False):
             with tt.AssertPrints("CPU times: ", suppress=False):
-                ip.run_cell("%time print('a space')")
+                ip.run_cell('%time print("a space")')
 
 
 # ';' at the end of %time prevents instruction value to be printed.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -438,6 +438,11 @@ def test_time():
         with tt.AssertPrints("hihi", suppress=False):
             ip.run_cell("f('hi')")
 
+    with tt.AssertPrints("a space"):
+        with tt.AssertPrints("Wall time: ", suppress=False):
+            with tt.AssertPrints("CPU times: ", suppress=False):
+                ip.run_cell("%time print('a space')")
+
 
 # ';' at the end of %time prevents instruction value to be printed.
 # This tests fix for #13837.


### PR DESCRIPTION
### Fixes #15017 

### Possible Cause
The Windows-specific `arg_split` uses `CommandLineToArgvW` API which mangles Python expressions with quotes, turning `print("a space")` into `print("a space)`.

### Solution
Use `strict=False` when calling `arg_split` in **partial** parsing mode. This triggers the Python-based fallback splitter instead of the Windows API, correctly preserving quoted strings.

Modified `parse_argstring` to pass `strict=not partial` to `arg_split`