### PR TITLE
tests: replace wall-clock stream-perf assertion with scaling ratio

### DIFF
--- a/tests/test_interactiveshell.py
+++ b/tests/test_interactiveshell.py
@@ -50,16 +50,46 @@ class DerivedInterrupt(KeyboardInterrupt):
     pass
 
 
-def test_stream_performance(capsys) -> None:
-    """It should be fast to execute."""
-    src = "for i in range(250_000): print(i)"
-    start = time.perf_counter()
-    ip.run_cell(src)
-    end = time.perf_counter()
-    # We try to read as otherwise on failure, pytest will print the 250k lines to stdout.
-    capsys.readouterr()
-    duration = end - start
-    assert duration < 10
+def test_stream_scales_linearly(capsys) -> None:
+    """Output streaming must scale ~linearly, not O(n²).
+
+    Regression test for #14937: in v9.1.0, ``for i in range(N): print(i)``
+    became ~50x slower because the displayhook accumulated stream output
+    via repeated ``str += data`` (re-allocating the entire string on every
+    print). Fixed in #14941 by switching the bundle to a list and using
+    ``.append``, which is O(1) amortised.
+
+    Rather than asserting an absolute wall-clock budget (which depends on
+    the reviewer's machine and flakes on shared CI / distro build hosts),
+    this measures the timing ratio between two sample sizes that differ
+    by 10x. For O(n) behaviour the time ratio should be ~10; for an O(n²)
+    regression the same input increase produces ~100x time. The empirical
+    measurements on this code path:
+
+      - With the fix in place: ratio is ~5–12 across noisy trials
+      - With the regression reverted: ratio is ~40
+
+    A threshold of 25 catches the regression (40 > 25) with comfortable
+    margin against post-fix noise (worst observed: 12), independent of
+    machine speed.
+    """
+    timings = {}
+    for n in (10_000, 100_000):
+        src = f"for i in range({n}): print(i)"
+        start = time.perf_counter()
+        ip.run_cell(src)
+        # Drain capsys so a failure here doesn't spam pytest output.
+        capsys.readouterr()
+        timings[n] = time.perf_counter() - start
+
+    small, big = timings[10_000], timings[100_000]
+    # Guard against divide-by-zero on absurdly fast machines.
+    ratio = big / max(small, 1e-6)
+    assert ratio < 25, (
+        f"O(n²)-like scaling detected: {small=:.3f}s, {big=:.3f}s, "
+        f"ratio={ratio:.1f} (expected ~10 for linear, ~100 for quadratic — "
+        f"see #14937)"
+    )
 
 
 class InteractiveShellTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

`tests/test_interactiveshell.py::test_stream_performance` (added in #14941 alongside the fix for #14937) asserts a 10-second wall-clock budget for printing 250k lines:

```python
def test_stream_performance(capsys) -> None:
    """It should be fast to execute."""
    src = "for i in range(250_000): print(i)"
    start = time.perf_counter()
    ip.run_cell(src)
    end = time.perf_counter()
    capsys.readouterr()
    assert end - start < 10
```

This passes on developer machines (~6.7s on an M1-class laptop) but flakes hard on shared CI / distro build hosts where 250k prints under load takes 25–30 seconds. It's currently a hard build failure for `ipython 9.5.0` in nixpkgs:

```
assert 29.643374418010353 < 10
```

The original intent — defending against the O(n²) regression in #14937 — is sound. The wall-clock proxy is the problem: it conflates machine speed with algorithmic complexity. Anyone reproducing the bug on a Raspberry Pi or a busy CI runner sees the test fail without there being any actual regression.

## Fix

Replace the wall-clock budget with a **scaling ratio** test: run the same workload at two input sizes (10k and 100k) and assert that 10× the work takes less than 25× the time.

For O(n) behaviour, the ratio should be ~10. For an O(n²) regression, the ratio is ~100. A threshold of 25 splits the difference cleanly and is independent of host speed.

## Empirical numbers

Measured on this branch:

| State                              | small (10k) | big (100k) | ratio    |
|------------------------------------|-------------|------------|----------|
| Post-fix (current `main`)          | 0.14–0.31s  | 1.18–2.67s | 4.7–11.7 |
| Regression reverted in `interactiveshell.py` | 0.36s | 14.57s | **39.9** |

Threshold of 25 sits comfortably between worst-case post-fix noise (11.7) and the regression signal (39.9).

## Validation

- [x] 5/5 sequential runs pass on idle host (post-fix code)
- [x] 5/5 sequential runs pass under 8 × `yes > /dev/null` CPU saturation
- [x] 3/3 sequential runs **fail** when the fix in `IPython/core/interactiveshell.py` is locally reverted (`bundle["stream"] = ""` + `+= data`)
- [x] Total test runtime drops from ~6.7s to ~3s as a side effect (smaller sample sizes)

## Notes

- Renamed `test_stream_performance` → `test_stream_scales_linearly` because that more accurately describes the asserted property. If you'd prefer to keep the old name for grep/release-notes continuity, happy to rename in a follow-up.
- Docstring includes the empirical numbers and a pointer back to #14937 / #14941 so the next person to touch this knows what threshold-tweak risks they're taking.

## Test plan

- [x] Local repro of the failure (regression reverted) — fails consistently
- [x] Local validation of the fix (regression restored) — passes consistently, idle and under load
- [ ] CI matrix on this PR