### PR TITLE
Use Any type in traceback tuple

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2141,7 +2141,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def showtraceback(
         self,
-        exc_tuple: tuple[type[BaseException], BaseException, Any] | None = None,
+        exc_tuple: tuple[type[BaseException], BaseException, AnyType] | None = None,
         filename: str | None = None,
         tb_offset: int | None = None,
         exception_only: bool = False,


### PR DESCRIPTION
And not traitlets any trait. Since this is a python standard library type, it seems likely that using the Any trait here was a typo?

Formally I would expect the traceback type to be `types.TracebackType | None` but perhaps there
is a good reason to use Any here?