### PR TITLE
Fix error on tab completions

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1352,8 +1352,6 @@ class Completer(Configurable):
             assert res is not None
             if len(res.body) != 1:
                 continue
-            if not isinstance(res.body[0], ast.Expr):
-                continue
             expr = res.body[0].value
             if isinstance(expr, ast.Tuple) and not code[-1] == ")":
                 # we skip implicit tuple, like when trimming `fun(a,b`<completion>

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1352,6 +1352,8 @@ class Completer(Configurable):
             assert res is not None
             if len(res.body) != 1:
                 continue
+            if not isinstance(res.body[0], ast.Expr):
+                continue
             expr = res.body[0].value
             if isinstance(expr, ast.Tuple) and not code[-1] == ")":
                 # we skip implicit tuple, like when trimming `fun(a,b`<completion>

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2695,24 +2695,3 @@ def test_trim_expr(code, expected):
 )
 def test_match_numeric_literal_for_dict_key(input, expected):
     assert _match_number_in_dict_key_prefix(input) == expected
-
-
-def test_completer_does_not_raise_value_error():
-    ip = get_ipython()
-    source = "\n".join(
-        [
-            "if cond:",
-            "   assert a.",
-        ]
-    )
-    value_error = None
-    with provisionalcompleter():
-        try:
-            completions = list(
-                ip.Completer.completions(text=source, offset=len(source))
-            )
-        except ValueError as e:
-            value_error = e
-            completions = []
-        assert isinstance(completions, list)
-        assert value_error is None

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2655,6 +2655,7 @@ def test_misc_no_jedi_completions(setup, code, expected, not_expected):
         ("x = {1, y", "y"),
         ("x = [1, y", "y"),
         ("x = fun(1, y", "y"),
+        (" assert a", "a"),
     ],
 )
 def test_trim_expr(code, expected):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2695,3 +2695,24 @@ def test_trim_expr(code, expected):
 )
 def test_match_numeric_literal_for_dict_key(input, expected):
     assert _match_number_in_dict_key_prefix(input) == expected
+
+
+def test_completer_does_not_raise_value_error():
+    ip = get_ipython()
+    source = "\n".join(
+        [
+            "if cond:",
+            "   assert a.",
+        ]
+    )
+    value_error = None
+    with provisionalcompleter():
+        try:
+            completions = list(
+                ip.Completer.completions(text=source, offset=len(source))
+            )
+        except ValueError as e:
+            value_error = e
+            completions = []
+        assert isinstance(completions, list)
+        assert value_error is None


### PR DESCRIPTION
### Fixes #15075 

### Description
Added a logic to check whether the node we have is `ast.Expr` before trying to access its `value`.