### PR TITLE
Clarify custom prompts example

### DIFF
--- a/docs/source/config/details.rst
+++ b/docs/source/config/details.rst
@@ -166,7 +166,8 @@ in the input prompt:
 
 .. code-block:: python
 
-    from IPython.terminal.prompts import Prompts, Token
+    from IPython.terminal.prompts import Prompts
+    from pygments.token import Token
     import os
 
     class MyPrompt(Prompts):


### PR DESCRIPTION
Import `Token` directly from `pygments.token` instead of using the middleman `IPython.terminal.prompts`.
This is mainly because `Token` is not documented at [`IPython.terminal.prompts`](https://ipython.readthedocs.io/en/latest/api/generated/IPython.terminal.prompts.html).