### PR TITLE
chore: add return type hint in alias.py

### DIFF
--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -219,7 +219,7 @@ class AliasManager(Configurable):
             self.soft_define_alias(name, cmd)
 
     @property
-    def aliases(self):
+    def aliases(self) -> list:
         return [(n, func.cmd) for (n, func) in self.linemagics.items()
                             if isinstance(func, Alias)]
 


### PR DESCRIPTION
## Summary
Added concrete return type annotations to functions in `IPython/core/alias.py` based on static analysis of return statements.

## Changes
- Add return type hint `-> list` to function

## Type of Change
- [x] Code quality improvement (type hints)
- [ ] Bug fix
- [ ] New feature

## Motivation
These type annotations are inferred from actual return values in the function bodies (e.g. `return True` → `-> bool`, `return []` → `-> list`). They improve:
- **IDE autocompletion** and type checking (mypy/pyright)
- **Code readability** for contributors navigating the codebase
- **Bug prevention** via static analysis

No functional changes — only type annotations added.
