### PR TITLE
Restore Python 3.11 support with conditional imports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         deps: [test_extra]
         # Test all on ubuntu, test ends on macos
         include:
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.11"
             deps: test_extra
           # free threaded, not with all dependencies
           - os: ubuntu-latest
@@ -114,10 +114,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Set up uv with Python 3.12
+    - name: Set up uv with Python 3.11
       uses: astral-sh/setup-uv@v7
       with:
-        python-version: '3.12'
+        python-version: '3.11'
         enable-cache: true
         activate-environment: true
         prune-cache: false

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -27,11 +27,10 @@ import warnings
 #-----------------------------------------------------------------------------
 
 # Don't forget to also update setup.py when this changes!
-if sys.version_info < (3, 12):
+if sys.version_info < (3, 11):
     raise ImportError(
         """
-IPython 9.x supports Python 3.12 and above, following SPEC0
-IPython 8.31+ supports Python 3.11 and above, following SPEC0
+IPython 9.x supports Python 3.11 and above, following SPEC0
 IPython 8.19+ supports Python 3.10 and above, following SPEC0.
 IPython 8.13+ supports Python 3.9 and above, following NEP 29.
 When using Python 2.7, please install IPython 5.x LTS Long Term Support version.

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -243,7 +243,11 @@ import __main__
 
 from typing import cast
 
-from typing import TypedDict, NotRequired, Protocol, TypeAlias, TypeGuard
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict, Protocol
+    from typing import NotRequired, TypeAlias, TypeGuard
+else:
+    from typing import TypedDict, NotRequired, Protocol, TypeAlias, TypeGuard
 
 
 # skip module docstests

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -874,9 +874,9 @@ class Pdb(OldPdb):
             try:
                 x = eval(arg, {}, {})
                 if type(x) == type(()):
-                    first, last = x
-                    first = int(first)
-                    last = int(last)
+                    first, last = x  # type: ignore[misc]
+                    first = int(first)  # type: ignore[call-overload]
+                    last = int(last)  # type: ignore[call-overload]
                     if last < first:
                         # Assume it's a count
                         last = first + last

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -32,7 +32,10 @@ from IPython.utils.decorators import undoc
 import types
 from typing import Self, LiteralString, get_type_hints
 
-from typing import TypeAliasType
+if sys.version_info < (3, 12):
+    from typing_extensions import TypeAliasType
+else:
+    from typing import TypeAliasType
 
 
 @undoc

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -356,8 +356,24 @@ class MagicAssign(TokenTransformBase):
 class SystemAssign(TokenTransformBase):
     """Transformer for assignments from system commands (a = !foo)"""
     @classmethod
-    def find(cls, tokens_by_line):
-        """Find the first system assignment (a = !foo) in the cell."""
+    def find_pre_312(cls, tokens_by_line):
+        for line in tokens_by_line:
+            assign_ix = _find_assign_op(line)
+            if (assign_ix is not None) \
+                    and not line[assign_ix].line.strip().startswith('=') \
+                    and (len(line) >= assign_ix + 2) \
+                    and (line[assign_ix + 1].type == tokenize.ERRORTOKEN):
+                ix = assign_ix + 1
+
+                while ix < len(line) and line[ix].type == tokenize.ERRORTOKEN:
+                    if line[ix].string == '!':
+                        return cls(line[ix].start)
+                    elif not line[ix].string.isspace():
+                        break
+                    ix += 1
+
+    @classmethod
+    def find_post_312(cls, tokens_by_line):
         for line in tokens_by_line:
             assign_ix = _find_assign_op(line)
             if (
@@ -368,6 +384,13 @@ class SystemAssign(TokenTransformBase):
                 and (line[assign_ix + 1].string == "!")
             ):
                 return cls(line[assign_ix + 1].start)
+
+    @classmethod
+    def find(cls, tokens_by_line):
+        """Find the first system assignment (a = !foo) in the cell."""
+        if sys.version_info < (3, 12):
+            return cls.find_pre_312(tokens_by_line)
+        return cls.find_post_312(tokens_by_line)
 
     def transform(self, lines: List[str]):
         """Transform a system assignment found by the ``find()`` classmethod.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2140,7 +2140,8 @@ class InteractiveShell(SingletonConfigurable):
         sys.last_type = etype
         sys.last_value = value
         sys.last_traceback = tb
-        sys.last_exc = value
+        if sys.version_info >= (3, 12):
+            sys.last_exc = value
 
         return etype, value, tb
 

--- a/IPython/core/tips.py
+++ b/IPython/core/tips.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import sys
 from random import choice
 from typing import Any
 
@@ -105,6 +106,11 @@ else:
             "You can find how to type a Unicode symbol by back-completing it, eg `\\Ⅷ<tab>` will expand to `\\ROMAN NUMERAL EIGHT`.",
             "IPython supports combining unicode identifiers, eg F\\vec<tab> will become F⃗, useful for physics equations. Play with \\dot \\ddot and others.",
         ]
+    )
+
+if sys.version_info < (3, 12):
+    _tips["random"].append(
+        "IPython support for Python versions outside of SPEC-0 is funded by the D.E. Shaw group: https://deshaw.com"
     )
 
 # Check if argcomplete is installed and add tip

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -994,7 +994,11 @@ class VerboseTB(TBTools):
                 self.pdb.botframe = etb.tb_frame
                 # last_value should be deprecated, but last-exc sometimme not set
                 # please check why later and remove the getattr.
-                exc = getattr(sys, "last_exc", sys.last_value)
+                exc = (
+                    sys.last_value
+                    if sys.version_info < (3, 12)
+                    else getattr(sys, "last_exc", sys.last_value)
+                )  # type: ignore[attr-defined]
                 if exc:
                     self.pdb.interaction(None, exc)
                 else:

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,10 @@ IPython (Interactive Python) is a command shell for interactive computing in mul
 
 **Python Support**
 
-Starting after IPython 8.16, we progressively transition to `Spec-0000 <https://scientific-python.org/specs/spec-0000/>`_.
+Starting after IPython 8.16, we follow `SPEC-0 <https://scientific-python.org/specs/spec-0000/>`_
+for determining the minimum supported Python version. Python 3.11 support is
+additionally maintained thanks to funding from the
+`D. E. Shaw group <https://deshaw.com/>`_.
 
 IPython requires Python 3.11 or newer.
 

--- a/docs/source/whatsnew/version9.rst
+++ b/docs/source/whatsnew/version9.rst
@@ -2,6 +2,27 @@
  9.x Series
 ============
 
+.. _version 9.13:
+
+IPython 9.13
+============
+
+Python 3.11 Support Restored
+-----------------------------
+
+Python 3.11 support has been restored. While IPython follows `SPEC-0
+<https://scientific-python.org/specs/spec-0000/>`__ for determining the minimum
+supported Python version, continued Python 3.11 support is funded by the
+`D. E. Shaw group <https://deshaw.com/>`_.
+
+
+Thanks
+------
+
+Thanks as well to the `D. E. Shaw group <https://deshaw.com/>`_ for sponsoring
+work on IPython including extended Python 3.11 support.
+
+
 .. _version 9.12:
 
 IPython 9.12
@@ -103,12 +124,12 @@ helps with reproducible builds and packaging workflows that may capture this sta
 `jupyterlab/jupyterlab#18552 <https://github.com/jupyterlab/jupyterlab/issues/18552>`_).
 
 
-Python 3.11 Deprecation
-------------------------
+Python 3.11 Deprecation (Reverted in 9.13)
+--------------------------------------------
 
-IPython has begun the process of dropping support for Python 3.11. Users
-still running Python 3.11 should plan to upgrade to a supported Python
-version.
+The deprecation of Python 3.11 announced in 9.11 has been reverted in 9.13.
+Python 3.11 support is maintained thanks to funding from the
+`D. E. Shaw group <https://deshaw.com/>`_.
 
 
 Autoreload Encoding Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 license = "BSD-3-Clause"
 license-files = ["LICENSE", "COPYING.rst"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     'colorama>=0.4.4; sys_platform == "win32"',
     "decorator>=5.1.0",
@@ -33,6 +33,7 @@ dependencies = [
     "pygments>=2.14.0", # wheel
     "stack_data>=0.6.0",
     "traitlets>=5.13.0",
+    "typing_extensions>=4.6; python_version<'3.12'",
 ]
 dynamic = ["authors", "version"]
 
@@ -97,7 +98,7 @@ all = [
 
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.11"
 ignore_missing_imports = true
 follow_imports = 'silent'
 exclude = [
@@ -123,6 +124,10 @@ disallow_incomplete_defs = true
 disallow_untyped_defs = true
 warn_redundant_casts = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+
+[[tool.mypy.overrides]]
+module = "sphinx.*"
+follow_imports = "skip"
 #warn_unreachable = true
 #strict = true
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,40 @@ requires utilities which are not available under Windows."""
 import os
 import sys
 
+# **Python version check**
+#
+# This check is also made in IPython/__init__, don't forget to update both when
+# changing Python version requirements.
+if sys.version_info < (3, 11):
+    pip_message = 'This may be due to an out of date pip. Make sure you have pip >= 9.0.1.'
+    try:
+        import pip
+        pip_version = tuple([int(x) for x in pip.__version__.split('.')[:3]])
+        if pip_version < (9, 0, 1) :
+            pip_message = 'Your pip version is out of date, please install pip >= 9.0.1. '\
+            'pip {} detected.'.format(pip.__version__)
+        else:
+            # pip is new enough - it must be something else
+            pip_message = ''
+    except Exception:
+        pass
+
+
+    error = """
+IPython 9.x supports Python 3.11 and above, following SPEC0
+IPython 8.19+ supports Python 3.10 and above, following SPEC0
+IPython 8.13+ supports Python 3.9 and above, following NEP 29.
+IPython 8.0-8.12 supports Python 3.8 and above, following NEP 29.
+
+Python {py} detected.
+{pip}
+""".format(
+        py=sys.version_info, pip=pip_message
+    )
+
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
 # At least we're on the python version we need, move on.
 
 from setuptools import setup

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -32,7 +32,10 @@ from IPython.core.guarded_eval import _is_type_annotation
 
 from typing import Self, LiteralString
 
-from typing import TypeAliasType
+if sys.version_info < (3, 12):
+    from typing_extensions import TypeAliasType
+else:
+    from typing import TypeAliasType
 
 
 def create_context(evaluation: str, **kwargs):

--- a/tests/test_zzz_autoreload.py
+++ b/tests/test_zzz_autoreload.py
@@ -396,6 +396,8 @@ class TestAutoreload(Fixture):
         self.shell.run_code("assert func2() == 'changed'")
         self.shell.run_code("t = Test(); assert t.new_func() == 'changed'")
         self.shell.run_code("assert number == 1")
+        if sys.version_info < (3, 12):
+            self.shell.run_code("assert TestEnum.B.value == 'added'")
 
         # ----------- TEST IMPORT FROM MODULE --------------------------
 


### PR DESCRIPTION
## Summary
This PR restores Python 3.11 support to IPython 9.x, reverting the previous deprecation. Python 3.11 continues to be supported thanks to funding from the D. E. Shaw group.

## Key Changes

- **Minimum Python version**: Updated from 3.12 to 3.11 across all configuration files (setup.py, pyproject.toml, IPython/__init__.py)
- **Conditional imports**: Added version checks for typing features that differ between Python 3.11 and 3.12:
  - `TypedDict` and `Protocol` imported from `typing_extensions` on Python < 3.12
  - `TypeAliasType` imported from `typing_extensions` on Python < 3.12
- **System attribute handling**: Added conditional logic for `sys.last_exc` which only exists in Python 3.12+
- **Tokenizer compatibility**: Split `SystemAssign.find()` into `find_pre_312()` and `find_post_312()` methods to handle differences in Python's tokenizer between versions
- **Test coverage**: Restored Python 3.11 to CI/CD matrix and added version-specific test conditions
- **Documentation**: Updated whatsnew documentation to reflect Python 3.11 support restoration and added acknowledgment of D. E. Shaw group sponsorship
- **Dependencies**: Added `typing_extensions>=4.6` as a conditional dependency for Python < 3.12

## Implementation Details

The changes maintain backward compatibility with Python 3.11 while preserving support for newer versions. Version checks are performed at import time where necessary, and runtime checks are used for features like `sys.last_exc` that may not exist in earlier versions. The tokenizer changes account for differences in how Python 3.11 and 3.12+ handle error tokens in system command assignments.
