### PR TITLE
Add regression test for classic prompt ellipsis strings

### DIFF
--- a/tests/test_inputtransformer2_line.py
+++ b/tests/test_inputtransformer2_line.py
@@ -98,6 +98,19 @@ CLASSIC_PROMPT_STANDALONE_CONTINUATION = (
     "...     print(1)\n",
 )
 
+CLASSIC_PROMPT_ELLIPSIS_IN_TRIPLE_QUOTED_STRING = (
+    """\
+text = \"\"\"
+... keep this line
+\"\"\"
+""",
+    """\
+text = \"\"\"
+... keep this line
+\"\"\"
+""",
+)
+
 
 def test_classic_prompt():
     for sample, expected in [
@@ -108,6 +121,7 @@ def test_classic_prompt():
         CLASSIC_PROMPT_DEDENT_LEADING_WS,
         CLASSIC_PROMPT_MULTILINE_DOCTEST,
         CLASSIC_PROMPT_STANDALONE_CONTINUATION,
+        CLASSIC_PROMPT_ELLIPSIS_IN_TRIPLE_QUOTED_STRING,
     ]:
         assert ipt2.classic_prompt(
             sample.splitlines(keepends=True)


### PR DESCRIPTION
Closes #12843.

This adds a regression test that keeps a leading `...` line inside a plain triple-quoted string untouched by `classic_prompt`, while preserving the existing doctest prompt stripping behavior.

Tests:
- `pytest tests/test_inputtransformer2_line.py -q`
