### PR TITLE
Include function names when using the fast-traceback path

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -541,6 +541,8 @@ class VerboseTB(TBTools):
         args, varargs, varkw, locals_ = inspect.getargvalues(frame_info.frame)
         if frame_info.executing is not None:
             func = frame_info.executing.code_qualname()
+        elif frame_info.code is not None:
+            func = getattr(frame_info.code, "co_qualname", None) or frame_info.code.co_name
         else:
             func = "?"
         if func == "<module>":


### PR DESCRIPTION
Fixes first 1/2 of Quansight/deshaw#675