### PR TITLE
Fix typos: 'occured' -> 'occurred', 'wether' -> 'whether'

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1389,7 +1389,7 @@ class ExecutionMagics(Magics):
         wall_st = wtime()
         # Track whether to propagate exceptions or exit
         exit_on_interrupt = False
-        interrupt_occured = False
+        interrupt_occurred = False
         captured_exception = None
 
         if mode == "eval":
@@ -1398,11 +1398,11 @@ class ExecutionMagics(Magics):
                 out = eval(code, glob, local_ns)
             except KeyboardInterrupt as e:
                 captured_exception = e
-                interrupt_occured = True
+                interrupt_occurred = True
                 exit_on_interrupt = True
             except Exception as e:
                 captured_exception = e
-                interrupt_occured = True
+                interrupt_occurred = True
                 if not args.no_raise_error:
                     exit_on_interrupt = True
             end = clock2()
@@ -1417,11 +1417,11 @@ class ExecutionMagics(Magics):
                     out = eval(code_2, glob, local_ns)
             except KeyboardInterrupt as e:
                 captured_exception = e
-                interrupt_occured = True
+                interrupt_occurred = True
                 exit_on_interrupt = True
             except Exception as e:
                 captured_exception = e
-                interrupt_occured = True
+                interrupt_occurred = True
                 if not args.no_raise_error:
                     exit_on_interrupt = True
             end = clock2()
@@ -1443,7 +1443,7 @@ class ExecutionMagics(Magics):
             print(f"Compiler : {_format_time(tc)}")
         if tp > tp_min:
             print(f"Parser   : {_format_time(tp)}")
-        if interrupt_occured:
+        if interrupt_occurred:
             if exit_on_interrupt and captured_exception:
                 raise captured_exception
             return

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -177,7 +177,7 @@ def _tokens_filename(
 
     Parameters
     ----------
-    em: wether bold or not
+    em: whether bold or not
     file : str
     """
     Normal = Token.NormalEm if em else Token.Normal


### PR DESCRIPTION

**Repo:** ipython/ipython (⭐ 16000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +7/-7

## What
Corrects two recurring spelling mistakes in the IPython source: the local
variable `interrupt_occured` in `IPython/core/magics/execution.py` (used by
the `%time`/`%%time` magic) is renamed to the correctly-spelled
`interrupt_occurred`, and the docstring for `_format_filename` in
`IPython/core/tbtools.py` is updated from "wether bold or not" to
"whether bold or not".

## Why
These are pure typo fixes that improve code readability and the quality of
user-facing docstrings. `occured` is a common misspelling that, while
hidden in a local variable today, may be referenced or grepped against in
the future; cleaning it up before it spreads keeps the codebase tidy. The
docstring fix improves rendered API documentation.

## Testing
The change is a pure rename of a local variable confined to one method
plus a docstring word change — no behavior change. `python -m py_compile`
on the two touched files succeeds. The existing test suite for the
`%time` magic exercises the renamed variable's code path.

## Risk
Low — local variable rename + docstring spelling fix, no public API impact.
