### PR TITLE
Infer type from return value and improve attribute completions

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -579,7 +579,7 @@ def _handle_assign(node: ast.Assign, context: EvaluationContext):
             for i in range(star_or_last_idx):
                 # Check for self.x assignment
                 if _is_instance_attribute_assignment(targets[i], context):
-                        class_transients[targets[i].attr] = values[i]
+                    class_transients[targets[i].attr] = values[i]
                 else:
                     transient_locals[targets[i].id] = values[i]
 
@@ -609,7 +609,7 @@ def _handle_assign(node: ast.Assign, context: EvaluationContext):
                         ]
         else:
             if _is_instance_attribute_assignment(target, context):
-                    class_transients[target.attr] = value
+                class_transients[target.attr] = value
             else:
                 transient_locals[target.id] = value
     return None

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -700,7 +700,9 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
 
         if func_context.class_transients is not None:
             if not is_static and not is_classmethod:
-                func_context.instance_arg_name = node.args.args[0].arg
+                func_context.instance_arg_name = (
+                    node.args.args[0].arg if node.args.args else None
+                )
 
         return_type = eval_node(node.returns, context=context)
 

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -663,8 +663,8 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
                     return_type, context
                 )
             else:
-                inferred_duck_object = _infer_return_value(node, context)
-                context.transient_locals[node.name] = inferred_duck_object
+                return_value = _infer_return_value(node, context)
+                context.transient_locals[node.name] = return_value
 
             return None
 

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -684,7 +684,7 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
         return None
     if isinstance(node, ast.ClassDef):
         # TODO support class decorators?
-        class_locals = {}
+        class_locals = context.transient_locals.copy()
         class_context = context.replace(transient_locals=class_locals)
         for child_node in node.body:
             eval_node(child_node, class_context)

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -942,7 +942,7 @@ def _merge_values(values, policy: EvaluationPolicy):
         if policy.can_call(v.__dir__):
             attributes.update(dir(v))
         try:
-            if policy.can_get_item(v, None):
+            if policy.can_call(v.items):
                 try:
                     for k, val in v.items():
                         key_values.setdefault(k, []).append(val)

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -938,18 +938,21 @@ def _merge_values(values, policy: EvaluationPolicy):
     merged_items = None
     key_values = {}
     for v in values:
-        if hasattr(v, "items") and policy.can_get_item(v, None):
-            try:
-                for k, val in v.items():
-                    key_values.setdefault(k, []).append(val)
-            except Exception as e:
-                pass
-        elif hasattr(v, "keys") and policy.can_call(v.keys):
-            try:
-                for k in v.keys():
-                    key_values.setdefault(k, []).append(None)
-            except Exception as e:
-                pass
+        try:
+            if policy.can_get_item(v, None):
+                try:
+                    for k, val in v.items():
+                        key_values.setdefault(k, []).append(val)
+                except Exception as e:
+                    pass
+            elif policy.can_call(v.keys):
+                try:
+                    for k in v.keys():
+                        key_values.setdefault(k, []).append(None)
+                except Exception as e:
+                    pass
+        except Exception as e:
+            pass
 
     if key_values:
         merged_items = {

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -922,6 +922,10 @@ def _collect_return_values(body, context):
                     return_values.append(value)
             except Exception:
                 pass
+        if isinstance(
+            stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
+            continue
         elif hasattr(stmt, "body") and isinstance(stmt.body, list):
             return_values.extend(_collect_return_values(stmt.body, context))
         if isinstance(stmt, ast.Try):

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -565,7 +565,6 @@ def _handle_assign(node: ast.Assign, context: EvaluationContext):
     value = eval_node(node.value, context)
     transient_locals = context.transient_locals
     class_transients = context.class_transients
-    policy = get_policy(context)
     for target in node.targets:
         if isinstance(target, (ast.Tuple, ast.List)):
             # Handle unpacking assignment
@@ -736,7 +735,6 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
         return None
     if isinstance(node, ast.ClassDef):
         # TODO support class decorators?
-        # class_locals = context.transient_locals.copy()
         class_locals = {}
         outer_locals = context.locals.copy()
         outer_locals.update(context.transient_locals)

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -937,7 +937,10 @@ def _merge_values(values, policy: EvaluationPolicy):
     types = {type(v) for v in values}
     merged_items = None
     key_values = {}
+    attributes = set()
     for v in values:
+        if policy.can_call(v.__dir__):
+            attributes.update(dir(v))
         try:
             if policy.can_get_item(v, None):
                 try:
@@ -972,11 +975,6 @@ def _merge_values(values, policy: EvaluationPolicy):
             if t in (list, set, tuple):
                 return t
             return values[0]
-
-    attributes = set()
-    for v in values:
-        if policy.can_call(v.__dir__):
-            attributes.update(dir(v))
 
     return _Duck(attributes=dict.fromkeys(attributes), items=merged_items)
 

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -968,13 +968,13 @@ def _merge_values(values, policy: EvaluationPolicy):
     merged_items = None
     key_values = {}
     for v in values:
-        if policy.can_get_item(v, None):
+        if hasattr(v, "items") and policy.can_get_item(v, None):
             try:
                 for k, val in v.items():
                     key_values.setdefault(k, []).append(val)
             except Exception as e:
                 pass
-        elif policy.can_call(v.keys):
+        elif hasattr(v, "keys") and policy.can_call(v.keys):
             try:
                 for k in v.keys():
                     key_values.setdefault(k, []).append(None)

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -736,8 +736,13 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
         return None
     if isinstance(node, ast.ClassDef):
         # TODO support class decorators?
-        class_locals = context.transient_locals.copy()
-        class_context = context.replace(transient_locals=class_locals)
+        # class_locals = context.transient_locals.copy()
+        class_locals = {}
+        outer_locals = context.locals.copy()
+        outer_locals.update(context.transient_locals)
+        class_context = context.replace(
+            transient_locals=class_locals, locals=outer_locals
+        )
         class_context.class_transients = class_locals
         for child_node in node.body:
             eval_node(child_node, class_context)

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -564,7 +564,7 @@ def _validate_policy_overrides(
 def _handle_assign(node: ast.Assign, context: EvaluationContext):
     value = eval_node(node.value, context)
     transient_locals = context.transient_locals
-    class_transients = getattr(context, "class_transients", None)
+    class_transients = context.class_transients
     for target in node.targets:
         if isinstance(target, (ast.Tuple, ast.List)):
             # Handle unpacking assignment
@@ -748,10 +748,9 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
             value = _resolve_annotation(eval_node(node.annotation, context), context)
             context.transient_locals[node.target.id] = value
         # Handle non-simple annotated assignments only for self.x: type = value
-        class_transients = getattr(context, "class_transients", None)
         if _is_instance_attribute_assignment(node.target, context):
             value = _resolve_annotation(eval_node(node.annotation, context), context)
-            class_transients[node.target.attr] = value
+            context.class_transients[node.target.attr] = value
         return None
     if isinstance(node, ast.Expression):
         return eval_node(node.body, context)

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -866,20 +866,13 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
 
 def _infer_return_value(node: ast.FunctionDef, context: EvaluationContext):
     """Execute the function body to infer its return value."""
-    temp_context = EvaluationContext(
-        globals=context.globals,
-        locals=context.locals.copy(),
-        evaluation=context.evaluation,
-        in_subscript=context.in_subscript,
-        transient_locals={},
-    )
 
     for stmt in node.body:
         if isinstance(stmt, ast.Return):
             if stmt.value is None:
                 return None
             try:
-                value = eval_node(stmt.value, temp_context)
+                value = eval_node(stmt.value, context)
                 if value is not NOT_EVALUATED:
                     return value
             except Exception:

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2189,6 +2189,55 @@ class TestCompleter(unittest.TestCase):
             ),
             "append",
         ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.test = []",
+                    "instance = NotYetDefined()",
+                    "instance.",
+                ]
+            ),
+            "test",
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.test = []",
+                    "instance = NotYetDefined()",
+                    "instance.test.",
+                ]
+            ),
+            "append",
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.test:str = []",
+                    "instance = NotYetDefined()",
+                    "instance.test.",
+                ]
+            ),
+            "capitalize",
+        ],
+        [
+            "\n".join(
+                [
+                    "l = []",
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.test = l",
+                    "instance = NotYetDefined()",
+                    "instance.test.",
+                ]
+            ),
+            "append",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2120,6 +2120,16 @@ class TestCompleter(unittest.TestCase):
             ),
             "as_integer_ratio",
         ],
+        [
+            "\n".join(
+                [
+                    "def my_test():",
+                    "    return {}",
+                    "my_test().",
+                ]
+            ),
+            "keys",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2178,6 +2178,17 @@ class TestCompleter(unittest.TestCase):
             ),
             "as_integer_ratio",
         ],
+        [
+            "\n".join(
+                [
+                    "def foo():",
+                    "    l = []",
+                    "    return l",
+                    "foo().",
+                ]
+            ),
+            "append",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2130,6 +2130,17 @@ class TestCompleter(unittest.TestCase):
             ),
             "keys",
         ],
+        [
+            "\n".join(
+                [
+                    "l = []",
+                    "def my_test():",
+                    "    return l",
+                    "my_test().",
+                ]
+            ),
+            "append",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2154,6 +2154,30 @@ class TestCompleter(unittest.TestCase):
             ),
             "append",
         ],
+        [
+            "\n".join(
+                [
+                    "def string_or_int(flag):",
+                    "    if flag:",
+                    "        return 'test'",
+                    "    return 1",
+                    "string_or_int().",
+                ]
+            ),
+            "capitalize",
+        ],
+        [
+            "\n".join(
+                [
+                    "def string_or_int(flag):",
+                    "    if flag:",
+                    "        return 'test'",
+                    "    return 1",
+                    "string_or_int().",
+                ]
+            ),
+            "as_integer_ratio",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2243,6 +2243,18 @@ class TestCompleter(unittest.TestCase):
         [
             "\n".join(
                 [
+                    "class NotYetDefined:",
+                    "    def test():",
+                    "        return []",
+                    "instance = NotYetDefined()",
+                    "instance.test().",
+                ]
+            ),
+            "append",
+        ],
+        [
+            "\n".join(
+                [
                     "def foo():",
                     "    if some_condition:",
                     "        return {'top':{'mid':{'leaf': 2}}}",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2268,7 +2268,7 @@ class TestCompleter(unittest.TestCase):
             "\n".join(
                 [
                     "def foo():",
-                    "    if 1+1==2:",
+                    "    if some_condition:",
                     "        return {'top':{'mid':{'leaf': 2}}}",
                     "    return {'top': {'mid':[]}}",
                     "foo()['top']['mid']['leaf'].",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2243,18 +2243,6 @@ class TestCompleter(unittest.TestCase):
         [
             "\n".join(
                 [
-                    "def test():",
-                    "   a = {}",
-                    "   a['b'] = []",
-                    "   return a",
-                    "test()['b'].",
-                ]
-            ),
-            "append",
-        ],
-        [
-            "\n".join(
-                [
                     "class NotYetDefined:",
                     "    def test():",
                     "        return []",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2141,6 +2141,19 @@ class TestCompleter(unittest.TestCase):
             ),
             "append",
         ],
+        [
+            "\n".join(
+                [
+                    "l = []",
+                    "class NotYetDefined:",
+                    "    def my_method(self):",
+                    "        return l",
+                    "my_instance = NotYetDefined()",
+                    "my_instance.my_method().",
+                ]
+            ),
+            "append",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2093,10 +2093,11 @@ class TestCompleter(unittest.TestCase):
             "\n".join(
                 [
                     "class NotYetDefined:",
-                    "    def my_method(self):",
+                    "    @property",
+                    "    def my_property(self):",
                     "        return 1.1",
                     "my_instance = NotYetDefined()",
-                    "my_instance.my_method().",
+                    "my_instance.my_property.",
                 ]
             ),
             "as_integer_ratio",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2256,19 +2256,6 @@ class TestCompleter(unittest.TestCase):
             "\n".join(
                 [
                     "class NotYetDefined:",
-                    "    def __init__(self):",
-                    "        self.a = {}",
-                    "        self.a['b'] = 'str'",
-                    "instance = NotYetDefined()",
-                    "instance.a['b'].",
-                ]
-            ),
-            "capitalize",
-        ],
-        [
-            "\n".join(
-                [
-                    "class NotYetDefined:",
                     "    def test():",
                     "        return []",
                     "instance = NotYetDefined()",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2080,6 +2080,30 @@ class TestCompleter(unittest.TestCase):
         [
             "\n".join(
                 [
+                    "class NotYetDefined:",
+                    "    def my_method(self):",
+                    "        return []",
+                    "my_instance = NotYetDefined()",
+                    "my_instance.my_method().",
+                ]
+            ),
+            "append",
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def my_method(self):",
+                    "        return 1.1",
+                    "my_instance = NotYetDefined()",
+                    "my_instance.my_method().",
+                ]
+            ),
+            "as_integer_ratio",
+        ],
+        [
+            "\n".join(
+                [
                     "my_instance = 1.1",
                     "assert my_instance.",
                 ]

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2230,10 +2230,23 @@ class TestCompleter(unittest.TestCase):
         [
             "\n".join(
                 [
+                    "class NotYetDefined:",
+                    "    def test(self):",
+                    "        self.l = []",
+                    "        return self.l",
+                    "instance = NotYetDefined()",
+                    "instance.test().",
+                ]
+            ),
+            "append",
+        ],
+        [
+            "\n".join(
+                [
                     "def foo():",
                     "    if 1+1==2:",
-                    "        return {'top':{'mid':{'leaf': 2}}}",
-                    "    return {'top': {'mid':[]}}",
+                    "        return {'top':{'mid':[]}}",
+                    "    return {'top': {'mid':{'leaf': 2}}}",
                     "foo()['top']['mid'].",
                 ]
             ),

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2245,12 +2245,12 @@ class TestCompleter(unittest.TestCase):
                 [
                     "def foo():",
                     "    if 1+1==2:",
-                    "        return {'top':{'mid':[]}}",
-                    "    return {'top': {'mid':{'leaf': 2}}}",
+                    "        return {'top':{'mid':{'leaf': 2}}}",
+                    "    return {'top': {'mid':[]}}",
                     "foo()['top']['mid'].",
                 ]
             ),
-            ["clear", "append"],
+            ["keys", "append"],
         ],
         [
             "\n".join(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2243,6 +2243,31 @@ class TestCompleter(unittest.TestCase):
         [
             "\n".join(
                 [
+                    "def test():",
+                    "   a = {}",
+                    "   a['b'] = []",
+                    "   return a",
+                    "test()['b'].",
+                ]
+            ),
+            "append",
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.a = {}",
+                    "        self.a['b'] = 'str'",
+                    "instance = NotYetDefined()",
+                    "instance.a['b'].",
+                ]
+            ),
+            "capitalize",
+        ],
+        [
+            "\n".join(
+                [
                     "class NotYetDefined:",
                     "    def test():",
                     "        return []",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2165,19 +2165,7 @@ class TestCompleter(unittest.TestCase):
                     "string_or_int().",
                 ]
             ),
-            "capitalize",
-        ],
-        [
-            "\n".join(
-                [
-                    "def string_or_int(flag):",
-                    "    if flag:",
-                    "        return 'test'",
-                    "    return 1",
-                    "string_or_int().",
-                ]
-            ),
-            "as_integer_ratio",
+            ["capitalize", "as_integer_ratio"],
         ],
         [
             "\n".join(
@@ -2206,8 +2194,8 @@ class TestCompleter(unittest.TestCase):
             "\n".join(
                 [
                     "class NotYetDefined:",
-                    "    def __init__(self):",
-                    "        self.test = []",
+                    "    def __init__(instance):",
+                    "        instance.test = []",
                     "instance = NotYetDefined()",
                     "instance.test.",
                 ]
@@ -2218,8 +2206,8 @@ class TestCompleter(unittest.TestCase):
             "\n".join(
                 [
                     "class NotYetDefined:",
-                    "    def __init__(self):",
-                    "        self.test:str = []",
+                    "    def __init__(this):",
+                    "        this.test:str = []",
                     "instance = NotYetDefined()",
                     "instance.test.",
                 ]
@@ -2231,13 +2219,37 @@ class TestCompleter(unittest.TestCase):
                 [
                     "l = []",
                     "class NotYetDefined:",
-                    "    def __init__(self):",
-                    "        self.test = l",
+                    "    def __init__(me):",
+                    "        me.test = l",
                     "instance = NotYetDefined()",
                     "instance.test.",
                 ]
             ),
             "append",
+        ],
+        [
+            "\n".join(
+                [
+                    "def foo():",
+                    "    if 1+1==2:",
+                    "        return {'top':{'mid':{'leaf': 2}}}",
+                    "    return {'top': {'mid':[]}}",
+                    "foo()['top']['mid'].",
+                ]
+            ),
+            ["clear", "append"],
+        ],
+        [
+            "\n".join(
+                [
+                    "def foo():",
+                    "    if 1+1==2:",
+                    "        return {'top':{'mid':{'leaf': 2}}}",
+                    "    return {'top': {'mid':[]}}",
+                    "foo()['top']['mid']['leaf'].",
+                ]
+            ),
+            "as_integer_ratio",
         ],
     ],
 )
@@ -2248,11 +2260,11 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
 
     with provisionalcompleter():
         completions = list(ip.Completer.completions(text=code, offset=offset))
-        match = [c for c in completions if c.text.lstrip(".") == insert_text]
-        message_on_fail = (
-            f"{insert_text} not found among {[c.text for c in completions]}"
-        )
-        assert len(match) == 1, message_on_fail
+        insert_texts = insert_text if isinstance(insert_text, list) else [insert_text]
+        for text in insert_texts:
+            match = [c for c in completions if c.text.lstrip(".") == text]
+            message_on_fail = f"{text} not found among {[c.text for c in completions]}"
+            assert len(match) == 1, message_on_fail
 
 
 @pytest.mark.parametrize(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2244,7 +2244,7 @@ class TestCompleter(unittest.TestCase):
             "\n".join(
                 [
                     "def foo():",
-                    "    if 1+1==2:",
+                    "    if some_condition:",
                     "        return {'top':{'mid':{'leaf': 2}}}",
                     "    return {'top': {'mid':[]}}",
                     "foo()['top']['mid'].",


### PR DESCRIPTION
### Fixes #15025 
### Fixes #15026 
### Follow-up to https://github.com/ipython/ipython/pull/14993

### Description
With:
```
%config Completer.use_jedi=True
```
Enables completions for class methods without return type annotations by evaluating the property body and inferring the type from the actual return value.
Also enables completions for instance attributes assigned in class methods.

<img width="438" height="450" alt="image" src="https://github.com/user-attachments/assets/51ec332a-0d89-4320-89b4-78cbb9040e7b" />

<img width="675" height="186" alt="image" src="https://github.com/user-attachments/assets/d9730a14-65ea-48ad-bf5d-66541271d1f6" />

<img width="777" height="368" alt="image" src="https://github.com/user-attachments/assets/be2c3adf-31f6-461f-a30d-354ab1f61fad" />

<img width="390" height="194" alt="image" src="https://github.com/user-attachments/assets/b07cae2b-dbae-4de2-8d55-875563608bf3" />

<img width="524" height="246" alt="image" src="https://github.com/user-attachments/assets/7a26703e-5379-47d8-938d-8f87134c109b" />


- [x] Added tests