### PR TITLE
Add 'exception' as alias for 'exceptions' command

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -470,7 +470,7 @@ class Pdb(OldPdb):
                 self._chained_exception_index = 0
 
         def do_exceptions(self, arg):
-            """exceptions [number]
+            """exceptions [number] (or exception [number])
             List or change current exception in an exception chain.
             Without arguments, list all the current exception in the exception
             chain. Exceptions will be numbered, with the current exception indicated
@@ -514,6 +514,17 @@ class Pdb(OldPdb):
                     self.print_stack_entry(self.stack[self.curindex])
                 else:
                     self.error("No exception with that number")
+
+    def do_exception(self,arg):
+        """exception [number]
+        Alias for 'exceptions' command. 
+        list or change current exception in an exception chain.
+        without arguments, list all the current exception in the exception chain. 
+        Exception will be numbered, with the current exception indicated
+        with arrow
+        If given an integer as argument, switch to the exception at the index.
+        """
+        return self.do_exceptions(arg)
 
     def interaction(self, frame, tb_or_exc):
         try:

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -937,3 +937,45 @@ def test_ignore_module_all_commands():
 
         child.sendline("continue")
         child.close()
+
+
+def test_exception_command_alias():
+    """Test that 'exception' is an alias for 'exceptions' command."""
+    from IPython.core.debugger import Pdb
+
+    # Create a Pdb instance
+    pdb_instance = Pdb()
+
+    # Verify both methods exist
+    assert hasattr(pdb_instance, 'do_exception')
+    assert hasattr(pdb_instance, 'do_exceptions')
+
+    # Verify they have the same behavior (calling exception calls exceptions)
+    # This is a basic sanity check
+    assert callable(pdb_instance.do_exception)
+    assert callable(pdb_instance.do_exceptions)
+
+
+def test_exception_command_alias_functionality():
+    """Test that 'exception' command works identically to 'exceptions'."""
+    from IPython.core.debugger import Pdb
+
+    # Create a Pdb instance
+    pdb_instance = Pdb()
+
+    # Test that both commands handle the same arguments without error
+    # When there are no chained exceptions, both should handle it gracefully
+
+    # These should not raise exceptions
+    result1 = pdb_instance.do_exceptions("")
+    result2 = pdb_instance.do_exception("")
+
+    # Both should return the same value (None in this case)
+    assert result1 == result2
+
+    # Test with an argument (should also not crash)
+    result3 = pdb_instance.do_exceptions("0")
+    result4 = pdb_instance.do_exception("0")
+
+    assert result3 == result4
+


### PR DESCRIPTION
- Added do_exception() method as alias for do_exceptions()
- Both singular and plural forms now work identically
- Added tests to verify the alias functionality
- Updated docstring to document both command forms

Fixes #14870