### PR TITLE
docs: clarify autoawait example requires running event loop

### DIFF
--- a/docs/source/interactive/autoawait.rst
+++ b/docs/source/interactive/autoawait.rst
@@ -36,6 +36,14 @@ syntax error in the Python REPL::
                               ^
     SyntaxError: invalid syntax
 
+.. note::
+
+    Libraries like ``aiohttp`` require a running event loop at the moment an
+    object such as ``ClientSession`` is constructed. IPython only starts an
+    event loop when a cell contains an ``await`` expression, so the example
+    below uses ``await asyncio.sleep(0)`` to force the loop to start before
+    ``aiohttp.ClientSession()`` is called.
+
 Should behave as expected in the IPython REPL::
 
     Python 3.12.0
@@ -43,6 +51,8 @@ Should behave as expected in the IPython REPL::
     IPython 9.0.0 -- An enhanced Interactive Python. Type '?' for help.
 
     In [1]: import aiohttp
+       ...: import asyncio
+       ...: await asyncio.sleep(0)
        ...: session = aiohttp.ClientSession()
        ...: result = session.get('https://api.github.com')
 


### PR DESCRIPTION
Fixes #14865.

The `aiohttp.ClientSession()` example in `autoawait.rst` raises `RuntimeError: no running event loop` because cell `In [1]` contains no `await`, so IPython has not yet started the loop when `ClientSession()` is constructed.

Per @Carreau's suggestion on the issue ("the easier way to force a loop is to await a dummy thing, like `await sleep(0)`"), this prepends `await asyncio.sleep(0)` to the first cell and adds a short note explaining why it is needed.
