### PR TITLE
Fix expected length in test_unicode_range for Python 3.15 alpha 7

### DIFF
--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -127,7 +127,7 @@ def test_unicode_range():
     assert len_exp == len_test, message
 
     # fail if new unicode symbols have been added.
-    assert len_exp <= 153626, message
+    assert len_exp <= 159801, message
 
 
 @contextmanager


### PR DESCRIPTION
The range itself had been updated in 63476b2, but the test started to fail with the latest alpha 7 release of Python 3.15.