### PR TITLE
docs: fix terminal title config description

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -401,7 +401,7 @@ class TerminalInteractiveShell(InteractiveShell):
 
     term_title_format = Unicode("IPython: {cwd}",
         help="Customize the terminal title format.  This is a python format string. " +
-             "Available substitutions are: {cwd}."
+             "Available substitutions include {cwd}."
     ).tag(config=True)
 
     display_completions = Enum(('column', 'multicolumn','readlinelike'),


### PR DESCRIPTION
## Summary

- Updates the `TerminalInteractiveShell.term_title_format` help text so the generated configuration docs keep the description, trait type, and default value in the correct places.
- Avoids the colon that caused the `{cwd}` substitution text to be parsed as a field in the rendered docs.

Closes #15177.

## Tests

- `git diff --check`
- `python docs/autogen_config.py` and checked the generated `terminal.rst` entry
- Checked the generated HTML snippet for `TerminalInteractiveShell.term_title_format`
- `python -m pytest tests/test_interactiveshell.py tests/test_application.py`