### PR TITLE
Fix %debug and ipdb with Python 3.15

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -540,6 +540,18 @@ class Pdb(OldPdb):
             """
             return self.do_exceptions(arg)
 
+    def _cmdloop(self):
+        # Override to bypass Python 3.15's _maybe_use_pyrepl_as_stdin(), which
+        # sets use_rawinput=False and conflicts with IPython's own input handling.
+        while True:
+            try:
+                self.allow_kbdint = True
+                self.cmdloop()
+                self.allow_kbdint = False
+                break
+            except KeyboardInterrupt:
+                self.message("--KeyboardInterrupt--")
+
     def interaction(self, frame, tb_or_exc):
         try:
             if CHAIN_EXCEPTIONS:


### PR DESCRIPTION
Python 3.15 introduced PyREPL as the default pdb input backend (via _maybe_use_pyrepl_as_stdin()), which temporarily sets use_rawinput=False before calling cmdloop(). IPython's TerminalPdb raises ValueError when it sees use_rawinput=False.

Override _cmdloop() in IPython.core.debugger.Pdb to bypass the PyREPL wrapping — IPython already has its own input handling via prompt_toolkit and doesn't need PyREPL.

Fixes: https://github.com/ipython/ipython/issues/15217