### PR TITLE
Reduce types in splitinput.py

### DIFF
--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -498,7 +498,7 @@ class AutocallChecker(PrefilterChecker):
         if not self.shell.autocall:
             return None
 
-        oinfo = line_info.ofind(self.shell) # This can mutate state via getattr
+        oinfo = self.shell._ofind(line_info.ifun)  # This can mutate state via getattr
         if not oinfo.found:
             return None
 
@@ -610,7 +610,7 @@ class AutoHandler(PrefilterHandler):
         the_rest = line_info.the_rest
         esc     = line_info.esc
         continue_prompt = line_info.continue_prompt
-        obj = line_info.ofind(self.shell).obj
+        obj = self.shell._ofind(line_info.ifun).obj
 
         # This should only be active for single-line input!
         if continue_prompt:

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -141,7 +141,7 @@ class LineInfo:
             Use ``shell._ofind(line_info.ifun)`` directly instead.
         """
         warnings.warn(
-            "LineInfo.ofind() is deprecated since IPython 9.8. "
+            "LineInfo.ofind() is deprecated since IPython 9.9. "
             "Use shell._ofind(line_info.ifun) directly instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -1,20 +1,7 @@
-# encoding: utf-8
 """
 Simple utility for splitting user input. This is used by both inputsplitter and
 prefilter.
-
-Authors:
-
-* Brian Granger
-* Fernando Perez
 """
-
-#-----------------------------------------------------------------------------
-#  Copyright (C) 2008-2011  The IPython Development Team
-#
-#  Distributed under the terms of the BSD License.  The full license is in
-#  the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
 # Imports
@@ -23,8 +10,6 @@ Authors:
 import re
 import sys
 
-from IPython.utils import py3compat
-from IPython.utils.encoding import get_stream_enc
 from IPython.core.oinspect import OInfo
 
 #-----------------------------------------------------------------------------
@@ -51,13 +36,11 @@ line_split = re.compile(r"""
              """, re.VERBOSE)
 
 
-def split_user_input(line, pattern=None):
+def split_user_input(line: str, pattern: re.Pattern[str] | None = None) -> tuple[str, str, str, str]:
     """Split user input into initial whitespace, escape character, function part
     and the rest.
     """
-    # We need to ensure that the rest of this routine deals only with unicode
-    encoding = get_stream_enc(sys.stdin, 'utf-8')
-    line = py3compat.cast_unicode(line, encoding)
+    assert isinstance(line, str)
 
     if pattern is None:
         pattern = line_split
@@ -111,7 +94,19 @@ class LineInfo:
     raw_the_rest
       the_rest without whitespace stripped.
     """
-    def __init__(self, line, continue_prompt=False):
+
+    line: str
+    continue_prompt: bool
+    pre: str
+    esc: str
+    ifun: str
+    raw_the_rest: str
+    the_rest: str
+    pre_char: str
+    pre_whitespace: str
+
+    def __init__(self, line: str, continue_prompt: bool = False) -> None:
+        assert isinstance(line, str)
         self.line            = line
         self.continue_prompt = continue_prompt
         self.pre, self.esc, self.ifun, self.raw_the_rest = split_user_input(line)
@@ -138,8 +133,8 @@ class LineInfo:
         """
         return ip._ofind(self.ifun)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "LineInfo [%s|%s|%s|%s]" %(self.pre, self.esc, self.ifun, self.the_rest)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<" + str(self) + ">"


### PR DESCRIPTION
As far as I can tell, those are always strings, so should remove some overhead.

Also deprecated and ruff-format the file.