### PR TITLE
Show completions for annotated union types

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -793,9 +793,12 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
 
         if is_property:
             if return_type is not None:
-                context.transient_locals[node.name] = _resolve_annotation(
-                    return_type, context
-                )
+                if is_type_annotation(return_type):
+                    context.transient_locals[node.name] = _resolve_annotation(
+                        return_type, context
+                    )
+                else:
+                    context.transient_locals[node.name] = return_type
             else:
                 return_value = _infer_return_value(node, func_context)
                 context.transient_locals[node.name] = return_value
@@ -806,7 +809,10 @@ def eval_node(node: Union[ast.AST, None], context: EvaluationContext):
             pass
 
         if return_type is not None:
-            dummy_function.__annotations__["return"] = return_type
+            if is_type_annotation(return_type):
+                dummy_function.__annotations__["return"] = return_type
+            else:
+                dummy_function.__inferred_return__ = return_type
         else:
             inferred_return = _infer_return_value(node, func_context)
             if inferred_return is not None:

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -577,6 +577,8 @@ def is_type_annotation(obj) -> bool:
         return True
     if isinstance(obj, types.GenericAlias):
         return True
+    if hasattr(types, "UnionType") and isinstance(obj, types.UnionType):
+        return True
     if type(obj).__name__ in ("_GenericAlias", "_SpecialForm", "_UnionGenericAlias"):
         return True
 

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -573,16 +573,19 @@ def _is_type_annotation(obj) -> bool:
     """
     if isinstance(obj, type):
         return True
-    if hasattr(typing, "get_origin"):
-        if typing.get_origin(obj) is not None:
-            return True
-    if hasattr(obj, "__module__") and obj.__module__ == "typing":
-        return True
     if isinstance(obj, types.GenericAlias):
         return True
     if hasattr(types, "UnionType") and isinstance(obj, types.UnionType):
         return True
-    if type(obj).__name__ in ("_GenericAlias", "_SpecialForm", "_UnionGenericAlias"):
+    if isinstance(obj, (typing._SpecialForm, typing._BaseGenericAlias)):
+        return True
+    if isinstance(obj, typing.TypeVar):
+        return True
+    # Types that support __class_getitem__
+    if isinstance(obj, type) and hasattr(obj, "__class_getitem__"):
+        return True
+    # Fallback: check if get_origin returns something
+    if hasattr(typing, "get_origin") and get_origin(obj) is not None:
         return True
 
     return False

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2536,37 +2536,6 @@ class TestCompleter(unittest.TestCase):
             ),
             ["capitalize"],
         ],
-        # Test union types
-        [
-            "\n".join(
-                [
-                    "t: int | str",
-                    "t.",
-                ]
-            ),
-            ["bit_length", "capitalize"],
-        ],
-        [
-            "\n".join(
-                [
-                    "def func() -> int | str: pass",
-                    "func().",
-                ]
-            ),
-            ["bit_length", "capitalize"],
-        ],
-        [
-            "\n".join(
-                [
-                    "class T:",
-                    "   @property",
-                    "   def p(self) -> int | str: pass",
-                    "t = T()",
-                    "t.p.",
-                ]
-            ),
-            ["bit_length", "capitalize"],
-        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):
@@ -2603,6 +2572,37 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
                 ]
             ),
             "append",
+        ],
+        # Test union types
+        [
+            "\n".join(
+                [
+                    "t: int | str",
+                    "t.",
+                ]
+            ),
+            ["bit_length", "capitalize"],
+        ],
+        [
+            "\n".join(
+                [
+                    "def func() -> int | str: pass",
+                    "func().",
+                ]
+            ),
+            ["bit_length", "capitalize"],
+        ],
+        [
+            "\n".join(
+                [
+                    "class T:",
+                    "   @property",
+                    "   def p(self) -> int | str: pass",
+                    "t = T()",
+                    "t.p.",
+                ]
+            ),
+            ["bit_length", "capitalize"],
         ],
     ],
 )

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2562,6 +2562,43 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
 
 
 @pytest.mark.parametrize(
+    "code,insert_text",
+    [
+        [
+            "\n".join(
+                [
+                    "t: int | dict = {'a': []}",
+                    "t.",
+                ]
+            ),
+            ["keys", "bit_length"],
+        ],
+        [
+            "\n".join(
+                [
+                    "t: int | dict = {'a': []}",
+                    "t['a'].",
+                ]
+            ),
+            "append",
+        ],
+    ],
+)
+def test_undefined_variables_without_jedi(code, insert_text):
+    offset = len(code)
+    ip.Completer.use_jedi = False
+    ip.Completer.evaluation = "limited"
+
+    with provisionalcompleter():
+        completions = list(ip.Completer.completions(text=code, offset=offset))
+        insert_texts = insert_text if isinstance(insert_text, list) else [insert_text]
+        for text in insert_texts:
+            match = [c for c in completions if c.text.lstrip(".") == text]
+            message_on_fail = f"{text} not found among {[c.text for c in completions]}"
+            assert len(match) == 1, message_on_fail
+
+
+@pytest.mark.parametrize(
     "code",
     [
         "\n".join(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2536,11 +2536,33 @@ class TestCompleter(unittest.TestCase):
             ),
             ["capitalize"],
         ],
+        # Test union types
         [
             "\n".join(
                 [
                     "t: int | str",
                     "t.",
+                ]
+            ),
+            ["bit_length", "capitalize"],
+        ],
+        [
+            "\n".join(
+                [
+                    "def func() -> int | str: pass",
+                    "func().",
+                ]
+            ),
+            ["bit_length", "capitalize"],
+        ],
+        [
+            "\n".join(
+                [
+                    "class T:",
+                    "   @property",
+                    "   def p(self) -> int | str: pass",
+                    "t = T()",
+                    "t.p.",
                 ]
             ),
             ["bit_length", "capitalize"],

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2494,6 +2494,24 @@ class TestCompleter(unittest.TestCase):
             ),
             "bit_length",
         ],
+        [
+            "\n".join(
+                [
+                    "t: list[str]",
+                    "t[0].",
+                ]
+            ),
+            ["capitalize"],
+        ],
+        [
+            "\n".join(
+                [
+                    "t: int | str",
+                    "t.",
+                ]
+            ),
+            ["bit_length", "capitalize"],
+        ],
     ],
 )
 def test_undefined_variables(use_jedi, evaluation, code, insert_text):


### PR DESCRIPTION
### Fixes #15077 

### Description
Added logic for `ast.BinOp` case to return an object with merged attributes when the binary operation represents a union type.