### PR TITLE
chore: add 2 return type hints in compilerop.py

### DIFF
--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -51,7 +51,7 @@ PyCF_MASK = functools.reduce(operator.or_,
 # Local utilities
 #-----------------------------------------------------------------------------
 
-def code_name(code, number=0):
+def code_name(code, number=0) -> str:
     """ Compute a (probably) unique name for code for caching.
 
     This now expects code to be unicode.
@@ -116,7 +116,7 @@ class CachingCompiler(codeop.Compile):
         """
         return code_name(transformed_code, number)
 
-    def format_code_name(self, name):
+    def format_code_name(self, name) -> str:
         """Return a user-friendly label and name for a code block.
 
         Parameters


### PR DESCRIPTION
## Summary
Added concrete return type annotations to functions in `IPython/core/compilerop.py` based on static analysis of return statements.

## Changes
- Add return type hint `-> str` to function
- Add return type hint `-> str` to function

## Type of Change
- [x] Code quality improvement (type hints)
- [ ] Bug fix
- [ ] New feature

## Motivation
These type annotations are inferred from actual return values in the function bodies (e.g. `return True` → `-> bool`, `return []` → `-> list`). They improve:
- **IDE autocompletion** and type checking (mypy/pyright)
- **Code readability** for contributors navigating the codebase
- **Bug prevention** via static analysis

No functional changes — only type annotations added.
