### PR TITLE
Suppress file completions in context of attributes/methods

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2749,7 +2749,7 @@ class IPCompleter(Completer):
                 return matches
             except NameError:
                 # catches <undefined attributes>.<tab>
-                matches = SimpleMatcherResult(completions=[], suppress=False)
+                return SimpleMatcherResult(completions=[], suppress=False)
         else:
             try:
                 matches = self.global_matches(context.token, context=context)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2209,6 +2209,15 @@ class IPCompleter(Completer):
         """
         # TODO: add a heuristic for suppressing (e.g. if it has OS-specific delimiter,
         #  starts with `/home/`, `C:\`, etc)
+        last_line = context.full_text.split("\n")[-1]
+        text_before_token = last_line[: last_line.rfind(context.token)]
+
+        # Suppress path completion when completing methods/attributes
+        if text_before_token.endswith((")", "]")):
+            return {
+                "completions": [],
+                "suppress": True,
+            }
 
         text = context.token
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2481,7 +2481,7 @@ class IPCompleter(Completer):
         return {
             "completions": matches,
             # static analysis should not suppress other matchers
-            "suppress": {_get_matcher_id(self.file_matcher)},
+            "suppress": {_get_matcher_id(self.file_matcher)} if matches else False,
         }
 
     def _jedi_matches(

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2744,13 +2744,12 @@ class IPCompleter(Completer):
                 matches = _convert_matcher_v1_result_to_v2(
                     matches, type="attribute", fragment=fragment
                 )
-                matches["suppress"] = {_get_matcher_id(self.file_matcher)}
+                if matches["completions"]:
+                    matches["suppress"] = {_get_matcher_id(self.file_matcher)}
                 return matches
             except NameError:
                 # catches <undefined attributes>.<tab>
-                return SimpleMatcherResult(
-                    completions=[], suppress={_get_matcher_id(self.file_matcher)}
-                )
+                matches = SimpleMatcherResult(completions=[], suppress=False)
         else:
             try:
                 matches = self.global_matches(context.token, context=context)
@@ -2761,7 +2760,7 @@ class IPCompleter(Completer):
                 completions=[
                     SimpleCompletion(text=match, type="variable") for match in matches
                 ],
-                suppress={_get_matcher_id(self.file_matcher)},
+                suppress=False,
             )
 
     @completion_matcher(api_version=1)

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2129,7 +2129,7 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
                 "x = MyClass()",
                 "x.b[0].",
             ]
-        )
+        ),
     ],
 )
 def test_no_file_completions_in_attr_access(code):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2121,6 +2121,14 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
                 "    return 1.1",
                 "my_test().",
             ]
+        ),
+        "\n".join(
+            [
+                "class MyClass():",
+                "    b: list[str]",
+                "x = MyClass()",
+                "x.b[0].",
+            ]
         )
     ],
 )
@@ -2129,12 +2137,13 @@ def test_no_file_completions_in_attr_access(code):
     with TemporaryWorkingDirectory():
         open(".hidden", "w", encoding="utf-8").close()
         offset = len(code)
-        with provisionalcompleter():
-            completions = list(ip.Completer.completions(text=code, offset=offset))
-            matches = [c for c in completions if c.text.lstrip(".") == "hidden"]
-            assert (
-                len(matches) == 0
-            ), f"File '.hidden' should not appear in attribute completion"
+        for use_jedi in (True, False):
+            with provisionalcompleter(), jedi_status(use_jedi):
+                completions = list(ip.Completer.completions(text=code, offset=offset))
+                matches = [c for c in completions if c.text.lstrip(".") == "hidden"]
+                assert (
+                    len(matches) == 0
+                ), f"File '.hidden' should not appear in attribute completion"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2113,6 +2113,34 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
 
 
 @pytest.mark.parametrize(
+    "code",
+    [
+        "\n".join(
+            [
+                "def my_test() -> float:",
+                "    return 1.1",
+                "my_test().",
+            ]
+        ),
+        'print("foo").',
+    ],
+)
+def test_no_file_completions_in_attr_access(code):
+    """Test that files are not suggested during attribute/method completion."""
+    with TemporaryWorkingDirectory():
+        # Create a hidden file
+        open(".hidden", "w", encoding="utf-8").close()
+        offset = len(code)
+        with provisionalcompleter():
+            completions = list(ip.Completer.completions(text=code, offset=offset))
+            matches = [c for c in completions if c.text.lstrip(".") == "hidden"]
+            # No file completions should appear
+            assert (
+                len(matches) == 0
+            ), f"File '.hidden' should not appear in attribute completion"
+
+
+@pytest.mark.parametrize(
     "line,expected",
     [
         # Basic test cases

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2121,20 +2121,17 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
                 "    return 1.1",
                 "my_test().",
             ]
-        ),
-        'print("foo").',
+        )
     ],
 )
 def test_no_file_completions_in_attr_access(code):
     """Test that files are not suggested during attribute/method completion."""
     with TemporaryWorkingDirectory():
-        # Create a hidden file
         open(".hidden", "w", encoding="utf-8").close()
         offset = len(code)
         with provisionalcompleter():
             completions = list(ip.Completer.completions(text=code, offset=offset))
             matches = [c for c in completions if c.text.lstrip(".") == "hidden"]
-            # No file completions should appear
             assert (
                 len(matches) == 0
             ), f"File '.hidden' should not appear in attribute completion"


### PR DESCRIPTION
### Fixes #15031

### Description
Suppress `file_matcher` when matching `attribute` \\ `methods`.