### PR TITLE
ci: add zizmor GitHub Actions security analysis and harden workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: 3.x
         cache: pip
@@ -20,7 +22,7 @@ jobs:
           docs/requirements.txt
           pyproject.toml
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install Graphviz
       run: |
         sudo apt-get update
@@ -40,6 +42,6 @@ jobs:
       run: |
         coverage combine `find . -name .coverage\*` && coverage xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
       with:
         name: Docs

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -37,9 +37,11 @@ jobs:
             python-version: "3.13"
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Update Python installer

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,14 +18,16 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install dependencies
       run: |
         uv pip install --system mypy pyflakes flake8 types-decorator '.[all]'

--- a/.github/workflows/nightly-wheel-build.yml
+++ b/.github/workflows/nightly-wheel-build.yml
@@ -5,6 +5,9 @@ on:
     # this cron is ran every Sunday at midnight UTC
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   upload_anaconda:
     name: Upload to Anaconda
@@ -13,16 +16,18 @@ jobs:
     if: github.event_name != 'pull_request' && (github.event_name != 'schedule' || github.repository_owner == 'ipython')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
           cache: pip
           cache-dependency-path: |
             pyproject.toml
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Try building with Python build
         if: runner.os != 'Windows'  # setup.py does not support sdist on Windows
         run: |
@@ -30,7 +35,7 @@ jobs:
           python -m build
 
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@main
+        uses: scientific-python/upload-nightly-action@9aaae99e2011eef05e293ad9ce15a521694fe9a9 # main
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,15 +17,14 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
-          cache: pip
-          cache-dependency-path: |
-            pyproject.toml
 
       - name: Install build dependencies
         run: |
@@ -62,11 +61,11 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Send Zulip notification
         if: startsWith(github.ref, 'refs/tags/')
-        uses: zulip/github-actions-zulip/send-message@v1
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: ${{ secrets.ZULIP_EMAIL }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,16 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: 3.x
         cache: pip
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install dependencies
       run: |
         # when changing the versions please update CONTRIBUTING.md too

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,14 +18,16 @@ jobs:
         python-version: ["3.x"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install dependencies
       run: |
         uv pip install --system ruff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
   - cron:  '23 1 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -43,16 +45,18 @@ jobs:
             want-latest-entry-point-code: true
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: |
           pyproject.toml
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install latex
       if: runner.os == 'Linux' && matrix.deps == 'test_extra'
       run: echo "disable latex for now, issues in mirros" #sudo apt-get -yq -o Acquire::Retries=3 --no-install-suggests --no-install-recommends install texlive dvipng
@@ -92,7 +96,7 @@ jobs:
       run: |
         pytest --color=yes -raXxs ${{ startsWith(matrix.python-version, 'pypy') && ' ' || '--cov --cov-report=xml' }} --maxfail=15
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
       with:
          token: ${{ secrets.CODECOV_TOKEN }}
          name: Test
@@ -113,9 +117,11 @@ jobs:
           - windows-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Set up uv with Python 3.11
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         python-version: '3.11'
         enable-cache: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [ main, 7.x, 8.x ]
+  pull_request:
+    branches: [ main, 7.x, 8.x ]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+    - name: Run zizmor
+      id: zizmor
+      run: uvx zizmor --format=sarif . > results.sarif
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload SARIF results
+      if: always()
+      uses: github/codeql-action/upload-sarif@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3
+      with:
+        sarif_file: results.sarif
+        category: zizmor
+    - name: Fail if zizmor found problems
+      if: steps.zizmor.outcome == 'failure'
+      run: exit 1

--- a/.github/workflows/zulip.yaml
+++ b/.github/workflows/zulip.yaml
@@ -9,6 +9,9 @@ on:
         default: 'Test Auto release notification of IPython from GitHub action'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   post-message:
     name: Post Message to Zulip
@@ -17,7 +20,7 @@ jobs:
     steps:
 
       - name: Send Zulip notification
-        uses: zulip/github-actions-zulip/send-message@v1
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1
         with:
           api-key: ${{ secrets.ORG_ZULIP_API_KEY }}
           email: ${{ secrets.ORG_ZULIP_EMAIL }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+# Configuration for zizmor (https://docs.zizmor.sh)
+# Require actions to be pinned to a full-length commit hash, so a moved tag or
+# branch can never silently change which code runs in CI. The version each
+# hash corresponds to is kept as a trailing comment on every `uses:`.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin


### PR DESCRIPTION
## Summary

Add [zizmor](https://docs.zizmor.sh) static analysis of our GitHub Actions workflows to CI, and address all of the findings it reports on the existing workflows.

## What's added

- **`.github/workflows/zizmor.yml`** — runs zizmor on every push/PR (via `uvx`, matching the repo's existing `uv` usage), uploads results as SARIF to the code-scanning dashboard, and **fails the job on any findings**.
- **`.github/zizmor.yml`** — config setting the `unpinned-uses` policy to `hash-pin`, so actions must be pinned to a full commit SHA.

## Workflow hardening (fixes for the findings)

- Added top-level `permissions: contents: read` blocks where they were missing (`test.yml`, `nightly-wheel-build.yml`, `zulip.yaml`) — resolves `excessive-permissions`.
- Set `persist-credentials: false` on all checkout steps — resolves `artipacked`.
- Dropped the pip cache from the publish workflow — resolves `cache-poisoning` (caching in a release job is risky).
- Pinned every action reference to a full commit SHA, keeping the version as a trailing comment (e.g. `actions/checkout@df4cb1c… # v6`) — resolves `unpinned-uses`.

After these changes `zizmor .github/workflows/` passes clean (exit 0).

## Notes

- SHA pins don't auto-update — adding Dependabot (`github-actions` ecosystem) as a follow-up would keep them current. Happy to include it here if preferred.

https://claude.ai/code/session_01YShxUAjngEa5CBa4hEVZAu