### PR TITLE
chore: add 5 return type hints in completer.py

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1400,7 +1400,7 @@ class Completer(Configurable):
         return self._auto_import_func
 
 
-def get__all__entries(obj):
+def get__all__entries(obj) -> list:
     """returns the strings in the __all__ attribute"""
     try:
         words = getattr(obj, '__all__')
@@ -1519,7 +1519,7 @@ def match_dict_keys(
     )
     text_serializable_types = (str, bytes, int, float, slice)
 
-    def filter_prefix_tuple(key):
+    def filter_prefix_tuple(key) -> bool:
         # Reject too short keys
         if len(key) <= prefix_tuple_size:
             return False
@@ -2383,7 +2383,7 @@ class IPCompleter(Completer):
         bare_text = text.lstrip(pre)
         global_matches = self.global_matches(bare_text)
         if not explicit_magic:
-            def matches(magic):
+            def matches(magic) -> tuple:
                 """
                 Filter magics, in particular remove magics that match
                 a name present in global namespace.
@@ -2900,7 +2900,7 @@ class IPCompleter(Completer):
         matches = self.python_func_kw_matches(context.token)
         return _convert_matcher_v1_result_to_v2_no_no(matches, type="param")
 
-    def python_func_kw_matches(self, text):
+    def python_func_kw_matches(self, text) -> list:
         """Match named parameters (kwargs) of the last open function.
 
         .. deprecated:: 8.6
@@ -3213,7 +3213,7 @@ class IPCompleter(Completer):
         result["do_not_suppress"] = {_get_matcher_id(self._jedi_matcher)}
         return result
 
-    def dispatch_custom_completer(self, text):
+    def dispatch_custom_completer(self, text) -> list:
         """
         .. deprecated:: 8.6
             You can use :meth:`custom_completer_matcher` instead.


### PR DESCRIPTION
## Summary
Added concrete return type annotations to functions in `IPython/core/completer.py` based on static analysis of return statements.

## Changes
- Add return type hint `-> list` to function
- Add return type hint `-> list` to function
- Add return type hint `-> tuple` to function
- Add return type hint `-> bool` to function
- Add return type hint `-> list` to function

## Type of Change
- [x] Code quality improvement (type hints)
- [ ] Bug fix
- [ ] New feature

## Motivation
These type annotations are inferred from actual return values in the function bodies (e.g. `return True` → `-> bool`, `return []` → `-> list`). They improve:
- **IDE autocompletion** and type checking (mypy/pyright)
- **Code readability** for contributors navigating the codebase
- **Bug prevention** via static analysis

No functional changes — only type annotations added.
