### PR TITLE
TST: add systematic backward compatibility checks against oldest supported versions of direct dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,3 +107,47 @@ jobs:
       with:
          name: Test
          files: /home/runner/work/ipython/ipython/coverage.xml
+
+  oldest-deps:
+    # pro-actively check backward compatibility
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    # Disable scheduled CI runs on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'ipython'
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          # include windows because of platform-specific direct dependencies
+          - windows-2022
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up uv with Python 3.11
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.11'
+        enable-cache: true
+        activate-environment: true
+        prune-cache: false
+        cache-dependency-glob: |
+          pyproject.toml
+
+    - name: Install Python dependencies (oldest supported versions)
+      run: uv pip install --resolution=lowest-direct -e .[test]
+
+    - name: Try building with uv build
+      if: runner.os != 'Windows'  # setup.py does not support sdist on Windows
+      run: |
+        uv build
+        shasum -a 256 dist/*
+
+    - name: Check manifest
+      if: runner.os != 'Windows'  # setup.py does not support sdist on Windows
+      run: uvx check-manifest
+
+    - name: pytest
+      env:
+        COLUMNS: 120
+      run: pytest --color=yes -raXxs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     'colorama>=0.4.4; sys_platform == "win32"',
     "decorator>=4.3.2", # wheel
     "ipython-pygments-lexers>=1.0.0",
-    "jedi>=0.17.0",
+    "jedi>=0.18.1",
     "matplotlib-inline>=0.1.5", # first guess (0.1.0 is known not to work)
     'pexpect>4.3; sys_platform != "win32" and sys_platform != "emscripten"',
     "prompt_toolkit>=3.0.41,<3.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license = "BSD-3-Clause"
 license-files = ["LICENSE", "COPYING.rst"]
 requires-python = ">=3.11"
 dependencies = [
-    'colorama>=0.4.4; sys_platform == "win32"', # lower bound is pure guess (not checked)
+    'colorama>=0.4.4; sys_platform == "win32"',
     "decorator>=4.3.2", # wheel
     "ipython-pygments-lexers>=1.0.0",
     "jedi>=0.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     'pexpect>4.3; sys_platform != "win32" and sys_platform != "emscripten"',
     "prompt_toolkit>=3.0.41,<3.1.0",
     "pygments>=2.11.0", # wheel
-    "stack_data>=0.0.7", # wheel
+    "stack_data>=0.6.0",
     "traitlets>=5.13.0",
     "typing_extensions>=4.6; python_version<'3.12'",
 ]


### PR DESCRIPTION
Follow up to #15041

Since this setup requires uv (pip install doesn't support the `--resolution` argument, crucial to this work), I've written it as a completely separate job instead of a matrix item. It would be possible to reconcile the two, but that would make for a much more invasive change where I'd replace pip with uv everywhere. Of course, if that's desired, I'm also happy to go all-in with uv, either here, or as a follow up PR.