### PR TITLE
DOC: clarify term_title_format help text

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -400,8 +400,8 @@ class TerminalInteractiveShell(InteractiveShell):
     ).tag(config=True)
 
     term_title_format = Unicode("IPython: {cwd}",
-        help="Customize the terminal title format.  This is a python format string. " +
-             "Available substitutions are: {cwd}."
+        help="Customize the terminal title format.  This is a Python format string. " +
+             "The available substitution is {cwd}."
     ).tag(config=True)
 
     display_completions = Enum(('column', 'multicolumn','readlinelike'),


### PR DESCRIPTION
Closes #15177.

This clarifies the `TerminalInteractiveShell.term_title_format` help text used in the generated configuration docs.

The previous wording used `Available substitutions are: {cwd}.`, which could be rendered incorrectly in the config option documentation. The updated wording keeps the same meaning while avoiding the problematic colon.

Validation:
- `conda run -n ipython_15177 python docs/autogen_config.py`
- `conda run -n ipython_15177 python -m py_compile IPython\terminal\interactiveshell.py`
- checked the updated `term_title_format` help text locally
- `git diff --check`

AI assistance:
I used ChatGPT/Codex to help identify the issue, inspect the relevant config-doc generation path, and prepare this small local patch. I reviewed the final diff and validation results before submitting.
