### PR TITLE
Update _tokens_filename with the option to not compress user path

### DIFF
--- a/IPython/core/doctb.py
+++ b/IPython/core/doctb.py
@@ -223,7 +223,12 @@ class DocTB(TBTools):
 
         assert frame_info._sd is not None
         result = theme_table[self._theme_name].format(
-            _tokens_filename(True, frame_info.filename, lineno=frame_info.lineno)
+            _tokens_filename(
+                True,
+                frame_info.filename,
+                lineno=frame_info.lineno,
+                compress_user=True,
+            )
         )
         result += ", " if call else ""
         result += f"{call}\n"

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -171,6 +171,7 @@ def _tokens_filename(
     file: str | None,
     *,
     lineno: int | None = None,
+    compress_user: bool = True,
 ) -> TokenStream:
     """
     Format filename lines with custom formatting from caching compiler or `File *.py` by default
@@ -179,6 +180,8 @@ def _tokens_filename(
     ----------
     em: wether bold or not
     file : str
+    compress_user : bool
+        When True (default), apply ``util_path.compress_user`` to the filename.
     """
     Normal = Token.NormalEm if em else Token.Normal
     Filename = Token.FilenameEm if em else Token.Filename
@@ -202,9 +205,9 @@ def _tokens_filename(
                 (Filename, f", line {lineno}"),
             ]
     else:
-        name = util_path.compress_user(
-            py3compat.cast_unicode(file or "", util_path.fs_encoding)
-        )
+        name = py3compat.cast_unicode(file or "", util_path.fs_encoding)
+        if compress_user:
+            name = util_path.compress_user(name)
         if lineno is None:
             return [
                 (Normal, "File "),

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -260,7 +260,7 @@ class ListTB(TBTools):
 
             item = theme_table[self._theme_name].format(
                 [(Token.NormalEm if em else Token.Normal, "  ")]
-                + _tokens_filename(em, filename, lineno=lineno)
+                + _tokens_filename(em, filename, lineno=lineno, compress_user=True)
             )
 
             # This seem to be only in xmode plain (%run sinpleer), investigate why not share with verbose.
@@ -332,6 +332,7 @@ class ListTB(TBTools):
                             True,
                             value.filename,
                             lineno=(None if lineno == "unknown" else lineno),
+                            compress_user=True,
                         )
                         + [(Token, "\n")]
                     )
@@ -615,7 +616,12 @@ class VerboseTB(TBTools):
             # fast fallback if file is too long
             assert frame_info.filename is not None
             level_tokens = (
-                _tokens_filename(True, frame_info.filename, lineno=frame_info.lineno)
+                _tokens_filename(
+                    True,
+                    frame_info.filename,
+                    lineno=frame_info.lineno,
+                    compress_user=True,
+                )
                 + [
                     (Token, ", " if call else ""),
                     (Token, call),
@@ -658,7 +664,12 @@ class VerboseTB(TBTools):
             return theme_table[self._theme_name].format(level_tokens + tb_tokens)
         else:
             result = theme_table[self._theme_name].format(
-                _tokens_filename(True, frame_info.filename, lineno=frame_info.lineno)
+                _tokens_filename(
+                    True,
+                    frame_info.filename,
+                    lineno=frame_info.lineno,
+                    compress_user=True,
+                )
             )
             result += ", " if call else ""
             result += f"{call}\n"


### PR DESCRIPTION
This can be desirable in some case,
in particular in complex deployment where the filesystem of the server and the kernel don't match to be able to open the file path from the UI.

This will later be extended with global IPython configuration options, maybe at runtime.

See Quansight/deshaw#259