### PR TITLE
fix: preserve sys.exit() exit codes in non-interactive mode

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -482,7 +482,6 @@ class InteractiveShellApp(Configurable):
             try:
                 self._exec_file(fname, shell_futures=True)
             except SystemExit as e:
-                self.shell.showtraceback(tb_offset=4)
                 if not self.interact:
                     exit_code = 1
                     if isinstance(e.code, int):

--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -481,6 +481,15 @@ class InteractiveShellApp(Configurable):
                     self.exit(2)
             try:
                 self._exec_file(fname, shell_futures=True)
+            except SystemExit as e:
+                self.shell.showtraceback(tb_offset=4)
+                if not self.interact:
+                    exit_code = 1
+                    if isinstance(e.code, int):
+                        exit_code = e.code
+                    elif e.code is None:
+                        exit_code = 0
+                    self.exit(exit_code)
             except:
                 self.shell.showtraceback(tb_offset=4)
                 if not self.interact:

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -327,7 +327,17 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             self.log.debug("IPython not interactive...")
             self.shell.restore_term_title()
             if not self.shell.last_execution_succeeded:
-                sys.exit(1)
+                exit_code = 1
+                result = self.shell.last_execution_result
+                if result is not None and isinstance(
+                    result.error_in_exec, SystemExit
+                ):
+                    code = result.error_in_exec.code
+                    if isinstance(code, int):
+                        exit_code = code
+                    elif code is None:
+                        exit_code = 0
+                sys.exit(exit_code)
 
 def load_default_config(ipython_dir=None):
     """Load the default config file from the default ipython_dir.

--- a/tests/test_shellapp.py
+++ b/tests/test_shellapp.py
@@ -15,6 +15,8 @@ Authors
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
+import subprocess
+import sys
 import unittest
 
 from IPython.testing import decorators as dec
@@ -54,3 +56,54 @@ class TestFileToRun(tt.TempFileMixin, unittest.TestCase):
             commands=['"__file__" in globals()', "print(123)", "exit()"],
         )
         assert "False" in out, f"Subprocess stderr:\n{err}\n-----"
+
+
+class TestExitCode(tt.TempFileMixin, unittest.TestCase):
+    """Test that IPython preserves exit codes from sys.exit()."""
+
+    def _ipython_rc(self, *args):
+        """Run IPython with given args and return the exit code."""
+        cmd = [sys.executable, "-m", "IPython"] + tt.default_argv() + list(args)
+        return subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def test_sys_exit_zero(self):
+        """sys.exit(0) should exit with code 0."""
+        rc = self._ipython_rc("-c", "import sys; sys.exit(0)")
+        assert rc == 0
+
+    def test_sys_exit_one(self):
+        """sys.exit(1) should exit with code 1."""
+        rc = self._ipython_rc("-c", "import sys; sys.exit(1)")
+        assert rc == 1
+
+    def test_sys_exit_two(self):
+        """sys.exit(2) should exit with code 2, not 1."""
+        rc = self._ipython_rc("-c", "import sys; sys.exit(2)")
+        assert rc == 2
+
+    def test_sys_exit_nonzero_arbitrary(self):
+        """sys.exit(42) should exit with code 42."""
+        rc = self._ipython_rc("-c", "import sys; sys.exit(42)")
+        assert rc == 42
+
+    def test_sys_exit_no_arg(self):
+        """sys.exit() with no argument should exit with code 0."""
+        rc = self._ipython_rc("-c", "import sys; sys.exit()")
+        assert rc == 0
+
+    def test_normal_execution_exits_zero(self):
+        """Normal code should exit with code 0."""
+        rc = self._ipython_rc("-c", "print('hello')")
+        assert rc == 0
+
+    def test_sys_exit_in_script(self):
+        """sys.exit(2) in a script file should exit with code 2."""
+        self.mktmp("import sys; sys.exit(2)\n")
+        rc = self._ipython_rc("--", self.fname)
+        assert rc == 2
+
+    def test_sys_exit_zero_in_script(self):
+        """sys.exit(0) in a script file should exit with code 0."""
+        self.mktmp("import sys; sys.exit(0)\n")
+        rc = self._ipython_rc("--", self.fname)
+        assert rc == 0


### PR DESCRIPTION
## Summary

Fixes #15132.

When running `ipython -c "import sys;sys.exit(2)"`, IPython returned exit code 1 instead of 2. Regular Python correctly returns 2.

**Root cause:** `TerminalIPythonApp.start()` in `ipapp.py` hardcoded `sys.exit(1)` for all failed executions, regardless of the actual exit code passed to `sys.exit()`.

## Changes

- **`IPython/terminal/ipapp.py`** -- Extract the original exit code from `last_execution_result.error_in_exec` when the error is a `SystemExit`. Falls back to exit code 1 for non-SystemExit failures.
- **`IPython/core/shellapp.py`** -- Add a separate `except SystemExit` clause in the file execution path of `_run_cmd_line_code()` to preserve exit codes when running script files.
- **`tests/test_shellapp.py`** -- Add 8 tests covering exit code preservation for `-c` execution and script file execution (codes 0, 1, 2, 42, no-arg, normal execution).

## How it works

When `sys.exit(N)` is called inside user code, `InteractiveShell.run_code()` catches the `SystemExit` and stores it in `result.error_in_exec`. The fix reads `error_in_exec.code` to extract the original exit code instead of discarding it.

Edge cases handled:
- `sys.exit(0)` and `sys.exit()` -- exit code 0
- `sys.exit(N)` for any integer N -- preserves N
- `sys.exit("message")` -- exit code 1 (matches Python behavior)
- Non-SystemExit failures -- exit code 1 (unchanged)

## Test plan

- [x] `ipython -c "import sys; sys.exit(2)"` returns code 2 (was 1)
- [x] `ipython -c "import sys; sys.exit(42)"` returns code 42 (was 1)
- [x] `ipython -c "import sys; sys.exit(0)"` returns code 0
- [x] `ipython -c "print('hello')"` returns code 0 (unchanged)
- [x] Script file with `sys.exit(2)` returns code 2
- [x] All 3 modified files pass syntax check