### PR TITLE
DOC: Fix typos in user-facing documentation

### DIFF
--- a/docs/source/config/details.rst
+++ b/docs/source/config/details.rst
@@ -26,7 +26,7 @@ multiple configuration options to be set to properly work:
 
  - Configure said provider with models, API keys, etc – this will depend on the
    provider, and you will have to refer to Jupyter-AI documentation, and/or your
-   LLM documenatation.
+   LLM documentation.
 
 
 While setting up IPython to use a real LLM, you can refer to
@@ -88,7 +88,7 @@ by setting the ``llm_construction_kwargs`` traitlet.
 
     c.TerminalInteractiveShell.llm_constructor_kwargs = {"model": "skynet"}
 
-This will depdend on the provider you chose, and you will have to refer to
+This will depend on the provider you chose, and you will have to refer to
 the provider documentation.
 
 Extra configuration may be needed by setting environment variables, this will

--- a/docs/source/interactive/autoawait.rst
+++ b/docs/source/interactive/autoawait.rst
@@ -312,7 +312,7 @@ task is running, if and only if the foreground task is async::
    In [4]: await asyncio.sleep(3)
    background 4
    background 5
-   background 6g
+   background 6
 
 In a Notebook, QtConsole, or any other frontend using IPykernel, background
 tasks should behave as expected.


### PR DESCRIPTION
Three small typo fixes I noticed while reading the IPython docs:

- ``documenatation`` -> ``documentation`` in the LLM suggestions configuration page.
- ``depdend`` -> ``depend`` on the same page.
- ``background 6g`` -> ``background 6`` in the background-task example output in the autoawait docs (looks like an off-by-one stray character in the copy-pasted REPL output).