### PR TITLE
Add prompt_toolkit's unix_word_rubout to assignable commands for shortcuts

### DIFF
--- a/IPython/terminal/shortcuts/__init__.py
+++ b/IPython/terminal/shortcuts/__init__.py
@@ -635,4 +635,5 @@ UNASSIGNED_ALLOWED_COMMANDS = [
     nc.forward_char,
     nc.forward_word,
     nc.unix_line_discard,
+    nc.unix_word_rubout,
 ]


### PR DESCRIPTION
`unix-word-rubout` / `nc.unix_word_rubout` is closer to a lot of folks' shell's Ctrl-W behaviour, so it would be nice to be able to set it up cleanly in config files.

As best as I can tell the set of unassigned allowed commands is neither tested nor documented anywhere; it's not clear what warrants inclusion or exclusion from the group.