### PR TITLE
fix: replace 97 bare except clauses with except Exception

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -260,7 +260,7 @@ class BaseIPythonApplication(Application):
         # ensure current working directory exists
         try:
             os.getcwd()
-        except:
+        except Exception:
             # exit if cwd doesn't exist
             self.log.error("Current working directory doesn't exist.")
             self.exit(1)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2977,7 +2977,7 @@ class IPCompleter(Completer):
             for namedArg in set(namedArgs) - usedNamedArgs:
                 if namedArg.startswith(text):
                     argMatches.append("%s=" %namedArg)
-        except:
+        except Exception:
             pass
 
         return argMatches

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -182,7 +182,7 @@ def try_import(mod: str, only_modules=False) -> List[str]:
     mod = mod.rstrip('.')
     try:
         m = import_module(mod)
-    except:
+    except Exception:
         return []
 
     m_is_init = '__init__' in (getattr(m, '__file__', '') or '')

--- a/IPython/core/crashhandler.py
+++ b/IPython/core/crashhandler.py
@@ -191,7 +191,7 @@ class CrashHandler:
         # and generate a complete report on disk
         try:
             report = open(report_name, "w", encoding="utf-8")
-        except:
+        except Exception:
             print('Could not create crash report on disk.', file=sys.stderr)
             return
 
@@ -220,7 +220,7 @@ class CrashHandler:
             rpt_add("Application name: %s\n\n" % self.app.name)
             rpt_add("Current user configuration structure:\n\n")
             rpt_add(config)
-        except:
+        except Exception:
             pass
         rpt_add(sec_sep+'Crash traceback:\n\n' + traceback)
 

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -882,7 +882,7 @@ class Pdb(OldPdb):
                         last = first + last
                 else:
                     first = max(1, int(x) - 5)
-            except:
+            except Exception:
                 print("*** Error in argument:", repr(arg), file=self.stdout)
                 return
         elif self.lineno is None or arg == ".":

--- a/IPython/core/debugger_backport.py
+++ b/IPython/core/debugger_backport.py
@@ -202,5 +202,5 @@ class PdbClosureBackport:
                 sys.stdout = save_stdout
                 sys.stdin = save_stdin
                 sys.displayhook = save_displayhook
-        except:
+        except Exception:
             self._error_exc()

--- a/IPython/core/doctb.py
+++ b/IPython/core/doctb.py
@@ -255,7 +255,7 @@ class DocTB(TBTools):
         # Get (safely) a string form of the exception info
         try:
             etype_str, evalue_str = map(str, (etype, evalue))
-        except:
+        except Exception:
             # User exception is improperly defined.
             etype, evalue = str, sys.exc_info()[:2]
             etype_str, evalue_str = map(str, (etype, evalue))

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -236,7 +236,7 @@ class DisplayFormatter(Configurable):
             md = None
             try:
                 data = formatter(obj)
-            except:
+            except Exception:
                 # FIXME: log the exception
                 raise
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -1618,7 +1618,7 @@ class InteractiveShell(SingletonConfigurable):
             for name in vlist:
                 try:
                     vdict[name] = eval(name, cf.f_globals, cf.f_locals)
-                except:
+                except Exception:
                     print('Could not get variable %s from %s' %
                            (name,cf.f_code.co_name))
         else:
@@ -1777,7 +1777,7 @@ class InteractiveShell(SingletonConfigurable):
                                 obj = obj[int(part)]
                             else:
                                 obj = getattr(obj, part)
-                    except:
+                    except Exception:
                         # Blanket except b/c some badly implemented objects
                         # allow __getattr__ to raise exceptions other than
                         # AttributeError, which then crashes IPython.
@@ -2071,7 +2071,7 @@ class InteractiveShell(SingletonConfigurable):
                 try:
                     stb = handler(self,etype,value,tb,tb_offset=tb_offset)
                     return validate_stb(stb)
-                except:
+                except Exception:
                     # clear custom handler immediately
                     self.set_custom_exc((), None)
                     print("Custom TB Handler failed, unregistering", file=sys.stderr)
@@ -2273,7 +2273,7 @@ class InteractiveShell(SingletonConfigurable):
         if filename and issubclass(etype, SyntaxError):
             try:
                 value.filename = filename
-            except:
+            except Exception:
                 # Not the format we expect; leave it alone
                 pass
 
@@ -2906,7 +2906,7 @@ class InteractiveShell(SingletonConfigurable):
         for key, expr in expressions.items():
             try:
                 value = self._format_user_obj(eval(expr, global_ns, user_ns))
-            except:
+            except Exception:
                 value = self._user_obj_error()
             out[key] = value
         return out
@@ -2960,7 +2960,7 @@ class InteractiveShell(SingletonConfigurable):
         try:
             with fname.open("rb"):
                 pass
-        except:
+        except Exception:
             warn('Could not open file <%s> for safe execution.' % fname)
             return
 
@@ -2990,7 +2990,7 @@ class InteractiveShell(SingletonConfigurable):
                         raise
                     if not exit_ignore:
                         self.showtraceback(exception_only=True)
-            except:
+            except Exception:
                 if raise_exceptions:
                     raise
                 # tb offset is 2 because we wrap execfile
@@ -3018,7 +3018,7 @@ class InteractiveShell(SingletonConfigurable):
         try:
             with fname.open("rb"):
                 pass
-        except:
+        except Exception:
             warn('Could not open file <%s> for safe execution.' % fname)
             return
 
@@ -3048,7 +3048,7 @@ class InteractiveShell(SingletonConfigurable):
                         result.raise_error()
                     elif not result.success:
                         break
-            except:
+            except Exception:
                 if raise_exceptions:
                     raise
                 self.showtraceback()
@@ -3078,7 +3078,7 @@ class InteractiveShell(SingletonConfigurable):
             except SystemExit as status:
                 if status.code:
                     raise
-        except:
+        except Exception:
             self.showtraceback()
             warn('Unknown failure executing module: <%s>' % mod_name)
 
@@ -3235,7 +3235,7 @@ class InteractiveShell(SingletonConfigurable):
                 result = ExecutionResult(info)
                 result.error_in_exec = e
                 self.showtraceback(running_compiled_code=True)
-            except:
+            except Exception:
                 pass
         return result
 
@@ -3482,7 +3482,7 @@ class InteractiveShell(SingletonConfigurable):
             if filename and isinstance(evalue, SyntaxError):
                 try:
                     evalue.filename = filename
-                except:
+                except Exception:
                     pass  # Keep the original filename if modification fails
 
             # Extract traceback if the error happened during compiled code execution
@@ -3691,7 +3691,7 @@ class InteractiveShell(SingletonConfigurable):
             if softspace(sys.stdout, 0):
                 print()
 
-        except:
+        except Exception:
             # It's possible to have exceptions raised here, typically by
             # compilation of odd code (such as a naked 'return' outside a
             # function) that did parse but isn't valid. Typically the exception
@@ -3763,7 +3763,7 @@ class InteractiveShell(SingletonConfigurable):
             if result is not None:
                 result.error_in_exec = value
             self.CustomTB(etype, value, tb)
-        except:
+        except Exception:
             if result is not None:
                 result.error_in_exec = sys.exc_info()[1]
             self.showtraceback(running_compiled_code=True)

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -369,7 +369,7 @@ Currently the magic system has the following functions:""",
         try:
             shell.InteractiveTB.set_mode(mode=new_mode)
             print('Exception reporting mode:',shell.InteractiveTB.mode)
-        except:
+        except Exception:
             raise
             xmode_switch_err('user')
 

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -528,7 +528,7 @@ class CodeMagics(Magics):
             last_call[0] = shell.displayhook.prompt_count
             if not opts_prev:
                 last_call[1] = args
-        except:
+        except Exception:
             pass
 
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -116,7 +116,7 @@ class TimeitResult:
             try:
                 "\xb1".encode(sys.stdout.encoding)
                 pm = "\xb1"
-            except:
+            except Exception:
                 pass
         return "{mean} {pm} {std} per loop (mean {pm} std. dev. of {runs} run{run_plural}, {loops:,} loop{loop_plural} each)".format(
             pm=pm,
@@ -1697,7 +1697,7 @@ def _format_time(timespan, precision=3):
         try:
             "μ".encode(sys.stdout.encoding)
             units = ["s", "ms", "μs", "ns"]
-        except:
+        except Exception:
             pass
     scaling = [1, 1e3, 1e6, 1e9]
 

--- a/IPython/core/magics/logging.py
+++ b/IPython/core/magics/logging.py
@@ -107,7 +107,7 @@ class LoggingMagics(Magics):
         if par:
             try:
                 logfname,logmode = par.split()
-            except:
+            except Exception:
                 logfname = par
                 logmode = 'backup'
         else:
@@ -125,7 +125,7 @@ class LoggingMagics(Magics):
         try:
             logger.logstart(logfname, loghead, logmode, log_output, timestamp,
                             log_raw_input)
-        except:
+        except Exception:
             self.shell.logfile = old_logfile
             warn("Couldn't start log: %s" % sys.exc_info()[1])
         else:

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -239,7 +239,7 @@ class NamespaceMagics(Magics):
         try:
             psearch(args,shell.ns_table,ns_search,
                     show_all=opt('a'),ignore_case=ignore_case, list_types=list_types)
-        except:
+        except Exception:
             shell.showtraceback()
 
     @skip_doctest
@@ -477,7 +477,7 @@ class NamespaceMagics(Magics):
                 except UnicodeEncodeError:
                     vstr = var.encode(DEFAULT_ENCODING,
                                       'backslashreplace')
-                except:
+                except Exception:
                     vstr = "<object with id %d (str() failed)>" % id(var)
                 vstr = vstr.replace('\n', '\\n')
                 if len(vstr) < 50:

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -544,7 +544,7 @@ class OSMagics(Magics):
         if parameter_s:
             try:
                 args = map(int,parameter_s.split())
-            except:
+            except Exception:
                 self.arg_err(self.dhist)
                 return
             if len(args) == 1:

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -377,7 +377,7 @@ class ScriptMagics(Magics):
             if p.returncode is None:
                 try:
                     p.send_signal(signal.SIGINT)
-                except:
+                except Exception:
                     pass
         time.sleep(0.1)
         self._gc_bg_processes()
@@ -387,7 +387,7 @@ class ScriptMagics(Magics):
             if p.returncode is None:
                 try:
                     p.terminate()
-                except:
+                except Exception:
                     pass
         time.sleep(0.1)
         self._gc_bg_processes()
@@ -397,7 +397,7 @@ class ScriptMagics(Magics):
             if p.returncode is None:
                 try:
                     p.kill()
-                except:
+                except Exception:
                     pass
         self._gc_bg_processes()
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -425,7 +425,7 @@ class Inspector(Configurable):
             return None
         try:
             return _render_signature(signature(obj), oname)
-        except:
+        except Exception:
             return None
 
     def __head(self, h: str) -> str:
@@ -907,7 +907,7 @@ class Inspector(Configurable):
             if not callable(obj):
                 try:
                     ds = "Alias to the system command:\n  %s" % obj[1]
-                except:
+                except Exception:
                     ds = "Alias: " + str(obj)
             else:
                 ds = "Alias to " + str(obj)
@@ -937,7 +937,7 @@ class Inspector(Configurable):
         try:
             bclass = obj.__class__
             out['base_class'] = str(bclass)
-        except:
+        except Exception:
             pass
 
         # String form, but snip if too long in ? form (full in ??)
@@ -952,7 +952,7 @@ class Inspector(Configurable):
                         q.strip() for q in ostr.split("\n")
                     )
                 out["string_form"] = ostr
-            except:
+            except Exception:
                 pass
 
         if ospace:
@@ -1051,7 +1051,7 @@ class Inspector(Configurable):
             if ds:
                 try:
                     cls = getattr(obj,'__class__')
-                except:
+                except Exception:
                     class_ds = None
                 else:
                     class_ds = getdoc(cls)

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -276,12 +276,12 @@ def page_file(fname, start=0, pager_cmd=None):
         if os.environ['TERM'] in ['emacs','dumb']:
             raise EnvironmentError
         system(pager_cmd + ' ' + fname)
-    except:
+    except Exception:
         try:
             if start > 0:
                 start -= 1
             page(open(fname, encoding="utf-8").read(), start)
-        except:
+        except Exception:
             print('Unable to show file',repr(fname))
 
 
@@ -298,7 +298,7 @@ def get_pager_cmd(pager_cmd=None):
     if pager_cmd is None:
         try:
             pager_cmd = os.environ['PAGER']
-        except:
+        except Exception:
             pager_cmd = default_pager_cmd
     
     if pager_cmd == 'less' and '-r' not in os.environ.get('LESS', '').lower():

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -329,7 +329,7 @@ class InteractiveShellApp(Configurable):
                 try:
                     self.log.info("Loading IPython extension: %s", ext)
                     self.shell.extension_manager.load_extension(ext)
-                except:
+                except Exception:
                     if self.reraise_ipython_extension_failures:
                         raise
                     msg = ("Error in loading extension: {ext}\n"
@@ -338,7 +338,7 @@ class InteractiveShellApp(Configurable):
                                location=self.profile_dir.location
                            ))
                     self.log.warning(msg, exc_info=True)
-        except:
+        except Exception:
             if self.reraise_ipython_extension_failures:
                 raise
             self.log.warning("Unknown error in loading extensions:", exc_info=True)
@@ -374,11 +374,11 @@ class InteractiveShellApp(Configurable):
                     self.log.info("Running code in user namespace: %s" %
                                   line)
                     self.shell.run_cell(line, store_history=False)
-                except:
+                except Exception:
                     self.log.warning("Error in executing line in user "
                                   "namespace: %s" % line)
                     self.shell.showtraceback()
-        except:
+        except Exception:
             self.log.warning("Unknown error in handling IPythonApp.exec_lines:")
             self.shell.showtraceback()
 
@@ -425,7 +425,7 @@ class InteractiveShellApp(Configurable):
             self.log.debug("Running PYTHONSTARTUP file %s...", python_startup)
             try:
                 self._exec_file(python_startup)
-            except:
+            except Exception:
                 self.log.warning("Unknown error in handling PYTHONSTARTUP file %s:", python_startup)
                 self.shell.showtraceback()
         for startup_dir in startup_dirs[::-1]:
@@ -438,7 +438,7 @@ class InteractiveShellApp(Configurable):
         try:
             for fname in sorted(startup_files):
                 self._exec_file(fname)
-        except:
+        except Exception:
             self.log.warning("Unknown error in handling startup files:")
             self.shell.showtraceback()
 
@@ -451,7 +451,7 @@ class InteractiveShellApp(Configurable):
         try:
             for fname in self.exec_files:
                 self._exec_file(fname)
-        except:
+        except Exception:
             self.log.warning("Unknown error in handling IPythonApp.exec_files:")
             self.shell.showtraceback()
 
@@ -463,7 +463,7 @@ class InteractiveShellApp(Configurable):
                 self.log.info("Running code given at command line (c=): %s" %
                               line)
                 self.shell.run_cell(line, store_history=False)
-            except:
+            except Exception:
                 self.log.warning("Error in executing line in user namespace: %s" %
                               line)
                 self.shell.showtraceback()
@@ -481,7 +481,7 @@ class InteractiveShellApp(Configurable):
                     self.exit(2)
             try:
                 self._exec_file(fname, shell_futures=True)
-            except:
+            except Exception:
                 self.shell.showtraceback(tb_offset=4)
                 if not self.interact:
                     self.exit(1)

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -68,7 +68,7 @@ def _safe_string(value: Any, what: Any, func: Any = str) -> str:
     # Copied from cpython/Lib/traceback.py
     try:
         return func(value)
-    except:
+    except Exception:
         return f"<{what} {func.__name__}() failed>"
 
 
@@ -135,12 +135,12 @@ def text_repr(value: Any) -> str:
         return pydoc.text.repr(value)  # type: ignore[call-arg]
     except KeyboardInterrupt:
         raise
-    except:
+    except Exception:
         try:
             return repr(value)
         except KeyboardInterrupt:
             raise
-        except:
+        except Exception:
             try:
                 # all still in an except block so we catch
                 # getattr raising
@@ -154,7 +154,7 @@ def text_repr(value: Any) -> str:
                 return "UNRECOVERABLE REPR FAILURE"
             except KeyboardInterrupt:
                 raise
-            except:
+            except Exception:
                 return "UNRECOVERABLE REPR FAILURE"
 
 

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -433,7 +433,7 @@ class ListTB(TBTools):
         # Lifted from traceback.py
         try:
             return str(value)
-        except:
+        except Exception:
             return "<unprintable %s object>" % type(value).__name__
 
 
@@ -705,7 +705,7 @@ class VerboseTB(TBTools):
         # Get (safely) a string form of the exception info
         try:
             etype_str, evalue_str = map(str, (etype, evalue))
-        except:
+        except Exception:
             # User exception is improperly defined.
             etype, evalue = str, sys.exc_info()[:2]
             etype_str, evalue_str = map(str, (etype, evalue))
@@ -1136,7 +1136,7 @@ class AutoFormattedTB(FormattedTB):
         AutoTB = AutoFormattedTB(mode = 'Verbose', theme_name='linux')
         try:
           ...
-        except:
+        except Exception:
           AutoTB()  # or AutoTB(out=logfile) where logfile is an open file object
     """
 

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -325,7 +325,7 @@ class ModuleReloader:
                         superreload(m, reload, self.old_objects)
                     if py_filename in self.failed:
                         del self.failed[py_filename]
-                except:
+                except Exception:
                     if not self.hide_errors:
                         logger = logging.getLogger("autoreload")
                         logger.exception(
@@ -582,7 +582,7 @@ def superreload(
 
     try:
         module = reload(module)
-    except:
+    except Exception:
         # restore module dictionary on failed reload
         module.__dict__.update(old_dict)
         raise
@@ -850,7 +850,7 @@ class AutoreloadMagics(Magics):
         if self._reloader.enabled:
             try:
                 self._reloader.check()
-            except:
+            except Exception:
                 pass
 
     def post_execute_hook(self):

--- a/IPython/external/pickleshare.py
+++ b/IPython/external/pickleshare.py
@@ -96,7 +96,7 @@ class PickleShareDB(collections_abc.MutableMapping):
             # The cached item has expired, need to read
             with fil.open("rb") as f:
                 obj = pickle.loads(f.read())
-        except:
+        except Exception:
             raise KeyError(key)
 
         self.cache[fil] = (obj, mtime)

--- a/IPython/lib/backgroundjobs.py
+++ b/IPython/lib/backgroundjobs.py
@@ -403,7 +403,7 @@ class BackgroundJobBase(threading.Thread):
         # make a new one
         try:
             make_tb = get_ipython().InteractiveTB.text
-        except:
+        except Exception:
             make_tb = AutoFormattedTB(
                 mode="Context", color_scheme="nocolor", tb_offset=1
             ).text
@@ -430,7 +430,7 @@ class BackgroundJobBase(threading.Thread):
             self.status    = BackgroundJobBase.stat_running
             self.stat_code = BackgroundJobBase.stat_running_c
             self.result    = self.call()
-        except:
+        except Exception:
             self.status    = BackgroundJobBase.stat_dead
             self.stat_code = BackgroundJobBase.stat_dead_c
             self.finished  = None

--- a/IPython/lib/deepreload.py
+++ b/IPython/lib/deepreload.py
@@ -179,7 +179,7 @@ def import_submodule(mod, subname, fullname):
                 m = importlib.reload(oldm)
             else:
                 m = importlib.import_module(subname, mod)
-        except:
+        except Exception:
             # load_module probably removed name from modules because of
             # the error.  Put back the original module object.
             if oldm:
@@ -266,12 +266,12 @@ def deep_reload_hook(m):
     global modules_reloading
     try:
         return modules_reloading[name]
-    except:
+    except Exception:
         modules_reloading[name] = m
 
     try:
         newm = importlib.reload(m)
-    except:
+    except Exception:
         sys.modules[name] = m
         raise
     finally:

--- a/IPython/lib/demo.py
+++ b/IPython/lib/demo.py
@@ -487,7 +487,7 @@ class Demo:
             finally:
                 sys.argv = save_argv
 
-        except:
+        except Exception:
             if self.inside_ipython:
                 self.ip_showtb(filename=self.fname)
         else:

--- a/IPython/sphinxext/custom_doctests.py
+++ b/IPython/sphinxext/custom_doctests.py
@@ -115,7 +115,7 @@ def float_doctest(sphinx_shell, args, input_lines, found, submitted):
     try:
         submitted = str_to_array(submitted)
         found = str_to_array(found)
-    except:
+    except Exception:
         # For example, if the array is huge and there are ellipsis in it.
         error = True
     else:

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -56,7 +56,7 @@ If the current section raises an exception, you can add the ``:okexcept:`` flag
 to the current block, otherwise the build will fail.
 
 .. ipython::
-   :okexcept:
+   :okexcept Exception:
 
    In [1]: 1/0
 
@@ -151,13 +151,13 @@ is specified, then only the last one is used.
 In addition to the Pseudo-Decorators/options described at the above link,
 several enhancements have been made. The directive will emit a message to the
 console at build-time if code-execution resulted in an exception or warning.
-You can suppress these on a per-block basis by specifying the :okexcept:
+You can suppress these on a per-block basis by specifying the :okexcept Exception:
 or :okwarning: options:
 
 .. code-block:: rst
 
     .. ipython::
-        :okexcept:
+        :okexcept Exception:
         :okwarning:
 
         In [1]: 1/0

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -85,7 +85,7 @@ class IPAppCrashHandler(CrashHandler):
                 rpt_add(line)
             rpt_add('\n*** Last line of input (may not be in above history):\n')
             rpt_add(self.app.shell._last_input_line+'\n')
-        except:
+        except Exception:
             pass
 
         return ''.join(report)

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -284,7 +284,7 @@ class TempFileMixin(unittest.TestCase):
                 # win32, there's nothing to cleanup.
                 try:
                     os.unlink(fname)
-                except:
+                except Exception:
                     # On Windows, even though we close the file, we still can't
                     # delete it.  I have no clue why
                     pass

--- a/IPython/utils/dir2.py
+++ b/IPython/utils/dir2.py
@@ -18,7 +18,7 @@ def safe_hasattr(obj: object, attr: str) -> bool:
     try:
         getattr(obj, attr)
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -186,7 +186,7 @@ def get_home_dir(require_writable=False) -> str:
                 r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
             ) as key:
                 homedir = wreg.QueryValueEx(key,'Personal')[0]
-        except:
+        except Exception:
             pass
 
     if (not require_writable) or _writable_dir(homedir):
@@ -324,7 +324,7 @@ def link_or_copy(src, dst):
         new_dst = dst + "-temp-%04X" %(random.randint(1, 16**4), )
         try:
             link_or_copy(src, new_dst)
-        except:
+        except Exception:
             try:
                 os.remove(new_dst)
             except OSError:

--- a/examples/Embedding/embed_function.py
+++ b/examples/Embedding/embed_function.py
@@ -12,5 +12,5 @@ d = 40
 
 try:
     raise Exception("adsfasdf")
-except:
+except Exception:
     embed(header="The second time")

--- a/tests/simpleerr.py
+++ b/tests/simpleerr.py
@@ -21,7 +21,7 @@ def bar(mode):
     elif mode == "exit":
         try:
             stat = int(sys.argv[2])
-        except:
+        except Exception:
             stat = 1
         sysexit(stat, mode)
     else:

--- a/tests/test_async_helpers.py
+++ b/tests/test_async_helpers.py
@@ -108,7 +108,7 @@ class AsyncTest(TestCase):
                     """
         try:
             {val}
-        except:
+        except Exception:
             pass
         """
                 ),
@@ -122,7 +122,7 @@ class AsyncTest(TestCase):
                     """
         try:
             pass
-        except:
+        except Exception:
             {val}
         """
                 ),
@@ -136,7 +136,7 @@ class AsyncTest(TestCase):
                     """
         try:
             pass
-        except:
+        except Exception:
             pass
         finally:
             {val}

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -4,7 +4,7 @@ from math import pi
 
 try:
     import numpy
-except:
+except Exception:
     numpy = None
 import pytest
 

--- a/tests/test_interactivshell.py
+++ b/tests/test_interactivshell.py
@@ -128,7 +128,7 @@ class mock_input_helper(object):
         except StopIteration:
             self.ip.keep_running = False
             return ""
-        except:
+        except Exception:
             self.exception = sys.exc_info()
             self.ip.keep_running = False
             return ""

--- a/tests/test_iplib.py
+++ b/tests/test_iplib.py
@@ -153,7 +153,7 @@ def doctest_tb_sysexit():
     ---> 37     bar(mode)
     <BLANKLINE>
     ...bar(mode)
-         24         except:
+         24         except Exception:
          25             stat = 1
     ---> 26         sysexit(stat, mode)
          27     else:
@@ -193,7 +193,7 @@ if SV_VERSION < (0, 6):
                 mode = "exit"
         <BLANKLINE>
         ... in bar(mode="exit")
-             ...     except:
+             ...     except Exception:
              ...         stat = 1
         ---> ...     sysexit(stat, mode)
                 mode = "exit"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -88,7 +88,7 @@ def doctest_run_builtins():
 
     In [12]: try:
        ....:     os.unlink(fname)
-       ....: except:
+       ....: except Exception:
        ....:     pass
        ....:
     """
@@ -619,7 +619,7 @@ def test_multiprocessing_run():
             assert "AttributeError" not in out
             assert "NameError" in out
             assert out.count("---->") == 1
-        except:
+        except Exception:
             raise
         finally:
             sys.modules["__mp_main__"] = mpm

--- a/tests/test_ultratb.py
+++ b/tests/test_ultratb.py
@@ -479,14 +479,14 @@ def test_handlers():
     buff.write("*** Before ***")
     try:
         buff.write(spam(1, (2, 3)))
-    except:
+    except Exception:
         traceback.print_exc(file=buff)
 
     handler = FormattedTB(ostream=buff)
     buff.write("*** FormattedTB ***")
     try:
         buff.write(spam(1, (2, 3)))
-    except:
+    except Exception:
         handler(*sys.exc_info())
     buff.write("")
 
@@ -494,7 +494,7 @@ def test_handlers():
     buff.write("*** VerboseTB ***")
     try:
         buff.write(spam(1, (2, 3)))
-    except:
+    except Exception:
         handler(*sys.exc_info())
     buff.write("")
 


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.