### PR TITLE
Move TerminalInteractiveshell.inputhook to Deprecated, from Pending.

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -1040,7 +1040,7 @@ class TerminalInteractiveShell(InteractiveShell):
         warn(
             "inputkook seem unused, and marked for deprecation/Removal as of IPython 9.0. "
             "Please open an issue if you are using it.",
-            category=PendingDeprecationWarning,
+            category=DeprecationWarning,
             stacklevel=2,
         )
         if self._inputhook is not None:


### PR DESCRIPTION
It's been 9 Month and we had no complaints on PendingDeprecation.