### PR TITLE
interleave fast path when rendering large tracebacks

### DIFF
--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -539,10 +539,13 @@ class VerboseTB(TBTools):
 
         assert isinstance(frame_info.lineno, int)
         args, varargs, varkw, locals_ = inspect.getargvalues(frame_info.frame)
+        func: str
         if frame_info.executing is not None:
             func = frame_info.executing.code_qualname()
         elif frame_info.code is not None:
-            func = getattr(frame_info.code, "co_qualname", None) or frame_info.code.co_name
+            func = (
+                getattr(frame_info.code, "co_qualname", None) or frame_info.code.co_name
+            )
         else:
             func = "?"
         if func == "<module>":
@@ -611,12 +614,14 @@ class VerboseTB(TBTools):
         if frame_info._sd is None:
             # fast fallback if file is too long
             assert frame_info.filename is not None
-            level_tokens = [
-                (Token.FilenameEm, util_path.compress_user(frame_info.filename)),
-                (Token, " "),
-                (Token, call),
-                (Token, "\n"),
-            ]
+            level_tokens = (
+                _tokens_filename(True, frame_info.filename, lineno=frame_info.lineno)
+                + [
+                    (Token, ", " if call else ""),
+                    (Token, call),
+                    (Token, "\n"),
+                ]
+            )
 
             _line_format = Parser(theme_name=self._theme_name).format2
             assert isinstance(frame_info.code, types.CodeType)
@@ -823,10 +828,9 @@ class VerboseTB(TBTools):
             pygments_formatter=formatter,
         )
 
-        # Let's estimate the amount of code we will have to parse/highlight.
+        # Collect traceback frames and their module sizes.
         cf: Optional[TracebackType] = etb
-        max_len = 0
-        tbs = []
+        tbs: list[tuple[TracebackType, int]] = []
         while cf is not None:
             try:
                 mod = inspect.getmodule(cf.tb_frame)
@@ -836,31 +840,32 @@ class VerboseTB(TBTools):
                     if root_name == "IPython":
                         cf = cf.tb_next
                         continue
-                max_len = get_line_number_of_frame(cf.tb_frame)
-
+                frame_len = get_line_number_of_frame(cf.tb_frame)
             except OSError:
-                max_len = 0
-            max_len = max(max_len, max_len)
-            tbs.append(cf)
-            cf = getattr(cf, "tb_next", None)
+                frame_len = 0
+            assert cf is not None  # narrowing for mypy; guarded by while condition
+            tbs.append((cf, frame_len))
+            cf = cf.tb_next
 
-        if max_len > FAST_THRESHOLD:
-            FIs: list[FrameInfo] = []
-            for tb in tbs:
+        # Process each frame individually: use stack_data for short modules,
+        # fall back to raw frames for long ones.
+        FIs: list[FrameInfo] = []
+        for tb, frame_len in tbs:
+            if frame_len > FAST_THRESHOLD:
                 frame = tb.tb_frame  # type: ignore[union-attr]
                 lineno = frame.f_lineno
                 code = frame.f_code
                 filename = code.co_filename
-                # TODO: Here we need to use before/after/
                 FIs.append(
                     FrameInfo(
                         "Raw frame", filename, lineno, frame, code, context=context
                     )
                 )
-            return FIs
-        res = list(stack_data.FrameInfo.stack_data(etb, options=options))[tb_offset:]
-        res2 = [FrameInfo._from_stack_data_FrameInfo(r) for r in res]
-        return res2
+            else:
+                sd_fi = next(stack_data.FrameInfo.stack_data(tb, options=options))
+                FIs.append(FrameInfo._from_stack_data_FrameInfo(sd_fi))
+
+        return FIs
 
     def structured_traceback(
         self,

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -841,8 +841,17 @@ class VerboseTB(TBTools):
                         cf = cf.tb_next
                         continue
                 frame_len = get_line_number_of_frame(cf.tb_frame)
+                if frame_len == 0:
+                    # File not found or not a .py file (e.g. <string> from
+                    # exec()).  Check if source is actually available; if not,
+                    # force the fast path so that FrameInfo's "Could not get
+                    # source" fallback is rendered.
+                    try:
+                        inspect.getsourcelines(cf.tb_frame)
+                    except OSError:
+                        frame_len = FAST_THRESHOLD + 1
             except OSError:
-                frame_len = 0
+                frame_len = FAST_THRESHOLD + 1
             assert cf is not None  # narrowing for mypy; guarded by while condition
             tbs.append((cf, frame_len))
             cf = cf.tb_next

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -847,10 +847,13 @@ class VerboseTB(TBTools):
             tbs.append((cf, frame_len))
             cf = cf.tb_next
 
-        # Process each frame individually: use stack_data for short modules,
-        # fall back to raw frames for long ones.
+        # Group consecutive frames by fast/slow and process each group.
+        # Consecutive slow frames must be processed together so that
+        # stack_data can detect RepeatedFrames (recursion collapsing).
         FIs: list[FrameInfo] = []
-        for tb, frame_len in tbs:
+        i = 0
+        while i < len(tbs):
+            tb, frame_len = tbs[i]
             if frame_len > FAST_THRESHOLD:
                 frame = tb.tb_frame  # type: ignore[union-attr]
                 lineno = frame.f_lineno
@@ -861,9 +864,23 @@ class VerboseTB(TBTools):
                         "Raw frame", filename, lineno, frame, code, context=context
                     )
                 )
+                i += 1
             else:
-                sd_fi = next(stack_data.FrameInfo.stack_data(tb, options=options))
-                FIs.append(FrameInfo._from_stack_data_FrameInfo(sd_fi))
+                # Collect the consecutive run of slow frames
+                group_start = i
+                while i < len(tbs) and tbs[i][1] <= FAST_THRESHOLD:
+                    i += 1
+                # Build set of frame objects in this group for filtering
+                group_frames = {tbs[j][0].tb_frame for j in range(group_start, i)}
+                # Process via stack_data starting from the first tb in the group
+                for sd_fi in stack_data.FrameInfo.stack_data(
+                    tbs[group_start][0], options=options
+                ):
+                    # stack_data follows tb_next through the full chain,
+                    # including IPython frames we skipped during collection.
+                    # Filter those out, but always keep RepeatedFrames.
+                    if isinstance(sd_fi, stack_data.RepeatedFrames) or sd_fi.frame in group_frames:
+                        FIs.append(FrameInfo._from_stack_data_FrameInfo(sd_fi))
 
         return FIs
 

--- a/tests/test_iplib.py
+++ b/tests/test_iplib.py
@@ -143,23 +143,19 @@ def doctest_tb_sysexit():
     In [22]: %tb
     ---------------------------------------------------------------------------
     SystemExit                                Traceback (most recent call last)
-    File ..., in execfile(fname, glob, loc, compiler)
-         ... with open(fname, "rb") as f:
-         ...     compiler = compiler or compile
-    ---> ...     exec(compiler(f.read(), fname, "exec"), glob, loc)
-    ...
-         34     except IndexError:
-         35         mode = "div"
-    ---> 37     bar(mode)
+    File ...:37
+         34 except IndexError:
+         35     mode = "div"
+    ---> 37 bar(mode)
     <BLANKLINE>
-    ...bar(mode)
-         24         except:
-         25             stat = 1
-    ---> 26         sysexit(stat, mode)
-         27     else:
-         28         raise ValueError("Unknown mode")
+    File ...:26, in bar(mode)
+         24     except:
+         25         stat = 1
+    ---> 26     sysexit(stat, mode)
+         27 else:
+         28     raise ValueError("Unknown mode")
     <BLANKLINE>
-    ...sysexit(stat, mode)
+    File ...:14, in sysexit(stat, mode)
          13 def sysexit(stat, mode):
     ---> 14     raise SystemExit(stat, f"Mode = {mode}")
     <BLANKLINE>

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1094,8 +1094,21 @@ def test_notebook_export_json_with_output():
             expected = expected_nb["cells"][i]
             assert expected["source"] == command
             assert actual["source"] == expected["source"]
-            assert (
-                actual["outputs"] == expected["outputs"]
+            _strip_ansi = re.compile(r"\x1b\[[0-9;]*m").sub
+
+            def strip_ansi_from_outputs(outputs):
+                result = []
+                for out in outputs:
+                    out = dict(out)
+                    if "traceback" in out:
+                        out["traceback"] = [
+                            _strip_ansi("", line) for line in out["traceback"]
+                        ]
+                    result.append(out)
+                return result
+
+            assert strip_ansi_from_outputs(actual["outputs"]) == strip_ansi_from_outputs(
+                expected["outputs"]
             ), f"Outputs do not match for cell {i+1} with source {command!r}"
     finally:
         _ip.colors = "nocolor"


### PR DESCRIPTION
This should preserve highlighting on function in small modules,

I'm not sure how much this affects performace as now we go from 1 call of stackdata, to potentially many calls.

Might close second 1/2 of https://github.com/Quansight/deshaw/issues/675