### PR TITLE
TST/DEP: add missing test dependency on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = [
     "pytest-asyncio",
     "testpath",
     "packaging",
+    "setuptools>=61.2",
 ]
 test_extra = [
     "ipython[test]",


### PR DESCRIPTION
setuptools is directly imported in some tests, but not declared as a requirement.
A test env created with, e.g. `uv`, doesn't include setuptools by default. This fixes it.