### PR TITLE
fixed AssertionError while rendering traceback in ipython 9.6.0

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -336,13 +336,18 @@ class ListTB(TBTools):
                     )
                 )
                 if textline == "":
-                    # sep 2025:
-                    # textline = py3compat.cast_unicode(value.text, "utf-8")
-                    if value.text is None:
+                    # Gracefully coerce SyntaxError.text into a printable str.
+                    value_text = getattr(value, "text", None)
+                    if value_text is None:
                         textline = ""
                     else:
-                        assert isinstance(value.text, str)
-                        textline = value.text
+                        try:
+                            textline = py3compat.cast_unicode(value_text, "utf-8")
+                        except Exception:
+                            # As a last resort, fall back to ``str`` for exotic objects.
+                            textline = str(value_text)
+                        if textline is None:
+                            textline = ""
 
                 if textline is not None:
                     i = 0

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -342,7 +342,11 @@ class ListTB(TBTools):
                         textline = ""
                     else:
                         try:
-                            textline = py3compat.cast_unicode(value_text, "utf-8")
+                            # Handle bytes by decoding to utf-8, fallback to str() for other types
+                            if isinstance(value_text, bytes):
+                                textline = value_text.decode("utf-8", "replace")
+                            else:
+                                textline = str(value_text)
                         except Exception:
                             # As a last resort, fall back to ``str`` for exotic objects.
                             textline = str(value_text)

--- a/tests/test_ultratb.py
+++ b/tests/test_ultratb.py
@@ -264,6 +264,12 @@ bar_syntax_error_test_2()
             with tt.AssertPrints("QWERTY"):
                 ip.showsyntaxerror()
 
+    def test_parseerror_non_string_text(self):
+        cell = "from xml.etree import ElementTree\nElementTree.fromstring('hello')"
+        with tt.AssertNotPrints("Internal Python error", channel="stderr"):
+            with tt.AssertPrints("ParseError"):
+                ip.run_cell(cell)
+
 
 import sys
 


### PR DESCRIPTION
Issue - [https://github.com/ipython/ipython/issues/15024](https://github.com/ipython/ipython/issues/15024)

## Resolution - 
Restored safe coercion of SyntaxError.text so tracebacks now decode bytes via py3compat.cast_unicode, fall back cleanly to str, and avoid the AssertionError path identified in gh-15024 (ultratb.py). Added a regression in test_ultratb.py that triggers xml.etree.ElementTree.ParseError and confirms we no longer emit “Internal Python error”.