### PR TITLE
Honor quotes when glob-expanding %run arguments

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -61,6 +61,7 @@ from IPython.utils.contexts import preserve_keys
 from IPython.utils.ipstruct import Struct
 from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, shellglob
+from IPython.utils.process import arg_split_with_quotes
 from IPython.utils.timing import clock, clock2
 from IPython.core.magics.ast_mod import ReplaceCodeTransformer
 
@@ -579,11 +580,12 @@ class ExecutionMagics(Magics):
         interactive work, while giving each program a 'clean sheet' to run in.
 
         Arguments are expanded using shell-like glob match.  Patterns
-        '*', '?', '[seq]' and '[!seq]' can be used.  Additionally,
-        tilde '~' will be expanded into user's home directory.  Unlike
-        real shells, quotation does not suppress expansions.  Use
-        *two* back slashes (e.g. ``\\\\*``) to suppress expansions.
-        To completely disable these expansions, you can use -G flag.
+        '*', '?', '[seq]' and '[!seq]' can be used, and tilde '~' is
+        expanded to the user's home directory.  As in real shells,
+        wrapping an argument in single or double quotes suppresses glob
+        expansion for that argument (see #12726).  You can also use
+        *two* back slashes (e.g. ``\\\\*``) outside of quotes, or pass
+        the ``-G`` flag to disable expansion entirely.
 
         On Windows systems, the use of single quotes `'` when specifying
         a file is not supported. Use double quotes `"`.
@@ -760,8 +762,21 @@ class ExecutionMagics(Magics):
         if 'G' in opts:
             args = arg_lst[1:]
         else:
-            # tilde and glob expansion
-            args = shellglob(map(os.path.expanduser,  arg_lst[1:]))
+            # tilde and glob expansion. Tokens that were quoted in
+            # parameter_s skip globbing so quotes suppress expansion the
+            # way they do in real shells (#12726).
+            quoted_remaining = {}
+            for tok, was_quoted in arg_split_with_quotes(parameter_s, strict=False):
+                if was_quoted:
+                    quoted_remaining[tok] = quoted_remaining.get(tok, 0) + 1
+            args = []
+            for a in arg_lst[1:]:
+                a_expanded = os.path.expanduser(a)
+                if quoted_remaining.get(a, 0) > 0:
+                    quoted_remaining[a] -= 1
+                    args.append(a_expanded)
+                else:
+                    args.extend(shellglob([a_expanded]))
 
         sys.argv = [filename] + args  # put in the proper filename
 

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -221,3 +221,50 @@ def arg_split(commandline: str, posix: bool = False, strict: bool = True) -> lis
             break
 
     return tokens
+
+
+def arg_split_with_quotes(
+    commandline: str, strict: bool = True
+) -> list[tuple[str, bool]]:
+    """Split a command line and report which tokens were originally quoted.
+
+    Returns a list of ``(token, was_quoted)`` pairs. ``token`` is the unquoted
+    form, as ``shlex.split(posix=True)`` returns, and ``was_quoted`` is True
+    if that token had any single- or double-quote characters in ``commandline``.
+
+    Useful for callers like ``%run`` that want to honor shell quoting when
+    deciding wether to apply further expansion (glob, tilde) to a token.
+
+    Detection is shlex-based on both passes so the quote semantics are the
+    same on Posix and Windows. If ``strict`` is False, malformed input (e.g.
+    an unbalanced quote) returns whatever was parsed so far instead of raising.
+    """
+    def _tokenize(s: str, posix: bool) -> list[str]:
+        lex = shlex.shlex(s, posix=posix)
+        lex.whitespace_split = True
+        lex.commenters = ''
+        out = []
+        while True:
+            try:
+                out.append(next(lex))
+            except StopIteration:
+                break
+            except ValueError:
+                if strict:
+                    raise
+                out.append(lex.token)
+                break
+        return out
+
+    raw_tokens = _tokenize(commandline, posix=False)
+    clean_tokens = _tokenize(commandline, posix=True)
+
+    if len(raw_tokens) != len(clean_tokens):
+        # If the two passes disagree (exotic input) report nothing as quoted
+        # so callers get the legacy, non-quote-aware behavior.
+        return [(t, False) for t in clean_tokens]
+
+    return [
+        (clean, ("'" in raw) or ('"' in raw))
+        for clean, raw in zip(clean_tokens, raw_tokens)
+    ]

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -20,7 +20,12 @@ elif sys.platform == "emscripten":
 else:
     from ._process_posix import system, getoutput, arg_split, check_pid
 
-from ._process_common import getoutputerror, get_output_error_code, process_handler
+from ._process_common import (
+    arg_split_with_quotes,
+    getoutputerror,
+    get_output_error_code,
+    process_handler,
+)
 
 
 class FindCmdError(Exception):

--- a/docs/source/whatsnew/pr/incompat-run-quoted-glob.rst
+++ b/docs/source/whatsnew/pr/incompat-run-quoted-glob.rst
@@ -1,0 +1,17 @@
+Quoted arguments to ``%run`` no longer undergo glob expansion
+-------------------------------------------------------------
+
+Wrapping a ``%run`` argument in single or double quotes now suppresses glob
+expansion of that argument, matching real shells. Previously quoting was
+documented as *not* suppressing expansion which was suprising.
+
+For example with ``foo.txt`` and ``bar.txt`` in the working directory::
+
+    %run script.py "*.txt"    # before: ['foo.txt', 'bar.txt']
+                              # after:  ['*.txt']
+
+The unquoted form (``%run script.py *.txt``) and the backslash-escape form
+(``%run script.py \*.txt``) are unchanged. Pass ``-G`` to disable expansion
+entirely.
+
+See :ghissue:`12726`.

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -26,6 +26,7 @@ from IPython.utils.process import (
     find_cmd,
     FindCmdError,
     arg_split,
+    arg_split_with_quotes,
     system,
     getoutput,
     getoutputerror,
@@ -92,6 +93,47 @@ def test_arg_split(argstr, argv):
 def test_arg_split_win32(argstr, argv):
     """Ensure that argument lines are correctly split like in a shell."""
     assert arg_split(argstr) == argv
+
+
+@pytest.mark.parametrize(
+    "argstr,expected",
+    [
+        ("foo bar", [("foo", False), ("bar", False)]),
+        ('"*.txt"', [("*.txt", True)]),
+        ("'*.txt'", [("*.txt", True)]),
+        # The repro from #12726: bare, double-quoted and single-quoted
+        # versions of the same chars.
+        (
+            "p \"p\" 'p' * \"*\" '*'",
+            [
+                ("p", False),
+                ("p", True),
+                ("p", True),
+                ("*", False),
+                ("*", True),
+                ("*", True),
+            ],
+        ),
+        (
+            '-i demo.py "*.txt" *.txt',
+            [
+                ("-i", False),
+                ("demo.py", False),
+                ("*.txt", True),
+                ("*.txt", False),
+            ],
+        ),
+    ],
+)
+def test_arg_split_with_quotes(argstr, expected):
+    """``arg_split_with_quotes`` flags tokens that came from quoted segments."""
+    assert arg_split_with_quotes(argstr) == expected
+
+
+def test_arg_split_with_quotes_strict_false():
+    """Unbalanced quotes should not raise when ``strict=False``."""
+    result = arg_split_with_quotes('foo "unbalanced', strict=False)
+    assert ("foo", False) in result
 
 
 class SubProcessTestCase(tt.TempFileMixin):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -113,15 +113,18 @@ def doctest_run_option_parser():
 def doctest_run_option_parser_for_posix():
     r"""Test option parser in %run (Linux/OSX specific).
 
-    You need double quote to escape glob in POSIX systems:
+    You can use a backslash to escape glob in POSIX systems:
 
     In [1]: %run print_argv.py print\\*.py
     ['print*.py']
 
-    You can't use quote to escape glob in POSIX systems:
+    You can also use single or double quotes to suppress glob expansion (#12726):
 
     In [2]: %run print_argv.py 'print*.py'
-    ['print_argv.py']
+    ['print*.py']
+
+    In [3]: %run print_argv.py "print*.py"
+    ['print*.py']
 
     """
 
@@ -549,6 +552,42 @@ class TestMagicRunWithPackage(unittest.TestCase):
         test_opts = "-x abc -m test"
         _ip.run_line_magic("run", "-m {0}.args -- {1}".format(self.package, test_opts))
         assert _ip.user_ns["a"] == test_opts
+
+
+def test_run_quoted_glob_arg_is_not_expanded():
+    """Quoted glob args to ``%run`` are passed through unexpanded (#12726)"""
+    with TemporaryDirectory() as td:
+        cwd = os.getcwd()
+        try:
+            os.chdir(td)
+            # Files that *would* match the glob if expansion happened.
+            for name in ("foo.txt", "bar.txt"):
+                with open(name, "w", encoding="utf-8") as f:
+                    f.write("")
+
+            script = pjoin(td, "show_argv.py")
+            with open(script, "w", encoding="utf-8") as f:
+                f.write("import sys\nargs = sys.argv[1:]\n")
+
+            # Sanity check: bare glob still expands as before.
+            _ip.user_ns.pop("args", None)
+            _ip.run_line_magic("run", '-i {} *.txt'.format(script))
+            assert sorted(_ip.user_ns["args"]) == ["bar.txt", "foo.txt"]
+
+            # Double-quoted glob should pass through literally on all platforms.
+            _ip.user_ns.pop("args", None)
+            _ip.run_line_magic("run", '-i {} "*.txt"'.format(script))
+            assert _ip.user_ns["args"] == ["*.txt"]
+
+            # Single-quoted glob — POSIX only. On windows single quotes aren't
+            # stripped by the splitter (see %run docstring), so skip.
+            if os.name == "posix":
+                _ip.user_ns.pop("args", None)
+                _ip.run_line_magic("run", "-i {} '*.txt'".format(script))
+                assert _ip.user_ns["args"] == ["*.txt"]
+        finally:
+            os.chdir(cwd)
+            _ip.run_line_magic("reset", "-f")
 
 
 def test_run__name__():


### PR DESCRIPTION
Fixes #12726.

## Summary

Wrapping a `%run` argument in single or double quotes now suppresses shell-style glob expansion of that argument matching how real shels behave. the existing backslash-escape (`\*`) and `-G` flag are unchanged. Before this with `foo.txt` and `bar.txt` in the working directory:

```python
In [1]: %run script.py "*.txt"
# sys.argv -> ['foo.txt', 'bar.txt']
```

After:

```python
In [1]: %run script.py "*.txt"
# sys.argv -> ['*.txt']
```

## Motivation

The issue thread already has a maintainer pointer:

> Looks like an oversight in `IPython.core.magics.execution.ExecutionMagics.parse_options`.

-- @MrMino, [comment](https://github.com/ipython/ipython/issues/12726#issuecomment-823672101)

## What changed

I added a new helper `arg_split_with_quotes(commandline, strict=True)` in `IPython/utils/_process_common.py` (re-exported from `IPython.utils.process`). Returns `[(token, was_quoted), ...]`. shlex-based on two passes - `posix=True` and `posix=False` - so the quote semantics are the same on every platform

`%run` consults it after `parse_options` and skips globbing for any `arg_lst` entry that came from a quoted token in `parameter_s`. Docstring updated.

This is a small backwards-incompatible behavior change so ofc anyone depending on the previous "quotes do not suppress globs" behavior wouldd see different output. I added `docs/source/whatsnew/pr/incompat-run-quoted-glob.rst`.

## Tests

- `tests/test_process.py`: parametrized unit tests for `arg_split_with_quotes` covering bare, double-quoted, single-quoted, mixed-with-options and `strict=False` cases.
- `tests/test_run.py`: new integration test `test_run_quoted_glob_arg_is_not_expanded` that runs `%run -i` against a small script in a tempdir with f les that would match `*.txt`, and checks `sys.argv` for bare double-quoted and (POSIX-only) single-quoted forms.
- Updated `doctest_run_option_parser_for_posix` its expected output was locking in the old buggy behavior.

The POSIX-only single-quote doctest is done by CI on the Linux/macOS jobs.

## Open questions

- The Windows doctest `doctest_run_option_parser_for_windows` still describes the existing `'print*.py'` → `["'print*.py'"]` behavior. That case is preserved by the patch (`CommandLineToArgvW` keeps the literal single quotes so they never enter the `quoted_remaining` set) so I left it. 
- Single quotes on Windows stay documented as unsupported.