### PR TITLE
Fix docstring formatting for prompt_line_number_format help text

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -746,9 +746,9 @@ class TerminalInteractiveShell(InteractiveShell):
     prompt_line_number_format = Unicode(
         "",
         help="The format for line numbering. Will be passed the current line number"
-        " `line` (int, 1 based), and the relative line number `rel_line`."
+        " ``line`` (int, 1 based), and the relative line number ``rel_line``."
         " For example to display both, you can use the following template string:"
-        " `c.TerminalInteractiveShell.prompt_line_number_format = '{line: 4d}/{rel_line:+03d} | '`"
+        " ``c.TerminalInteractiveShell.prompt_line_number_format = '{line: 4d}/{rel_line:+03d} | '``"
         " This will display the current line number, with a leading space and a width of at least 4"
         " characters, as well as the relative line number, 0-padded and always with a + or - sign."
         " Note that when using Emacs mode, the prompt of the first line may not update.",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ docrepr
 prompt_toolkit
 ipykernel
 intersphinx_registry
+sphinx_toml


### PR DESCRIPTION
## Summary
This PR fixes the docstring formatting in the `prompt_line_number_format` configuration option help text by using proper reStructuredText inline literal markup.

## Changes
- Updated help text for `prompt_line_number_format` in `IPython/terminal/interactiveshell.py` to use double backticks (`` `` ``) instead of single backticks (`` ` ``) for inline code formatting
  - Changed variable names `line` and `rel_line` to use proper RST literal markup
  - Changed configuration example to use proper RST literal markup for better rendering in documentation

## Details
The single backtick syntax is not valid reStructuredText for inline literals. Using double backticks ensures the code snippets and variable names are properly formatted when the help text is rendered in documentation or help systems.

https://claude.ai/code/session_01JarfqKh8jPzkgNksGVptwi