### PR TITLE
doc: clarify xmode docstring with mode descriptions

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -354,7 +354,7 @@ Currently the magic system has the following functions:""",
         - ``Minimal``: shows only the exception type and message, without
           a traceback.
         - ``Docs``: a stripped-down version of Verbose, designed for use
-        when running doctests.
+          when running doctests.
 
         If called without arguments, cycles through the available modes.
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -346,9 +346,19 @@ Currently the magic system has the following functions:""",
 
         Valid modes: Plain, Context, Verbose, Minimal, and Docs.
 
-        If called without arguments, acts as a toggle.
+        - ``Plain``: similar to Python's default traceback.
+        - ``Context``: shows several lines of surrounding context for each
+          frame in the traceback.
+        - ``Verbose``: like Context, but also displays local variable values
+          in each frame.
+        - ``Minimal``: shows only the exception type and message, without
+          a traceback.
+        - ``Docs``: a stripped-down version of Verbose, designed for use
+        when running doctests.
 
-        When in verbose mode the value `--show` (and `--hide`)
+        If called without arguments, cycles through the available modes.
+
+        When in verbose mode the value ``--show`` (and ``--hide``)
         will respectively show (or hide) frames with ``__tracebackhide__ =
         True`` value set.
         """


### PR DESCRIPTION
## Summary
Closes #13981

The `%xmode` magic docstring listed valid modes but did not describe 
what each mode does. This PR adds a brief description for each mode 
and clarifies that calling `%xmode` without arguments cycles through 
modes rather than just toggling.

## Changes
- Added description for each mode: Plain, Context, Verbose, Minimal, Docs
- Corrected "acts as a toggle" to "cycles through the available modes"
- Kept existing note about `--show`/`--hide` in Verbose mode

## AI Usage
Copilot was used to draft the docstring. All suggestions were reviewed, 
tested, and corrected where inaccurate (specifically the Docs mode description).