### PR TITLE
fix: only surface nested repr_mimebundle NotImplementedError

### DIFF
--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -281,7 +281,15 @@ def catch_format_error(method, self, *args, **kwargs):
     try:
         r = method(self, *args, **kwargs)
     except NotImplementedError:
-        # don't warn on NotImplementedErrors
+        if getattr(self, "catch_notimplemented", True):
+            # don't warn on NotImplementedErrors for repr methods that use it to opt out
+            return self._check_return(None, args[0])
+        exc_info = sys.exc_info()
+        ip = get_ipython()
+        if ip is not None:
+            ip.showtraceback(exc_info)
+        else:
+            traceback.print_exception(*exc_info)
         return self._check_return(None, args[0])
     except Exception:
         exc_info = sys.exc_info()
@@ -1002,6 +1010,7 @@ class MimeBundleFormatter(BaseFormatter):
     """
     print_method = ObjectName('_repr_mimebundle_')
     _return_type = dict
+    catch_notimplemented = False
 
     def _check_return(self, r, obj):
         r = super(MimeBundleFormatter, self)._check_return(r, obj)

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -275,29 +275,48 @@ def _safe_repr(obj):
 class FormatterWarning(UserWarning):
     """Warning class for errors in formatters"""
 
+
+def _traceback_depth(tb):
+    depth = 0
+    while tb is not None:
+        depth += 1
+        tb = tb.tb_next
+    return depth
+
+
+def _show_formatter_traceback(exc_info):
+    ip = get_ipython()
+    if ip is not None:
+        ip.showtraceback(exc_info)
+    else:
+        traceback.print_exception(*exc_info)
+
+
+def _should_suppress_notimplemented(formatter, exc_info):
+    if not getattr(formatter, "show_nested_notimplemented", False):
+        return True
+
+    _, _, tb = exc_info
+    # A deliberate formatter opt-out only passes through the decorator frame,
+    # the formatter __call__, and the repr method itself.
+    return _traceback_depth(tb) <= 3
+
+
 @decorator
 def catch_format_error(method, self, *args, **kwargs):
     """show traceback on failed format call"""
     try:
         r = method(self, *args, **kwargs)
     except NotImplementedError:
-        if getattr(self, "catch_notimplemented", True):
-            # don't warn on NotImplementedErrors for repr methods that use it to opt out
-            return self._check_return(None, args[0])
         exc_info = sys.exc_info()
-        ip = get_ipython()
-        if ip is not None:
-            ip.showtraceback(exc_info)
-        else:
-            traceback.print_exception(*exc_info)
+        if _should_suppress_notimplemented(self, exc_info):
+            # allow direct repr-method opt-outs to fall back silently
+            return self._check_return(None, args[0])
+        _show_formatter_traceback(exc_info)
         return self._check_return(None, args[0])
     except Exception:
         exc_info = sys.exc_info()
-        ip = get_ipython()
-        if ip is not None:
-            ip.showtraceback(exc_info)
-        else:
-            traceback.print_exception(*exc_info)
+        _show_formatter_traceback(exc_info)
         return self._check_return(None, args[0])
     return self._check_return(r, args[0])
 
@@ -1010,7 +1029,7 @@ class MimeBundleFormatter(BaseFormatter):
     """
     print_method = ObjectName('_repr_mimebundle_')
     _return_type = dict
-    catch_notimplemented = False
+    show_nested_notimplemented = True
 
     def _check_return(self, r, obj):
         r = super(MimeBundleFormatter, self)._check_return(r, obj)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -594,6 +594,23 @@ def test_repr_mime_failure():
     assert "text/plain" in d
 
 
+def test_repr_mime_notimplemented_shows_traceback():
+    class BadReprMime(object):
+        def _repr_mimebundle_(self, include=None, exclude=None):
+            raise NotImplementedError("This error is ignored")
+
+    f = get_ipython().display_formatter
+    obj = BadReprMime()
+
+    with capture_output() as captured:
+        d, md = f.format(obj)
+
+    assert "text/plain" in d
+    assert "Traceback" in captured.stdout
+    assert "NotImplementedError" in captured.stdout
+    assert "_repr_mimebundle_" in captured.stdout
+
+
 def test_custom_repr_namedtuple_partialmethod():
     from functools import partialmethod
     from typing import NamedTuple

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -594,10 +594,29 @@ def test_repr_mime_failure():
     assert "text/plain" in d
 
 
-def test_repr_mime_notimplemented_shows_traceback():
+def test_repr_mime_notimplemented_direct_optout():
     class BadReprMime(object):
         def _repr_mimebundle_(self, include=None, exclude=None):
             raise NotImplementedError("This error is ignored")
+
+    f = get_ipython().display_formatter
+    obj = BadReprMime()
+
+    with capture_output() as captured:
+        d, md = f.format(obj)
+
+    assert "text/plain" in d
+    assert "" == captured.stderr
+    assert "" == captured.stdout
+
+
+def test_repr_mime_nested_notimplemented_shows_traceback():
+    def helper():
+        raise NotImplementedError("This error is no longer ignored")
+
+    class BadReprMime(object):
+        def _repr_mimebundle_(self, include=None, exclude=None):
+            helper()
 
     f = get_ipython().display_formatter
     obj = BadReprMime()


### PR DESCRIPTION
Closes #15154

## Summary
- keep swallowing direct `NotImplementedError` opt-outs from repr methods so interactive fallbacks keep working
- surface nested `_repr_mimebundle_` `NotImplementedError`s from helper code instead of silently discarding them
- add regression tests covering both the direct opt-out path and the nested helper-error path

## Validation
- `source .venv/bin/activate && pytest tests/test_formatters.py -q`
