### PR TITLE
Fix completions for methods starting with `_`

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2608,8 +2608,8 @@ class IPCompleter(Completer):
         if re.search(r"(?<!\w)(?<!\d\.)([-+]?\d+\.(\d+)?)(?!\w)$", line):
             return self._CompletionContextType.GLOBAL
 
-        # Handle all other attribute matches np.ran, d[0].k, (a,b).count
-        chain_match = re.search(r".*(.+(?<!\s)\.(?:[a-zA-Z]\w*)?)$", line)
+        # Handle all other attribute matches np.ran, d[0].k, (a,b).count, obj._private
+        chain_match = re.search(r".*(.+(?<!\s)\.(?:[a-zA-Z_]\w*)?)$", line)
         if chain_match:
             return self._CompletionContextType.ATTRIBUTE
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2068,6 +2068,26 @@ class TestCompleter(unittest.TestCase):
             a_matcher.matcher_priority = 3
             _(["completion_a"])
 
+    def test_private_attr_completions(self):
+        ip = get_ipython()
+        ip.user_ns["Test"] = type("Test", (), {"_test1": 1, "__test2": 2})
+        ip.user_ns["t"] = ip.user_ns["Test"]()
+
+        try:
+            with provisionalcompleter():
+                completions = list(ip.Completer.completions(text="t._", offset=3))
+                completion_texts = [c.text for c in completions]
+
+                assert (
+                    "_test1" in completion_texts
+                ), f"_test1 not found in {completion_texts}"
+                assert (
+                    "__test2" in completion_texts
+                ), f"__test2 not found in {completion_texts}"
+        finally:
+            del ip.user_ns["Test"]
+            del ip.user_ns["t"]
+
 
 @pytest.mark.parametrize(
     "use_jedi,evaluation",

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2072,6 +2072,7 @@ class TestCompleter(unittest.TestCase):
         ip = get_ipython()
         ip.user_ns["Test"] = type("Test", (), {"_test1": 1, "__test2": 2})
         ip.user_ns["t"] = ip.user_ns["Test"]()
+        ip.Completer.use_jedi = False
 
         try:
             with provisionalcompleter():
@@ -2079,10 +2080,10 @@ class TestCompleter(unittest.TestCase):
                 completion_texts = [c.text for c in completions]
 
                 assert (
-                    "_test1" in completion_texts
+                    "._test1" in completion_texts
                 ), f"_test1 not found in {completion_texts}"
                 assert (
-                    "__test2" in completion_texts
+                    ".__test2" in completion_texts
                 ), f"__test2 not found in {completion_texts}"
         finally:
             del ip.user_ns["Test"]

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2739,6 +2739,8 @@ def test_no_file_completions_in_attr_access(code):
         ("dict_with_dots = {'key.with.dots': value.attr", "attribute"),
         ("d[f'{a}']['{a.", "global"),
         ("ls .", "global"),
+        ("t._", "attribute"),
+        ("t.__a", "attribute"),
     ],
 )
 def test_completion_context(line, expected):


### PR DESCRIPTION
### Fixes #15104 

### Description
The current regex pattern only matches attribute access where the attribute name starts with a letter ([a-zA-Z]). This PR modifies the pattern to handle attributes starting with `_` too.