### PR TITLE
Strictly suppress `file_matcher` in attribute completions

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2605,7 +2605,7 @@ class IPCompleter(Completer):
             return self._CompletionContextType.GLOBAL
 
         # Handle all other attribute matches np.ran, d[0].k, (a,b).count
-        chain_match = re.search(r".*(.+\.(?:[a-zA-Z]\w*)?)$", line)
+        chain_match = re.search(r".*(.+(?<!\s)\.(?:[a-zA-Z]\w*)?)$", line)
         if chain_match:
             return self._CompletionContextType.ATTRIBUTE
 

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2473,8 +2473,7 @@ class IPCompleter(Completer):
 
     @context_matcher(identifier="IPCompleter.jedi_matcher")
     def _jedi_matcher(self, context: CompletionContext) -> _JediMatcherResult:
-        text = context.text_until_cursor
-        text = self._extract_code(text)
+        text = self._extract_code(context.text_until_cursor)
         completion_type = self._determine_completion_context(text)
         matches = self._jedi_matches(
             cursor_column=context.cursor_position,

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2651,18 +2651,17 @@ def test_completion_context(line, expected):
 @pytest.mark.parametrize(
     "line,expected,expected_after_assignment",
     [
-        ("test file", True, False),  # overshadowed by variable
-        ("test .", True, False),
-        ("test file.", True, False),
-        ("%test .file.ext", True, True),  # magic, not affected by variable
-        ("!test file.", True, True),  # bang, not affected by variable
+        ("test_alias file", True, False),  # overshadowed by variable
+        ("test_alias .", True, False),
+        ("test_alias file.", True, False),
+        ("%test_alias .file.ext", True, True),  # magic, not affected by variable
+        ("!test_alias file.", True, True),  # bang, not affected by variable
     ],
 )
 def test_completion_in_cli_context(line, expected, expected_after_assignment):
     """Test completion context with and without variable overshadowing"""
     ip = get_ipython()
-    ip.run_cell("alias test echo test")
-    print("\nDEBUG:\n", ip.alias_manager.aliases)
+    ip.run_cell("alias test_alias echo test_alias")
     get_context = ip.Completer._is_completing_in_cli_context
 
     # Normal case
@@ -2671,13 +2670,13 @@ def test_completion_in_cli_context(line, expected, expected_after_assignment):
 
     # Test with alias assigned as a variable
     try:
-        ip.user_ns["test"] = "some_value"
+        ip.user_ns["test_alias"] = "some_value"
         result_after_assignment = get_context(line)
         assert (
             result_after_assignment == expected_after_assignment
         ), f"Failed after assigning 'ls' as a variable for input: '{line}'"
     finally:
-        ip.user_ns.pop("test", None)
+        ip.user_ns.pop("test_alias", None)
 
 @pytest.mark.xfail(reason="Completion context not yet supported")
 @pytest.mark.parametrize(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2561,6 +2561,14 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
                 "x.b[0].",
             ]
         ),
+        "\n".join(
+            [
+                "class MyClass():",
+                "    b: list[str]",
+                "x = MyClass()",
+                "x.fake_attr().",
+            ]
+        ),
     ],
 )
 def test_no_file_completions_in_attr_access(code):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2662,6 +2662,7 @@ def test_completion_in_cli_context(line, expected, expected_after_assignment):
     """Test completion context with and without variable overshadowing"""
     ip = get_ipython()
     ip.run_cell("alias test echo test")
+    print("\nDEBUG:\n", ip.alias_manager.aliases)
     get_context = ip.Completer._is_completing_in_cli_context
 
     # Normal case

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2648,6 +2648,35 @@ def test_completion_context(line, expected):
     assert result.value == expected, f"Failed on input: '{line}'"
 
 
+@pytest.mark.parametrize(
+    "line,expected,expected_after_assignment",
+    [
+        ("ls file", True, False),  # overshadowed by variable
+        ("ls .", True, False),
+        ("ls file.", True, False),
+        ("%ls .file.ext", True, True),  # magic, not affected by variable
+        ("!ls file.", True, True),  # bang, not affected by variable
+    ],
+)
+def test_completion_in_cli_context(line, expected, expected_after_assignment):
+    """Test completion context with and without variable overshadowing"""
+    ip = get_ipython()
+    get_context = ip.Completer._is_completing_in_cli_context
+
+    # Normal case
+    result = get_context(line)
+    assert result == expected, f"Failed on input: '{line}'"
+
+    # Test with alias assigned as a variable
+    try:
+        ip.user_ns["ls"] = "some_value"
+        result_after_assignment = get_context(line)
+        assert (
+            result_after_assignment == expected_after_assignment
+        ), f"Failed after assigning 'ls' as a variable for input: '{line}'"
+    finally:
+        ip.user_ns.pop("ls", None)
+
 @pytest.mark.xfail(reason="Completion context not yet supported")
 @pytest.mark.parametrize(
     "line, expected",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -424,11 +424,17 @@ class TestCompleter(unittest.TestCase):
             c = ip.complete(prefix)[1]
             self.assertEqual(c, names)
 
-            # Now check with a function call
-            cmd = 'a = f("%s' % prefix
-            c = ip.complete(prefix, cmd)[1]
-            comp = {prefix + s for s in suffixes}
-            self.assertTrue(comp.issubset(set(c)))
+            test_cases = {
+                "function call": 'a = f("',
+                "shell bang": "!ls ",
+                "ls magic": r"%ls ",
+                "alias ls": "ls ",
+            }
+            for name, code in test_cases.items():
+                cmd = f"{code}{prefix}"
+                c = ip.complete(prefix, cmd)[1]
+                comp = {prefix + s for s in suffixes}
+                self.assertTrue(comp.issubset(set(c)), msg=f"completes in {name}")
 
     def test_quoted_file_completions(self):
         ip = get_ipython()
@@ -2677,6 +2683,7 @@ def test_completion_in_cli_context(line, expected, expected_after_assignment):
         ), f"Failed after assigning 'ls' as a variable for input: '{line}'"
     finally:
         ip.user_ns.pop("test_alias", None)
+
 
 @pytest.mark.xfail(reason="Completion context not yet supported")
 @pytest.mark.parametrize(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2651,17 +2651,17 @@ def test_completion_context(line, expected):
 @pytest.mark.parametrize(
     "line,expected,expected_after_assignment",
     [
-        ("ls file", True, False),  # overshadowed by variable
-        ("ls .", True, False),
-        ("ls file.", True, False),
-        ("%ls .file.ext", True, True),  # magic, not affected by variable
-        ("!ls file.", True, True),  # bang, not affected by variable
+        ("test file", True, False),  # overshadowed by variable
+        ("test .", True, False),
+        ("test file.", True, False),
+        ("%test .file.ext", True, True),  # magic, not affected by variable
+        ("!test file.", True, True),  # bang, not affected by variable
     ],
 )
 def test_completion_in_cli_context(line, expected, expected_after_assignment):
     """Test completion context with and without variable overshadowing"""
     ip = get_ipython()
-    print("\n\nDEBUG:\n", ip.alias_manager.aliases)
+    ip.run_cell("alias test echo test")
     get_context = ip.Completer._is_completing_in_cli_context
 
     # Normal case
@@ -2670,13 +2670,13 @@ def test_completion_in_cli_context(line, expected, expected_after_assignment):
 
     # Test with alias assigned as a variable
     try:
-        ip.user_ns["ls"] = "some_value"
+        ip.user_ns["test"] = "some_value"
         result_after_assignment = get_context(line)
         assert (
             result_after_assignment == expected_after_assignment
         ), f"Failed after assigning 'ls' as a variable for input: '{line}'"
     finally:
-        ip.user_ns.pop("ls", None)
+        ip.user_ns.pop("test", None)
 
 @pytest.mark.xfail(reason="Completion context not yet supported")
 @pytest.mark.parametrize(

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2637,6 +2637,7 @@ def test_no_file_completions_in_attr_access(code):
         ('f"formatted {obj.attr}', "global"),
         ("dict_with_dots = {'key.with.dots': value.attr", "attribute"),
         ("d[f'{a}']['{a.", "global"),
+        ("ls .", "global"),
     ],
 )
 def test_completion_context(line, expected):

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2661,6 +2661,7 @@ def test_completion_context(line, expected):
 def test_completion_in_cli_context(line, expected, expected_after_assignment):
     """Test completion context with and without variable overshadowing"""
     ip = get_ipython()
+    print("\n\nDEBUG:\n", ip.alias_manager.aliases)
     get_context = ip.Completer._is_completing_in_cli_context
 
     # Normal case


### PR DESCRIPTION
### Fixes #15031 

### Description
The current logic only suppresses matchers if they are in the suppress set and there are matching results. As a result, `file_matcher` can still display file matches when attribute completion fails. This PR updates the logic to always suppress `file_matcher` during attribute completion, regardless of whether any attributes were successfully matched.