### PR TITLE
DOC: Copyedit `prompt_line_number_format` description

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -741,8 +741,8 @@ class TerminalInteractiveShell(InteractiveShell):
 
     prompt_line_number_format = Unicode(
         "",
-        help="The format for line numbering. Will be passed `line` (int, 1 based),"
-        " which is the current line number, and `rel_line`, which is the relative line number."
+        help="The format for line numbering. Will be passed the current line number"
+        " `line` (int, 1 based), and the relative line number `rel_line`."
         " For example to display both, you can use the following template string:"
         " `c.TerminalInteractiveShell.prompt_line_number_format = '{line: 4d}/{rel_line:+03d} | '`"
         " This will display the current line number, with a leading space and a width of at least 4"

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -741,13 +741,13 @@ class TerminalInteractiveShell(InteractiveShell):
 
     prompt_line_number_format = Unicode(
         "",
-        help="The format for line numbering, will be passed `line` (int, 1 based)"
-        " the current line number and `rel_line` the relative line number."
-        " for example to display both you can use the following template string :"
-        " c.TerminalInteractiveShell.prompt_line_number_format='{line: 4d}/{rel_line:+03d} | '"
-        " This will display the current line number, with leading space and a width of at least 4"
-        " character, as well as the relative line number 0 padded and always with a + or - sign."
-        " Note that when using Emacs mode the prompt of the first line may not update.",
+        help="The format for line numbering. Will be passed `line` (int, 1 based),"
+        " which is the current line number, and `rel_line`, which is the relative line number."
+        " For example to display both, you can use the following template string:"
+        " `c.TerminalInteractiveShell.prompt_line_number_format = '{line: 4d}/{rel_line:+03d} | '`"
+        " This will display the current line number, with a leading space and a width of at least 4"
+        " characters, as well as the relative line number, 0-padded and always with a + or - sign."
+        " Note that when using Emacs mode, the prompt of the first line may not update.",
     ).tag(config=True)
 
     @observe('term_title')


### PR DESCRIPTION
Grammar, clarity, code formatting.

I wanted to format the code as a code block, but I'm not sure how to do that in RST, so I used inline code formatting for the meantime.