### PR TITLE
Use weakref finalize to close sqlite.conenctions

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -10,6 +10,7 @@ import atexit
 import datetime
 import os
 import re
+import weakref
 
 
 import threading
@@ -322,12 +323,14 @@ class HistoryAccessor(HistoryAccessorBase):
         """Connect to the database, and create tables if necessary."""
         if not self.enabled:
             self.db = DummyDB()
+            self._finalizer = weakref.finalize(self, lambda db: db.close(), self.db)
             return
 
         # use detect_types so that timestamps return datetime objects
         kwargs = dict(detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
         kwargs.update(self.connection_options)
         self.db = sqlite3.connect(str(self.hist_file), **kwargs)  # type: ignore [call-overload]
+        self._finalizer = weakref.finalize(self, lambda db: db.close(), self.db)
         with self.db:
             self.db.execute(
                 """CREATE TABLE IF NOT EXISTS sessions (session integer
@@ -348,10 +351,6 @@ class HistoryAccessor(HistoryAccessorBase):
             )
         # success! reset corrupt db count
         self._corrupt_db_counter = 0
-
-    def __del__(self) -> None:
-        if hasattr(self, "db"):
-            self.db.close()
 
     def writeout_cache(self) -> None:
         """Overridden by HistoryManager to dump the cache before certain
@@ -721,7 +720,6 @@ class HistoryManager(HistoryAccessor):
     def __del__(self) -> None:
         if self.save_thread is not None:
             self.save_thread.stop()
-        HistoryAccessor.__del__(self)
 
     @classmethod
     def _stop_thread(cls) -> None:

--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -50,27 +50,26 @@ class HistoryTrim(BaseIPythonApplication):
     def start(self):
         profile_dir = Path(self.profile_dir.location)
         hist_file = profile_dir / "history.sqlite"
-        con = sqlite3.connect(hist_file)
+        with sqlite3.connect(hist_file) as con:
 
-        # Grab the recent history from the current database.
-        inputs = list(con.execute('SELECT session, line, source, source_raw FROM '
-                                'history ORDER BY session DESC, line DESC LIMIT ?', (self.keep+1,)))
-        if len(inputs) <= self.keep:
-            print("There are already at most %d entries in the history database." % self.keep)
-            print("Not doing anything. Use --keep= argument to keep fewer entries")
-            return
+            # Grab the recent history from the current database.
+            inputs = list(con.execute('SELECT session, line, source, source_raw FROM '
+                                    'history ORDER BY session DESC, line DESC LIMIT ?', (self.keep+1,)))
+            if len(inputs) <= self.keep:
+                print("There are already at most %d entries in the history database." % self.keep)
+                print("Not doing anything. Use --keep= argument to keep fewer entries")
+                return
 
-        print("Trimming history to the most recent %d entries." % self.keep)
+            print("Trimming history to the most recent %d entries." % self.keep)
 
-        inputs.pop() # Remove the extra element we got to check the length.
-        inputs.reverse()
-        if inputs:
-            first_session = inputs[0][0]
-            outputs = list(con.execute('SELECT session, line, output FROM '
-                                       'output_history WHERE session >= ?', (first_session,)))
-            sessions = list(con.execute('SELECT session, start, end, num_cmds, remark FROM '
-                                        'sessions WHERE session >= ?', (first_session,)))
-        con.close()
+            inputs.pop() # Remove the extra element we got to check the length.
+            inputs.reverse()
+            if inputs:
+                first_session = inputs[0][0]
+                outputs = list(con.execute('SELECT session, line, output FROM '
+                                        'output_history WHERE session >= ?', (first_session,)))
+                sessions = list(con.execute('SELECT session, start, end, num_cmds, remark FROM '
+                                            'sessions WHERE session >= ?', (first_session,)))
 
         # Create the new history database.
         new_hist_file = profile_dir / "history.sqlite.new"
@@ -79,26 +78,25 @@ class HistoryTrim(BaseIPythonApplication):
             # Make sure we don't interfere with an existing file.
             i += 1
             new_hist_file = profile_dir / ("history.sqlite.new" + str(i))
-        new_db = sqlite3.connect(new_hist_file)
-        new_db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer
-                            primary key autoincrement, start timestamp,
-                            end timestamp, num_cmds integer, remark text)""")
-        new_db.execute("""CREATE TABLE IF NOT EXISTS history
-                        (session integer, line integer, source text, source_raw text,
-                        PRIMARY KEY (session, line))""")
-        new_db.execute("""CREATE TABLE IF NOT EXISTS output_history
-                        (session integer, line integer, output text,
-                        PRIMARY KEY (session, line))""")
-        new_db.commit()
+        with sqlite3.connect(new_hist_file) as new_db:
+            new_db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer
+                                primary key autoincrement, start timestamp,
+                                end timestamp, num_cmds integer, remark text)""")
+            new_db.execute("""CREATE TABLE IF NOT EXISTS history
+                            (session integer, line integer, source text, source_raw text,
+                            PRIMARY KEY (session, line))""")
+            new_db.execute("""CREATE TABLE IF NOT EXISTS output_history
+                            (session integer, line integer, output text,
+                            PRIMARY KEY (session, line))""")
+            new_db.commit()
 
 
-        if inputs:
-            with new_db:
-                # Add the recent history into the new database.
-                new_db.executemany('insert into sessions values (?,?,?,?,?)', sessions)
-                new_db.executemany('insert into history values (?,?,?,?)', inputs)
-                new_db.executemany('insert into output_history values (?,?,?)', outputs)
-        new_db.close()
+            if inputs:
+                with new_db:
+                    # Add the recent history into the new database.
+                    new_db.executemany('insert into sessions values (?,?,?,?,?)', sessions)
+                    new_db.executemany('insert into history values (?,?,?,?)', inputs)
+                    new_db.executemany('insert into output_history values (?,?,?)', outputs)
 
         if self.backup:
             i = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,6 +379,9 @@ ipdoctest_optionflags = [
    "ELLIPSIS"
 ]
 asyncio_mode = "strict"
+filterwarnings = [
+    "error::ResourceWarning",
+]
 
 [tool.pyright]
 pythonPlatform="All"


### PR DESCRIPTION
Maybe closes https://github.com/ipython/ipython/issues/15128. (We can sometimes see a similar `ResourceWarning` when running the pandas tests suite)

`weakref.finalize` is the recommended way to run cleanup routines compared to `__del__` https://docs.python.org/3/library/weakref.html#comparing-finalizers-with-del-methods, so defined a `self._finalizer` to close the `sqlite3.Connection`. Additionally, adds a `"error::ResourceWarning"` warning filter to pytest so these warnings are treated as errors.