### PR TITLE
fix: duplicated words in usage.py and oinspect.py docstrings

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -1093,7 +1093,7 @@ class Inspector(Configurable):
         """
         Check whether the source *src* contains the docstring *doc*.
 
-        This is is helper function to skip displaying the docstring if the
+        This is a helper function to skip displaying the docstring if the
         source already contains it, avoiding repetition of information.
         """
         try:

--- a/IPython/core/usage.py
+++ b/IPython/core/usage.py
@@ -46,7 +46,7 @@ Usage
     This file is typically installed in the `IPYTHONDIR` directory, and there
     is a separate configuration directory for each profile. The default profile
     directory will be located in $IPYTHONDIR/profile_default. IPYTHONDIR
-    defaults to to `$HOME/.ipython`.  For Windows users, $HOME resolves to
+    defaults to `$HOME/.ipython`.  For Windows users, $HOME resolves to
     C:\\Users\\YourUserName in most instances.
 
     To initialize a profile with the default configuration file, do::


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in docstrings:
- `IPython/core/usage.py` — "IPYTHONDIR defaults to to `$HOME/.ipython`." → "IPYTHONDIR defaults to `$HOME/.ipython`."
- `IPython/core/oinspect.py` — "This is is helper function to skip displaying the docstring if the" → "This is a helper function to skip displaying the docstring if the"

No code/behavior change.