### PR TITLE
avoid psutil requirement on emscripten

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "matplotlib-inline>=0.1.6",
     'pexpect>4.6; sys_platform != "win32" and sys_platform != "emscripten"',
     "prompt_toolkit>=3.0.41,<3.1.0",
-    "psutil>=7",
+    'psutil>=7; sys_platform != "emscripten"',
     "pygments>=2.14.0", # wheel
     "stack_data>=0.6.0",
     "traitlets>=5.13.0",


### PR DESCRIPTION
Congratulations on 9.13. :tada: 

This builds on #15184 by adding an environment marker to the hard `psutil` dependency for  emscripten environments. To my knowledge, no current approach offers processes.