### PR TITLE
Accept singular pdb exception command

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -515,6 +515,12 @@ class Pdb(OldPdb):
                 else:
                     self.error("No exception with that number")
 
+        def do_exception(self, arg):
+            """exception [number]
+            Alias for the ``exceptions`` command.
+            """
+            return self.do_exceptions(arg)
+
     def interaction(self, frame, tb_or_exc):
         try:
             if CHAIN_EXCEPTIONS:

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -279,6 +279,19 @@ def test_interruptible_core_debugger():
         sys.settrace(tracer_orig)
 
 
+@pytest.mark.skipif(
+    not debugger.CHAIN_EXCEPTIONS,
+    reason="chained exception navigation is not available",
+)
+def test_exception_command_aliases_exceptions():
+    ipdb = debugger.Pdb()
+
+    with patch.object(ipdb, "do_exceptions", return_value=True) as do_exceptions:
+        assert ipdb.onecmd("exception 0") is True
+
+    do_exceptions.assert_called_once_with("0")
+
+
 @skip_win32
 def test_xmode_skip():
     """that xmode skip frames


### PR DESCRIPTION
## Summary
- add `exception` as an alias for the existing `exceptions` chained-exception debugger command
- cover the command dispatch path with a regression test

Closes #14870

## Tests
- `.\.venv312\Scripts\python.exe -m pytest tests/test_debugger.py -q`