### PR TITLE
DEP: update and add missing lower bounds on direct dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,15 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    'colorama; sys_platform == "win32"',
-    "decorator",
-    "ipython-pygments-lexers",
-    "jedi>=0.16",
-    "matplotlib-inline",
+    'colorama>=0.4.4; sys_platform == "win32"', # lower bound is pure guess (not checked)
+    "decorator>=4.3.2", # wheel
+    "ipython-pygments-lexers>=1.0.0",
+    "jedi>=0.17.0",
+    "matplotlib-inline>=0.1.5", # first guess (0.1.0 is known not to work)
     'pexpect>4.3; sys_platform != "win32" and sys_platform != "emscripten"',
     "prompt_toolkit>=3.0.41,<3.1.0",
-    "pygments>=2.4.0",
-    "stack_data",
+    "pygments>=2.11.0", # wheel
+    "stack_data>=0.0.7", # wheel
     "traitlets>=5.13.0",
     "typing_extensions>=4.6; python_version<'3.12'",
 ]
@@ -63,15 +63,15 @@ doc = [
     "ipython[test,matplotlib]",
     "setuptools>=61.2",
     "sphinx_toml==0.0.4",
-    "sphinx-rtd-theme",
+    "sphinx-rtd-theme>=0.1.8", # wheel
     "sphinx>=1.3",
     "typing_extensions",
 ]
 test = [
-    "pytest",
-    "pytest-asyncio",
-    "testpath",
-    "packaging",
+    "pytest>=7.0.0", # keep in sync with tool.pytest.ini_options.minversion
+    "pytest-asyncio>=1.0.0", # first guess
+    "testpath>=0.2", # wheel
+    "packaging>=20.1.0", # first guess
     "setuptools>=61.2",
 ]
 test_extra = [
@@ -84,7 +84,7 @@ test_extra = [
     "ipykernel>6.30",
     "numpy>=1.25",
     "pandas>2.0",
-    "trio",
+    "trio>=0.1.0", # wheel
 ]
 matplotlib = [
    "matplotlib>3.7"
@@ -324,7 +324,7 @@ check_untyped_defs = true
 disallow_untyped_decorators = false
 
 [tool.pytest.ini_options]
-minversion = "7"
+minversion = "7" # keep in sync with project.optional-dependencies.test
 addopts = [
    "--durations=10",
    "-pIPython.testing.plugin.pytest_ipdoctest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = [
     "pytest-asyncio",
     "testpath",
     "packaging",
+    "setuptools>=61.2",
 ]
 test_extra = [
     "ipython[test]",


### PR DESCRIPTION
Include changes from #15040
This is a best-effort attempt to provide/update lower bounds on direct dependencies in two groups: hard requirements, and test dependencies.
At the time of opening, I still see 7 test failing locally with an env obtained with `uv sync --resolution=lowest-direct` which may indicate that some updates are still needed (although it is not clear what dependencies are causing the failures). It could also be a symptom of *transitive* dependencies incompatibilities. In any case, this is still much better than no explicit lower bounds at all.
The end goal is to enable testing downstream with `--resolution=lowest`.
To guide reviewers I've included small comments to justify my choice of lower bounds. I simply commented "wheel" in places where I picked the oldest version that has a compatible wheel on PyPI (in some cases, older versions might still build from source, but relying on much more recent versions of setuptools is more or less bound to break at some point).

If you're interested, I'd be happy to also setup a CI job to systematically check that lower bounds are sound and up to date.