### PR TITLE
Support completions for lambdas and `async` functions

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -685,6 +685,16 @@ def _is_instance_attribute_assignment(
     )
 
 
+def _get_coroutine_attributes() -> dict[str, Optional[object]]:
+    async def _dummy():
+        return None
+
+    coro = _dummy()
+    try:
+        return {attr: getattr(coro, attr, None) for attr in dir(coro)}
+    finally:
+        coro.close()
+
 def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
     """Evaluate AST node in provided context.
 
@@ -974,7 +984,7 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
                 awaited_type = (
                     inferred_return if inferred_return is not None else return_type
                 )
-                coroutine_duck = ImpersonatingDuck()
+                coroutine_duck = _Duck(attributes=_get_coroutine_attributes())
                 coroutine_duck.__awaited_type__ = awaited_type
                 return coroutine_duck
             if inferred_return is not NOT_EVALUATED:

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -695,6 +695,7 @@ def _get_coroutine_attributes() -> dict[str, Optional[object]]:
     finally:
         coro.close()
 
+
 def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
     """Evaluate AST node in provided context.
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2296,6 +2296,26 @@ class TestCompleter(unittest.TestCase):
             ),
             "as_integer_ratio",
         ],
+        [
+            "\n".join(
+                [
+                    "async def async_func():",
+                    "    return []",
+                    "async_func().",
+                ]
+            ),
+            "cr_await",
+        ],
+        [
+            "\n".join(
+                [
+                    "async def async_func():",
+                    "    return []",
+                    "(await async_func()).",
+                ]
+            ),
+            "append",
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -552,6 +552,16 @@ def test_mocks_items_of_call_results(data, code, expected_items):
             ),
             str,
         ],
+        [
+            "\n".join(
+                [
+                    "async def async_func():",
+                    "    return []",
+                    "(await async_func())",
+                ]
+            ),
+            list,
+        ],
     ],
 )
 def test_mock_class_and_func_instances(code, expected):

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -562,6 +562,15 @@ def test_mocks_items_of_call_results(data, code, expected_items):
             ),
             list,
         ],
+        [
+            "\n".join(
+                [
+                    "make_list = lambda:[]",
+                    "make_list()",
+                ]
+            ),
+            list,
+        ],
     ],
 )
 def test_mock_class_and_func_instances(code, expected):


### PR DESCRIPTION
### Fixes #15045

### Description
Handle `lambda` and `async` functions in `guarded_eval` to enhance completions.