### PR TITLE
Fix Markdown and JSON __repr__ to return actual data

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -461,6 +461,9 @@ class HTML(TextDisplayObject):
 
 class Markdown(TextDisplayObject):
 
+    def __repr__(self):
+        return self.data
+
     def _repr_markdown_(self):
         return self._data_and_metadata()
 
@@ -639,6 +642,9 @@ class JSON(DisplayObject):
 
     def _data_and_metadata(self):
         return self.data, self.metadata
+
+    def __repr__(self):
+        return json.dumps(self.data, indent=2)
 
     def _repr_json_(self):
         return self._data_and_metadata()

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -58,7 +58,8 @@ def test_geojson():
             "maxZoom": 18,
         },
     )
-    assert "<IPython.core.display.GeoJSON object>" == str(gj)
+    # assert "<IPython.core.display.GeoJSON object>" == str(gj)
+    assert str(gj) == json.dumps(gj.data, indent=2)
 
 
 def test_retina_png():


### PR DESCRIPTION
## Problem
`Markdown` and `JSON` display objects had no `__repr__`, so they fell 
back to `DisplayObject.__repr__` which returns the unhelpful 
`<IPython.core.display.Markdown object>` string. This caused nbconvert 
output and terminal reprs to show garbage instead of actual content.

## Changes
- Add `Markdown.__repr__` returning `self.data`
- Add `JSON.__repr__` returning `json.dumps(self.data, indent=2)` 
  (as requested by @Carreau in #14150)
- Update `test_geojson` to assert the correct repr output

## Notes
- Builds on the approach in #14150 and directly addresses the 
  maintainer feedback requesting `json.dumps` with indentation
- `test_display_formatter_active_types_config` failure is a 
  pre-existing Windows environment issue unrelated to this PR

Closes #12895