### PR TITLE
Fix crash on literal with surrogate (#15098)

### DIFF
--- a/IPython/core/async_helpers.py
+++ b/IPython/core/async_helpers.py
@@ -136,20 +136,15 @@ def _pseudo_sync_runner(coro):
 
 
 def _should_be_async(cell: str) -> bool:
-    """Detect if a block of code need to be wrapped in an `async def`
+    """Detect if a block of code needs to be wrapped in an `async def`
 
-    Attempt to parse the block of code, it it compile we're fine.
-    Otherwise we  wrap if and try to compile.
-
-    If it works, assume it should be async. Otherwise Return False.
-
-    Not handled yet: If the block of code has a return statement as the top
-    level, it will be seen as async. This is a know limitation.
+    If the code block has a top-level return statement or is otherwise
+    invalid, `False` will be returned.
     """
     try:
         code = compile(
             cell, "<>", "exec", flags=getattr(ast, "PyCF_ALLOW_TOP_LEVEL_AWAIT", 0x0)
         )
         return inspect.CO_COROUTINE & code.co_flags == inspect.CO_COROUTINE
-    except (SyntaxError, MemoryError):
+    except (SyntaxError, ValueError, MemoryError):
         return False

--- a/tests/test_async_helpers.py
+++ b/tests/test_async_helpers.py
@@ -44,6 +44,14 @@ class AsyncTest(TestCase):
             )
         )
 
+        self.assertFalse(_should_be_async("return await foo()"))
+        self.assertFalse(_should_be_async("return bar()"))
+        self.assertFalse(_should_be_async("some invalid Python code"))
+
+        self.assertFalse(_should_be_async("'\\ud800'"))
+        # Note: the next assert assumes the tests run without the `-OO` flag
+        self.assertFalse(_should_be_async("'\\ud800'\nawait foo"))
+
     def _get_top_level_cases(self):
         # These are test cases that should be valid in a function
         # but invalid outside of a function.

--- a/tests/test_async_helpers.py
+++ b/tests/test_async_helpers.py
@@ -4,6 +4,7 @@ Test for async helpers.
 Should only trigger on python 3.5+ or will have syntax errors.
 """
 
+import sys
 from itertools import chain, repeat
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING
@@ -49,8 +50,10 @@ class AsyncTest(TestCase):
         self.assertFalse(_should_be_async("some invalid Python code"))
 
         self.assertFalse(_should_be_async("'\\ud800'"))
-        # Note: the next assert assumes the tests run without the `-OO` flag
-        self.assertFalse(_should_be_async("'\\ud800'\nawait foo"))
+        
+        if sys.version_info >= (3, 13):
+            # Note: the next assert assumes the tests run without the `-OO` flag
+            self.assertFalse(_should_be_async("'\\ud800'\nawait foo"))
 
     def _get_top_level_cases(self):
         # These are test cases that should be valid in a function


### PR DESCRIPTION
Fixes issue #15098.

This now works as expected:
```
$ ipython
Python 3.13.5 (main, Jul  4 2025, 23:57:18) [GCC 15.1.1 20250521 (Red Hat 15.1.1-2)]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.9.0.dev -- An enhanced Interactive Python. Type '?' for help.
Tip: Use `object?` to see the help on `object`, `object??` to view its source

In [1]: "\ud800"
Out[1]: '\ud800'

In [2]: ord(_)
Out[2]: 55296
```

This raises an exception, as intended in Python 3.13+:
```
In [1]: def f():
   ...:     "\ud800"
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
File ~/.pyenv/versions/3.13.5/lib/python3.13/codeop.py:118, in Compile.__call__(self, source, filename, symbol, flags, **kwargs)
    116     flags &= ~PyCF_DONT_IMPLY_DEDENT
    117     flags &= ~PyCF_ALLOW_INCOMPLETE_INPUT
--> 118 codeob = compile(source, filename, symbol, flags, True)
    119 if flags & PyCF_ONLY_AST:
    120     return codeob  # this is an ast.Module in this case

UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 0: surrogates not allowed
```