### PR TITLE
Use `print_stack_entry` to print frames in Python 3.14

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -602,6 +602,19 @@ class Pdb(OldPdb):
         filename = frame.f_code.co_filename
         self.shell.hooks.synchronize_with_editor(filename, lineno, 0)
 
+    def _pdbcmd_print_frame_status(self, arg):
+        """Use print_stack_entry to print frames in Python 3.14+."""
+        if sys.version_info[:2] >= (3, 14):
+            # This is the only line changed from the base class.
+            self.print_stack_entry(self.stack[self.curindex])
+
+            # Same as in 3.14
+            self._validate_file_mtime()
+            self._show_display()
+        else:
+            # 3.13 and 3.12 don't need any changes.
+            super()._pdbcmd_print_frame_status(arg)
+
     def _get_frame_locals(self, frame):
         """ "
         Accessing f_local of current frame reset the namespace, so we want to avoid

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -613,7 +613,7 @@ class Pdb(OldPdb):
             self._show_display()
         else:
             # 3.13 and 3.12 don't need any changes.
-            super()._pdbcmd_print_frame_status(arg)
+            super()._pdbcmd_print_frame_status(arg) # type: ignore[misc]
 
     def _get_frame_locals(self, frame):
         """ "


### PR DESCRIPTION
This change is needed to override some changes done in the base `Pdb` class in 3.14, which end up using `print_stack_trace` to print stack entries in IPython:

https://github.com/python/cpython/blob/5b33e9c1763813c459f9857ad3c168692fb95148/Lib/pdb.py#L1258-L1261

It's effect can be seen when using a `breakpoint()` call in Spyder:

**Before**

<img width="1115" height="875" alt="image" src="https://github.com/user-attachments/assets/3e20e502-4441-40f0-8743-225a94add8c7" />

**After**

<img width="662" height="344" alt="image" src="https://github.com/user-attachments/assets/08b0798c-43bc-4975-a4fc-95d2477379f4" />
