### PR TITLE
Update _tokens_filename to never compress user path.

### DIFF
--- a/IPython/core/doctb.py
+++ b/IPython/core/doctb.py
@@ -10,6 +10,7 @@ import stack_data
 from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.token import Token
 
+from IPython.utils import path as util_path
 from IPython.utils.PyColorize import Theme, TokenStream, theme_table
 from IPython.utils.terminal import get_terminal_size
 
@@ -223,7 +224,11 @@ class DocTB(TBTools):
 
         assert frame_info._sd is not None
         result = theme_table[self._theme_name].format(
-            _tokens_filename(True, frame_info.filename, lineno=frame_info.lineno)
+            _tokens_filename(
+                True,
+                util_path.compress_user(frame_info.filename),
+                lineno=frame_info.lineno,
+            )
         )
         result += ", " if call else ""
         result += f"{call}\n"

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -202,9 +202,7 @@ def _tokens_filename(
                 (Filename, f", line {lineno}"),
             ]
     else:
-        name = util_path.compress_user(
-            py3compat.cast_unicode(file or "", util_path.fs_encoding)
-        )
+        name = py3compat.cast_unicode(file or "", util_path.fs_encoding)
         if lineno is None:
             return [
                 (Normal, "File "),

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -260,7 +260,9 @@ class ListTB(TBTools):
 
             item = theme_table[self._theme_name].format(
                 [(Token.NormalEm if em else Token.Normal, "  ")]
-                + _tokens_filename(em, filename, lineno=lineno)
+                + _tokens_filename(
+                    em, util_path.compress_user(filename or ""), lineno=lineno
+                )
             )
 
             # This seem to be only in xmode plain (%run sinpleer), investigate why not share with verbose.
@@ -330,7 +332,7 @@ class ListTB(TBTools):
                         [(Token, "  ")]
                         + _tokens_filename(
                             True,
-                            value.filename,
+                            util_path.compress_user(value.filename),
                             lineno=(None if lineno == "unknown" else lineno),
                         )
                         + [(Token, "\n")]
@@ -615,7 +617,11 @@ class VerboseTB(TBTools):
             # fast fallback if file is too long
             assert frame_info.filename is not None
             level_tokens = (
-                _tokens_filename(True, frame_info.filename, lineno=frame_info.lineno)
+                _tokens_filename(
+                    True,
+                    util_path.compress_user(frame_info.filename),
+                    lineno=frame_info.lineno,
+                )
                 + [
                     (Token, ", " if call else ""),
                     (Token, call),
@@ -658,7 +664,11 @@ class VerboseTB(TBTools):
             return theme_table[self._theme_name].format(level_tokens + tb_tokens)
         else:
             result = theme_table[self._theme_name].format(
-                _tokens_filename(True, frame_info.filename, lineno=frame_info.lineno)
+                _tokens_filename(
+                    True,
+                    util_path.compress_user(frame_info.filename),
+                    lineno=frame_info.lineno,
+                )
             )
             result += ", " if call else ""
             result += f"{call}\n"


### PR DESCRIPTION
Make it caller responsibility.

This can be desirable in some case to not compress, in particular in compex deployment where the filesystem of the server and the kernel don't match to be able to open the file path from the UI.

This will later be extended with global IPython configuration options, maybe at runtime.

Alternative to #15194

See Quansight/deshaw#259