### PR TITLE
Use current buffer for attribute completions

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -1278,19 +1278,20 @@ class Completer(Configurable):
         except tokenize.TokenError:
             pass
 
-        obj = self._evaluate_expr(expr)
-        if obj is not_found:
-            if context:
-                # try to evaluate on full buffer
-                previous_lines = "\n".join(
-                    context.full_text.split("\n")[: context.cursor_line]
+        obj = not_found
+        if context:
+            # try to evaluate on full buffer
+            previous_lines = "\n".join(
+                context.full_text.split("\n")[: context.cursor_line]
+            )
+            if previous_lines:
+                all_code_lines_before_cursor = (
+                    self._extract_code(previous_lines) + "\n" + expr
                 )
-                if previous_lines:
-                    all_code_lines_before_cursor = (
-                        self._extract_code(previous_lines) + "\n" + expr
-                    )
-                    obj = self._evaluate_expr(all_code_lines_before_cursor)
+                obj = self._evaluate_expr(all_code_lines_before_cursor)
 
+        if obj is not_found:
+            obj = self._evaluate_expr(expr)
             if obj is not_found:
                 return [], ""
 

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -2575,6 +2575,22 @@ def test_undefined_variables(use_jedi, evaluation, code, insert_text):
             assert len(match) == 1, message_on_fail
 
 
+def test_attribute_completion_uses_current_buffer_redefinition():
+    code = "\n".join(["a = []", "a."])
+    ip = get_ipython()
+    ip.user_ns["a"] = 1
+
+    try:
+        with provisionalcompleter(), jedi_status(False), evaluation_policy("limited"):
+            completions = list(ip.Completer.completions(text=code, offset=len(code)))
+    finally:
+        del ip.user_ns["a"]
+
+    completion_texts = {completion.text.lstrip(".") for completion in completions}
+    assert "append" in completion_texts
+    assert "as_integer_ratio" not in completion_texts
+
+
 @pytest.mark.parametrize(
     "code,insert_text",
     [


### PR DESCRIPTION
fixes #15043 

Fix stale attribute completions when a variable is redefined earlier in the same input buffer by checking the current buffer before falling back to the existing namespace value. Adds a regression test for completing a = [] when a was previously bound to an integer.