### PR TITLE
document %history usage with all lines of a session

### DIFF
--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -121,10 +121,10 @@ class HistoryMagics(Magics):
             Line 4, current session
         ``4-6``
             Lines 4-6, current session
+        ``~2/``
+            All lines of session 2 before current
         ``243/1-5``
             Lines 1-5, session 243
-        ``~2/7``
-            Line 7, session 2 before current
         ``~8/1-~6/5``
             From the first line of 8 sessions ago, to the fifth line of 6
             sessions ago.


### PR DESCRIPTION
Hello IPython team,

This tiny PR aims to make to easier to read the usage doc of the [%history](https://ipython.readthedocs.io/en/stable/interactive/magics.html#magic-history) magic.

Presently, usage examples for the `range` arguments are:
```
 ``4``
    Line 4, current session
``4-6``
    Lines 4-6, current session
``243/1-5``
    Lines 1-5, session 243
``~2/7``
    Line 7, session 2 before current
``~8/1-~6/5``
    From the first line of 8 sessions ago, to the fifth line of 6
    sessions ago.
```

While I was trying to print all lines from a past session, I got the feeling that the case of how to print all lines of a session is not obviously documented (i.e. it took me 2-3 trials to get the result correctly).

In this PR, I propose to add to 3rd position (between ``4-6`` and ``243/1-5``):

```
``~2/``
            All lines of session 2 before current
```

Then I removed the case ``~2/7`` because it's redundant with the new ``~2/`` + the existing ``243/1-5``, I believe.