### PR TITLE
Restore underscore tracking after deletion

### DIFF
--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -223,8 +223,13 @@ class DisplayHook(Configurable):
             for unders in ['_'*i for i in range(1,4)]:
                 if unders not in self.shell.user_ns:
                     continue
-                if getattr(self, unders) is not self.shell.user_ns.get(unders):
-                    update_unders = False
+                user_value = self.shell.user_ns[unders]
+                if unders in self.shell.user_ns_hidden:
+                    if self.shell.user_ns_hidden[unders] is user_value:
+                        continue
+                elif getattr(self, unders) is user_value:
+                    continue
+                update_unders = False
 
             self.___ = self.__
             self.__ = self._


### PR DESCRIPTION
Fixes #15000 

Fixes displayhook underscore ownership detection so automatic `_` tracking resumes after `del _`, while still preserving active user-assigned `_`, `__`, and `___` values.

