### PR TITLE
Handle stdout without isatty in kitty check

### DIFF
--- a/IPython/core/kitty.py
+++ b/IPython/core/kitty.py
@@ -10,7 +10,8 @@ def _supports_kitty_graphics() -> bool:
     if platform.system() not in ("Darwin", "Linux"):
         return False
 
-    if not sys.stdout.isatty():
+    isatty = getattr(sys.stdout, "isatty", None)
+    if not callable(isatty) or not isatty():
         return False
     # Hardcoding process names instead of using
     # https://sw.kovidgoyal.net/kitty/graphics-protocol/#querying-support-and-available-transmission-mediums

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -1,0 +1,50 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+class DummyStdout:
+    def write(self, *args, **kwargs):
+        pass
+
+    def flush(self):
+        pass
+
+
+class StdoutWithNonCallableIsatty(DummyStdout):
+    isatty = False
+
+
+def test_supports_kitty_graphics_handles_stdout_without_callable_isatty(monkeypatch):
+    import platform
+
+    from IPython.core import kitty
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    for stdout in (DummyStdout(), StdoutWithNonCallableIsatty()):
+        monkeypatch.setattr(sys, "stdout", stdout)
+        assert kitty._supports_kitty_graphics() is False
+
+
+def test_import_ipython_handles_stdout_without_isatty():
+    code = """
+import sys
+
+class DummyFile:
+    def write(self, *args, **kwargs):
+        pass
+
+    def flush(self):
+        pass
+
+sys.stdout = DummyFile()
+import IPython
+"""
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Guard kitty graphics detection when `sys.stdout` lacks a callable `isatty`.
- Add regression coverage for importing IPython with a Sphinx-like dummy stdout.

Fixes #15191

## Testing
- `pytest tests/test_kitty.py`
- `pytest tests/test_kitty.py tests/test_imports.py`
- `python - <<'PY' ...` dummy-stdout import check
