### PR TITLE
Add forward compatibility for pdb.Pdb's mode argument

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -243,6 +243,8 @@ class Pdb(OldPdb):
         stdin=None,
         stdout=None,
         context: int | None | str = 5,
+        *,
+        mode: str | None = None,
         **kwargs,
     ):
         """Create a new IPython debugger.
@@ -258,6 +260,13 @@ class Pdb(OldPdb):
         context : int
             Number of lines of source code context to show when
             displaying stacktrace information.
+        mode : str, optional
+            How the debugger was invoked, one of ``'inline'`` (used by the
+            ``breakpoint()`` builtin), ``'cli'`` (used by the command line
+            invocation) or ``None`` (backwards compatible behaviour). This
+            argument was added to stdlib's ``pdb.Pdb`` in Python 3.14; it is
+            accepted on every supported Python version here but only forwarded
+            to the underlying ``pdb.Pdb`` when it is actually supported.
         **kwargs
             Passed to pdb.Pdb.
 
@@ -272,6 +281,15 @@ class Pdb(OldPdb):
         if isinstance(context, str):
             context = int(context)
         self.context = context
+
+        # The `mode` argument was added to `pdb.Pdb` in Python 3.14. We accept
+        # it on every supported Python version so that callers written against
+        # 3.14+ keep working, but only forward it to the underlying `pdb.Pdb`
+        # when it understands it.
+        if sys.version_info >= (3, 14):
+            kwargs["mode"] = mode
+        else:
+            self.mode = mode
 
         # `kwargs` ensures full compatibility with stdlib's `pdb.Pdb`.
         OldPdb.__init__(self, completekey, stdin, stdout, **kwargs)
@@ -351,11 +369,11 @@ class Pdb(OldPdb):
         self._theme_name = scheme.lower()
         self.parser.theme_name = scheme.lower()
 
-    def set_trace(self, frame=None):
+    def set_trace(self, frame=None, **kwargs):
         if frame is None:
             frame = sys._getframe().f_back
         self.initial_frame = frame
-        return super().set_trace(frame)
+        return super().set_trace(frame, **kwargs)
 
     def get_stack(self, *args, **kwargs):
         stack, pos = super().get_stack(*args, **kwargs)

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -950,3 +950,64 @@ def test_ignore_module_all_commands():
 
         child.sendline("continue")
         child.close()
+
+
+# -----------------------------------------------------------------------------
+# Signature compatibility with stdlib's ``pdb.Pdb``
+# -----------------------------------------------------------------------------
+
+import inspect
+import pdb as _stdlib_pdb
+
+from IPython.terminal.debugger import TerminalPdb
+
+_PDB_SUBCLASSES = [debugger.Pdb, debugger.InterruptiblePdb, TerminalPdb]
+
+# TerminalPdb instantiates a prompt_toolkit session, which needs a real
+# console and cannot be created on Windows CI (NoConsoleScreenBufferError),
+# so we skip instantiating it there.
+_PDB_SUBCLASSES_INSTANTIABLE = [
+    debugger.Pdb,
+    debugger.InterruptiblePdb,
+    pytest.param(TerminalPdb, marks=skip_win32),
+]
+
+
+@pytest.mark.parametrize(
+    "cls", _PDB_SUBCLASSES, ids=lambda c: c.__name__
+)
+def test_pdb_subclass_signature_compatible(cls):
+    """IPython debuggers derived from ``pdb.Pdb`` should be drop-in
+    replacements, i.e. accept every keyword argument that the stdlib
+    ``pdb.Pdb`` accepts (directly or via ``**kwargs``)."""
+    assert issubclass(cls, _stdlib_pdb.Pdb)
+
+    stdlib_params = inspect.signature(_stdlib_pdb.Pdb.__init__).parameters
+    ip_params = inspect.signature(cls.__init__).parameters
+    accepts_var_keyword = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in ip_params.values()
+    )
+
+    for name, param in stdlib_params.items():
+        if name == "self":
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        assert accepts_var_keyword or name in ip_params, (
+            f"{cls.__name__} does not accept the {name!r} argument "
+            "supported by stdlib pdb.Pdb"
+        )
+
+
+@pytest.mark.parametrize(
+    "cls", _PDB_SUBCLASSES_INSTANTIABLE, ids=lambda c: c.__name__
+)
+@pytest.mark.parametrize("mode", [None, "inline", "cli"])
+def test_pdb_subclass_accepts_mode(cls, mode):
+    """The ``mode`` argument (added to ``pdb.Pdb`` in Python 3.14) should be
+    accepted on every supported Python version and stored on the instance."""
+    inst = cls(mode=mode)
+    assert inst.mode == mode


### PR DESCRIPTION
This PR adds support for the `mode` argument that was introduced to stdlib's `pdb.Pdb` in Python 3.14, ensuring IPython's debugger subclasses remain drop-in replacements across Python versions.

- Updated `IPython.core.debugger.Pdb.__init__` to accept a `mode` keyword argument that specifies how the debugger was invoked (`'inline'`, `'cli'`, or `None`)
  - The argument is forwarded to the underlying `pdb.Pdb` on Python 3.14+
  - On earlier Python versions, it's stored as an instance attribute for compatibility
  - Added docstring documentation for the new parameter

- Added test coverage to verify signature compatibility:
  - `test_pdb_subclass_signature_compatible`: validates that all IPython debugger subclasses (`Pdb`, `InterruptiblePdb`, `TerminalPdb`) accept every argument that stdlib's `pdb.Pdb` accepts (directly or via `**kwargs`)
  - `test_pdb_subclass_accepts_mode`: ensures the `mode` argument is accepted and stored on all supported Python versions. `TerminalPdb` is skipped on Windows for the instantiation case, since it creates a prompt_toolkit session that requires a real console (`NoConsoleScreenBufferError` on headless Windows CI)

Should help with spyder-ide/spyder#25550

Might release that as 9.14.1 (unless 9.15 at end of month is ok).