### PR TITLE
execution count more atomic, run_cell_async reenterable

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -63,7 +63,7 @@ class DisplayHook(Configurable):
 
     @property
     def prompt_count(self):
-        return self.shell.execution_count
+        return self.shell.execution_count - 1
 
     #-------------------------------------------------------------------------
     # Methods used in __call__. Override these methods to modify the behavior
@@ -127,7 +127,7 @@ class DisplayHook(Configurable):
         """
         # Use write, not print which adds an extra space.
         sys.stdout.write(self.shell.separate_out)
-        outprompt = 'Out[{}]: '.format(self.shell.execution_count)
+        outprompt = 'Out[{}]: '.format(self.shell.execution_count - 1)
         if self.do_full_cache:
             sys.stdout.write(outprompt)
 

--- a/IPython/core/displaypub.py
+++ b/IPython/core/displaypub.py
@@ -149,7 +149,7 @@ class DisplayPublisher(Configurable):
 
         outputs = self.shell.history_manager.outputs
 
-        target_execution_count = self.shell.execution_count
+        target_execution_count = self.shell.execution_count - 1
         if self._in_post_execute:
             # We're in post_execute, so this is likely a matplotlib flush
             # Use execution_count - 1 to associate with the cell that created the plot

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3046,6 +3046,7 @@ class InteractiveShell(SingletonConfigurable):
         """
         stream = getattr(sys, channel)
         original_write = stream.write
+        execution_count = self.execution_count
 
         def write(data, *args, **kwargs):
             """Write data to both the original destination and the capture dictionary."""
@@ -3060,7 +3061,6 @@ class InteractiveShell(SingletonConfigurable):
                 return result
             if not data:
                 return result
-            execution_count = self.execution_count
             output_stream = None
             outputs_by_counter = self.history_manager.outputs
             output_type = "out_stream" if channel == "stdout" else "err_stream"
@@ -3293,17 +3293,18 @@ class InteractiveShell(SingletonConfigurable):
         if silent:
             store_history = False
 
+        execution_count = result.execution_count = self.execution_count
+
         if store_history:
-            result.execution_count = self.execution_count
+            self.execution_count += 1
 
         def error_before_exec(value):
             if store_history:
                 if self.history_manager:
                     # Store formatted traceback and error details
                     self.history_manager.exceptions[
-                        self.execution_count
+                        execution_count
                     ] = self._format_exception_for_storage(value)
-                self.execution_count += 1
             result.error_before_exec = value
             self.last_execution_succeeded = False
             self.last_execution_result = result
@@ -3348,15 +3349,13 @@ class InteractiveShell(SingletonConfigurable):
         # Store raw and processed history
         if store_history:
             assert self.history_manager is not None
-            self.history_manager.store_inputs(self.execution_count, cell, raw_cell)
+            self.history_manager.store_inputs(execution_count, cell, raw_cell)
         if not silent:
             self.logger.log(cell, raw_cell)
 
         # Display the exception if input processing failed.
         if preprocessing_exc_tuple is not None:
             self.showtraceback(preprocessing_exc_tuple)
-            if store_history:
-                self.execution_count += 1
             return error_before_exec(preprocessing_exc_tuple[1])
 
         # Our own compiler remembers the __future__ environment. If we want to
@@ -3365,7 +3364,7 @@ class InteractiveShell(SingletonConfigurable):
         compiler = self.compile if shell_futures else self.compiler_class()
 
         with self.builtin_trap:
-            cell_name = compiler.cache(cell, self.execution_count, raw_code=raw_cell)
+            cell_name = compiler.cache(cell, execution_count, raw_code=raw_cell)
 
             with self.display_trap:
                 # Compile to bytecode
@@ -3412,16 +3411,12 @@ class InteractiveShell(SingletonConfigurable):
             assert self.history_manager is not None
             # Write output to the database. Does nothing unless
             # history output logging is enabled.
-            self.history_manager.store_output(self.execution_count)
-            exec_count = self.execution_count
+            self.history_manager.store_output(execution_count)
             if result.error_in_exec:
                 # Store formatted traceback and error details
                 self.history_manager.exceptions[
-                    exec_count
+                    execution_count
                 ] = self._format_exception_for_storage(result.error_in_exec)
-
-            # Each cell is a *single* input, regardless of how many lines it has
-            self.execution_count += 1
 
         return result
 

--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -87,7 +87,7 @@ class Prompts:
     def out_prompt_tokens(self):
         return [
             (Token.OutPrompt, 'Out['),
-            (Token.OutPromptNum, str(self.shell.execution_count)),
+            (Token.OutPromptNum, str(self.shell.execution_count - 1)),
             (Token.OutPrompt, ']: '),
         ]
 


### PR DESCRIPTION
This pull request makes `run_cell_async` able to re-enter itself without messing the history causing a new session. This solves issue #15087 

The changes are to increment `execution_count` of `InteractiveShell` _before_ running the user code in a cell, and some compatible changes so that prompts and outputs get the correct `execution_count`.

With this change it's possible to modify frontends so that they can run multiple cells concurrently. I've written a small one-file package on top of ipykernel that shows this nicely and works well

https://github.com/drorspei/bgipykernel