### PR TITLE
Infer type for locals and attributes defined in `__init__()`

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -677,6 +677,10 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
         class_context = context.replace(transient_locals=class_locals)
         for child_node in node.body:
             eval_node(child_node, class_context)
+        # extract self.attribute assignments
+        init_attributes = _extract_init_attributes(node, class_context)
+        # Merge init attributes into class_locals
+        class_locals.update(init_attributes)
         bases = tuple([eval_node(base, context) for base in node.bases])
         dummy_class = type(node.name, bases, class_locals)
         context.transient_locals[node.name] = dummy_class
@@ -852,6 +856,116 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
         return eval_node(node.test, context)
     return None
 
+
+def _extract_init_attributes(class_node: ast.ClassDef, context: EvaluationContext):
+    """Extract attribute assignments from __init__ method.
+
+    Looks for patterns like:
+        self.attr = value
+        self.attr: Type = value
+
+    And infers their types by evaluating the assigned values.
+
+    Returns dictionary mapping attribute names to their inferred Duck types
+    """
+    attributes = {}
+    init_method = None
+    for node in class_node.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__":
+            init_method = node
+            break
+
+    if not init_method:
+        return attributes
+
+    temp_context = EvaluationContext(
+        globals=context.globals,
+        locals=context.locals,
+        evaluation=context.evaluation,
+        in_subscript=context.in_subscript,
+        transient_locals={},
+    )
+
+    for stmt in init_method.body:
+        # Handle regular assignments: self.attr = value
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Attribute):
+                    if isinstance(target.value, ast.Name) and target.value.id == "self":
+                        attr_name = target.attr
+                        try:
+                            # Evaluate the assigned value
+                            value = eval_node(stmt.value, temp_context)
+                            if value is not None and value is not NOT_EVALUATED:
+                                inferred_type = _create_duck_from_value(value)
+                                if inferred_type is not None:
+                                    attributes[attr_name] = inferred_type
+                        except Exception:
+                            # Skip the attribute
+                            pass
+
+        # Handle annotated assignments: self.attr: Type = value
+        elif isinstance(stmt, ast.AnnAssign):
+            if isinstance(stmt.target, ast.Attribute):
+                if (
+                    isinstance(stmt.target.value, ast.Name)
+                    and stmt.target.value.id == "self"
+                ):
+                    attr_name = stmt.target.attr
+
+                    # Try to use the annotation
+                    if stmt.annotation:
+                        try:
+                            annotation = eval_node(stmt.annotation, temp_context)
+                            resolved = _resolve_annotation(annotation, context)
+                            if resolved is not None:
+                                attributes[attr_name] = resolved
+                                continue
+                        except Exception:
+                            pass
+
+                    # Try to infer from value
+                    if stmt.value:
+                        try:
+                            value = eval_node(stmt.value, temp_context)
+                            if value is not None and value is not NOT_EVALUATED:
+                                inferred_type = _create_duck_from_value(value)
+                                if inferred_type is not None:
+                                    attributes[attr_name] = inferred_type
+                        except Exception:
+                            pass
+
+    return attributes
+
+
+def _create_duck_from_value(value):
+    """Create a Duck object from an actual runtime value."""
+    if value is None or value is NOT_EVALUATED:
+        return None
+    value_type = type(value)
+    if isinstance(value, dict):
+        return _Duck(
+            attributes=dict.fromkeys(dir(dict())), items=value if value else {}
+        )
+    elif isinstance(value, list):
+        element_duck = None
+        if value:
+            element_duck = _create_duck_from_value(value[0])
+        return _Duck(
+            attributes=dict.fromkeys(dir(list())),
+            items=_GetItemDuck(lambda: element_duck),
+        )
+    elif isinstance(value, set):
+        return _Duck(attributes=dict.fromkeys(dir(set())))
+    elif isinstance(value, tuple):
+        return value
+    elif isinstance(value, (str, int, float, bool, bytes)):
+        return _Duck(attributes=dict.fromkeys(dir(value_type())))
+    else:
+        try:
+            return _create_duck_for_heap_type(value_type)
+        except Exception:
+            return _Duck(attributes=dict.fromkeys(dir(value)))
 
 def _eval_return_type(func: Callable, node: ast.Call, context: EvaluationContext):
     """Evaluate return type of a given callable function.

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -931,9 +931,7 @@ def _extract_variables_from_module(
     module_node: Union[ast.Module, ast.Interactive, None], context: EvaluationContext
 ):
     """Extract and evaluate variable assignments from a module AST.
-
     Scans the module for top-level variable assignments and evaluates them.
-    This allows code like:
 
     Args:
         module_node: The Module or Interactive AST node

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -897,9 +897,7 @@ def _extract_init_attributes(class_node: ast.ClassDef, context: EvaluationContex
                             # Evaluate the assigned value
                             value = eval_node(stmt.value, temp_context)
                             if value is not None and value is not NOT_EVALUATED:
-                                inferred_type = _create_duck_from_value(value)
-                                if inferred_type is not None:
-                                    attributes[attr_name] = inferred_type
+                                attributes[attr_name] = value
                         except Exception:
                             # Skip the attribute
                             pass
@@ -929,43 +927,12 @@ def _extract_init_attributes(class_node: ast.ClassDef, context: EvaluationContex
                         try:
                             value = eval_node(stmt.value, temp_context)
                             if value is not None and value is not NOT_EVALUATED:
-                                inferred_type = _create_duck_from_value(value)
-                                if inferred_type is not None:
-                                    attributes[attr_name] = inferred_type
+                                attributes[attr_name] = value
                         except Exception:
                             pass
 
     return attributes
 
-
-def _create_duck_from_value(value):
-    """Create a Duck object from an actual runtime value."""
-    if value is None or value is NOT_EVALUATED:
-        return None
-    value_type = type(value)
-    if isinstance(value, dict):
-        return _Duck(
-            attributes=dict.fromkeys(dir(dict())), items=value if value else {}
-        )
-    elif isinstance(value, list):
-        element_duck = None
-        if value:
-            element_duck = _create_duck_from_value(value[0])
-        return _Duck(
-            attributes=dict.fromkeys(dir(list())),
-            items=_GetItemDuck(lambda: element_duck),
-        )
-    elif isinstance(value, set):
-        return _Duck(attributes=dict.fromkeys(dir(set())))
-    elif isinstance(value, tuple):
-        return value
-    elif isinstance(value, (str, int, float, bool, bytes)):
-        return _Duck(attributes=dict.fromkeys(dir(value_type())))
-    else:
-        try:
-            return _create_duck_for_heap_type(value_type)
-        except Exception:
-            return _Duck(attributes=dict.fromkeys(dir(value)))
 
 def _eval_return_type(func: Callable, node: ast.Call, context: EvaluationContext):
     """Evaluate return type of a given callable function.

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2096,6 +2096,30 @@ class TestCompleter(unittest.TestCase):
             ),
             "as_integer_ratio",
         ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.test = []",
+                    "instance = NotYetDefined()",
+                    "instance.test.",
+                ]
+            ),
+            "append",
+        ],
+        [
+            "\n".join(
+                [
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.test:str = []",
+                    "instance = NotYetDefined()",
+                    "instance.test.",
+                ]
+            ),
+            "capitalize",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2120,6 +2120,28 @@ class TestCompleter(unittest.TestCase):
             ),
             "capitalize",
         ],
+        [
+            "\n".join(
+                [
+                    "l = []",
+                    "class NotYetDefined:",
+                    "    def __init__(self):",
+                    "        self.test = l",
+                    "instance = NotYetDefined()",
+                    "instance.test.",
+                ]
+            ),
+            "append",
+        ],
+        [
+            "\n".join(
+                [
+                    "l = {}",
+                    "l.",
+                ]
+            ),
+            "keys",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):


### PR DESCRIPTION
### Fixes #15026 
### Follow-up to https://github.com/ipython/ipython/pull/14993

### Description
With:
```
%config Completer.use_jedi=True
```
#### Enables completions for locals

<img width="429" height="270" alt="image" src="https://github.com/user-attachments/assets/7af5bf4f-eafc-4886-af90-89fc20e1f047" />


#### Enables completions for instance attributes assigned in `__init__()`.

<img width="390" height="194" alt="image" src="https://github.com/user-attachments/assets/b07cae2b-dbae-4de2-8d55-875563608bf3" />

<img width="524" height="246" alt="image" src="https://github.com/user-attachments/assets/7a26703e-5379-47d8-938d-8f87134c109b" />

- [x] Added tests