### PR TITLE
Fix Markdown and JSON __repr__ to return actual data

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -461,6 +461,9 @@ class HTML(TextDisplayObject):
 
 class Markdown(TextDisplayObject):
 
+    def __repr__(self):
+        return self.data
+
     def _repr_markdown_(self):
         return self._data_and_metadata()
 
@@ -639,6 +642,9 @@ class JSON(DisplayObject):
 
     def _data_and_metadata(self):
         return self.data, self.metadata
+
+    def __repr__(self):
+        return json.dumps(self.data, indent=2)
 
     def _repr_json_(self):
         return self._data_and_metadata()


### PR DESCRIPTION
Fix Markdown and JSON __repr__ to return actual data

- Add Markdown.__repr__ returning self.data so nbconvert and terminals
  show actual markdown text instead of <IPython.core.display.Markdown object>
- Add JSON.__repr__ returning json.dumps(self.data, indent=2) as
  requested in review on PR #14150

Closes #12895