### PR TITLE
Strip ANSI escape sequences from Sphinx directive output

### DIFF
--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -220,6 +220,7 @@ except Exception:
 #-----------------------------------------------------------------------------
 # for tokenizing blocks
 COMMENT, INPUT, OUTPUT =  range(3)
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 PSEUDO_DECORATORS = ["suppress", "verbatim", "savefig", "doctest"]
 
@@ -513,7 +514,7 @@ class EmbeddedSphinxShell:
 
         # Fetch the processed output. (This is not the submitted output.)
         self.cout.seek(0)
-        processed_output = self.cout.read()
+        processed_output = _ANSI_RE.sub("", self.cout.read())
         if not is_suppress and not is_semicolon:
             #
             # In IPythonDirective.run, the elements of `ret` are eventually

--- a/IPython/sphinxext/tests/test_ansi_stripping.py
+++ b/IPython/sphinxext/tests/test_ansi_stripping.py
@@ -1,0 +1,28 @@
+"""Test that ANSI escape sequences are stripped from directive output."""
+
+import re
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def test_strip_ansi_basic():
+    """ANSI color codes should be removed from output."""
+    raw = "\x1b[31mred text\x1b[0m"
+    assert _ANSI_RE.sub("", raw) == "red text"
+
+
+def test_strip_ansi_multiple_codes():
+    """Multiple ANSI codes in a single string should all be removed."""
+    raw = "\x1b[1m\x1b[32mbold green\x1b[0m normal \x1b[4munderline\x1b[0m"
+    assert _ANSI_RE.sub("", raw) == "bold green normal underline"
+
+
+def test_strip_ansi_no_codes():
+    """Strings without ANSI codes should pass through unchanged."""
+    raw = "plain output"
+    assert _ANSI_RE.sub("", raw) == "plain output"
+
+
+def test_strip_ansi_empty():
+    """Empty strings should remain empty."""
+    assert _ANSI_RE.sub("", "") == ""


### PR DESCRIPTION
Fixes #11424

The IPython Sphinx directive can produce output containing raw ANSI escape
sequences (e.g. color codes from tracebacks), which render as garbled text
in HTML/PDF docs. This PR strips those escape codes from processed_output
in EmbeddedSphinxShell.process_input using a compiled regex before the
output reaches the final rendered documentation.

Changes:
- Added _ANSI_RE regex pattern to strip ANSI escape sequences
- Applied stripping to self.cout.read() output in process_input
- Added unit tests for ANSI stripping behavior