### PR TITLE
Fix history memory fallback after SQLite lock

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -696,7 +696,7 @@ class HistoryManager(HistoryAccessor):
                 self.hist_file,
                 exc_info=True,
             )
-            self.hist_file = ":memory:"
+            self._switch_to_memory_history()
 
         self.using_thread = False
         if self.enabled and self.hist_file != ":memory:":
@@ -708,7 +708,8 @@ class HistoryManager(HistoryAccessor):
                     "Failed to start history saving thread. History will not be saved.",
                     exc_info=True,
                 )
-                self.hist_file = ":memory:"
+                self._switch_to_memory_history()
+                self.save_thread = None
             else:
                 self.using_thread = True
         self._instances.add(self)
@@ -716,6 +717,16 @@ class HistoryManager(HistoryAccessor):
             len(HistoryManager._instances),
             HistoryManager._max_inst,
         )
+
+    def _switch_to_memory_history(self) -> None:
+        """Switch history storage to an in-memory SQLite database."""
+        try:
+            self.db.close()
+        except Exception:
+            pass
+        self.hist_file = ":memory:"
+        self.init_db()
+        self.new_session()
 
     def __del__(self) -> None:
         if self.save_thread is not None:
@@ -1176,7 +1187,7 @@ class HistorySavingThread(threading.Thread):
 
         self.save_flag.set()
         self._stopped = True
-        if self != threading.current_thread():
+        if self.ident is not None and self != threading.current_thread():
             self.join()
 
     def __del__(self) -> None:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -8,6 +8,7 @@
 import io
 import gc
 import os
+import sqlite3
 import sys
 import tempfile
 from datetime import datetime
@@ -272,6 +273,72 @@ def test_hist_file_config(hmmax3):
             # delete it.  I have no clue why
             pass
             HistoryManager.__max_inst = 1
+
+
+def test_histmanager_memory_fallback_reopens_db(hmmax3, tmp_path, caplog):
+    hist_file = tmp_path / "history.sqlite"
+    ip = get_ipython()
+    hm1 = None
+    hm2 = None
+    lock = None
+    try:
+        hm1 = HistoryManager(shell=ip, hist_file=hist_file)
+        hm1.end_session()
+        hm1.save_thread.stop()
+        hm1.db.close()
+
+        lock = sqlite3.connect(hist_file)
+        lock.execute("BEGIN IMMEDIATE")
+
+        hm2 = HistoryManager(shell=ip, hist_file=hist_file)
+        assert hm2.hist_file == ":memory:"
+        assert hm2.db.execute("PRAGMA database_list").fetchall() == [(0, "main", "")]
+
+        hm2.store_inputs(1, "a = 1")
+        hm2.writeout_cache()
+        assert list(hm2.get_tail(1, include_latest=True)) == [
+            (hm2.session_number, 1, "a = 1")
+        ]
+    finally:
+        if hm2 is not None:
+            hm2.end_session()
+            hm2.db.close()
+        if lock is not None:
+            lock.rollback()
+            lock.close()
+        hm1 = None
+        hm2 = None
+        caplog.clear()
+        gc.collect()
+
+
+def test_histmanager_thread_start_failure_uses_memory(
+    hmmax2, tmp_path, monkeypatch, caplog
+):
+    def fail_start(self):
+        raise RuntimeError("thread unavailable")
+
+    monkeypatch.setattr("IPython.core.history.HistorySavingThread.start", fail_start)
+
+    hm = None
+    try:
+        hm = HistoryManager(shell=get_ipython(), hist_file=tmp_path / "history.sqlite")
+        assert hm.hist_file == ":memory:"
+        assert hm.db.execute("PRAGMA database_list").fetchall() == [(0, "main", "")]
+        assert hm.save_thread is None
+
+        hm.store_inputs(1, "a = 1")
+        hm.writeout_cache()
+        assert list(hm.get_tail(1, include_latest=True)) == [
+            (hm.session_number, 1, "a = 1")
+        ]
+    finally:
+        if hm is not None:
+            hm.end_session()
+            hm.db.close()
+        hm = None
+        caplog.clear()
+        gc.collect()
 
 
 def test_histmanager_disabled(hmmax2):


### PR DESCRIPTION
## Summary

Fix `HistoryManager`'s fallback to `:memory:` when file-backed SQLite history cannot create a new session.

Previously, the fallback only changed `hist_file` to `:memory:`. The existing `self.db` connection still pointed at the locked on-disk `history.sqlite`, so later history writes could continue to raise `sqlite3.OperationalError: database is locked`.

This patch adds a helper that closes the current DB connection, switches `hist_file` to `:memory:`, initializes a new in-memory SQLite DB, and creates a new history session there.

## Motivation

This came up via SageMath when one Sage/IPython session is busy and a second one starts against the same IPython profile. The second session can fail to create a history session due to a locked SQLite file, then prompt_toolkit later tries to load/write history and hits an unhandled event-loop exception.

Fix https://github.com/sagemath/sage/issues/42144

## Tests

Ran:

```bash
python -m pytest -c /dev/null tests/test_history.py::test_histmanager_memory_fallback_reopens_db -q
```

Also reproduced the Sage-style terminal path with a held `history.sqlite` write lock and confirmed the patched IPython no longer emits the later `Failed to open SQLite history` or unhandled event-loop exception.
