### PR TITLE
Fix oinspect TypeError with generic __getattr__ objects; fix test path quoting

### DIFF
--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -793,7 +793,7 @@ class Inspector(Configurable):
                 required_parameters = [
                     parameter
                     for parameter in inspect.signature(hook).parameters.values()
-                    if parameter.default != inspect.Parameter.default
+                    if parameter.default is inspect.Parameter.empty
                 ]
                 if len(required_parameters) == 1:
                     res = hook(hook_data)
@@ -886,7 +886,8 @@ class Inspector(Configurable):
         prelude = ""
         if info and info.parent is not None and hasattr(info.parent, HOOK_NAME):
             parents_docs_dict = getattr(info.parent, HOOK_NAME)
-            parents_docs = parents_docs_dict.get(att_name, None)
+            if isinstance(parents_docs_dict, dict):
+                parents_docs = parents_docs_dict.get(att_name, None)
         out: InfoDict = cast(
             InfoDict,
             {

--- a/docs/source/whatsnew/pr/fix-oinspect-getattr-and-path-spaces.rst
+++ b/docs/source/whatsnew/pr/fix-oinspect-getattr-and-path-spaces.rst
@@ -1,0 +1,21 @@
+Fix oinspect TypeError with objects using generic ``__getattr__``
+=================================================================
+
+Objects whose ``__getattr__`` returns something other than ``dict`` for
+``__custom_documentations__`` (e.g. polars ``Expr``, which returns a new
+``Expr`` for any attribute name) no longer cause a ``TypeError`` when
+inspected with ``?`` or :func:`%pinfo`.  The lookup is now guarded with
+``isinstance(..., dict)``.  :ghissue:`15072`
+
+Also fixed an incorrect comparison in the MIME-hook inspection path
+(``inspect.Parameter.default`` → ``inspect.Parameter.empty``) that
+accidentally relied on a property-object inequality to filter required
+parameters.
+
+Fix test failures when IPython source path contains spaces
+==========================================================
+
+``test_exit_code_signal`` in :file:`tests/test_interactiveshell.py` now
+uses :func:`shlex.quote` when interpolating ``sys.executable`` and the
+temporary filename into a shell command string, preventing test failures
+on systems where either path contains spaces.  :ghissue:`15100`

--- a/tests/test_interactiveshell.py
+++ b/tests/test_interactiveshell.py
@@ -12,6 +12,7 @@ recurring bugs we seem to encounter with high-level interaction.
 import asyncio
 import ast
 import os
+import shlex
 import signal
 import shutil
 import sys
@@ -657,7 +658,7 @@ class ExitCodeChecks(tt.TempFileMixin):
             "signal.setitimer(signal.ITIMER_REAL, 0.1)\n"
             "time.sleep(1)\n"
         )
-        self.system("%s %s" % (sys.executable, self.fname))
+        self.system("%s %s" % (shlex.quote(sys.executable), shlex.quote(self.fname)))
         self.assertEqual(ip.user_ns["_exit_code"], -signal.SIGALRM)
 
     @onlyif_cmds_exist("csh")

--- a/tests/test_oinspect.py
+++ b/tests/test_oinspect.py
@@ -547,6 +547,30 @@ def test_pinfo_docstring_dynamic(capsys):
     assert re.search(r"Type:\s+NoneType", captured.out)
 
 
+def test_pinfo_getattr_object(capsys):
+    """Test that pinfo doesn't crash on objects with generic __getattr__.
+
+    Regression test for issue #15072: polars Expr objects have a generic
+    __getattr__ that returns a new Expr for any attribute name, which caused
+    TypeError when pinfo tried to call .get() on the returned Expr instead of
+    a dict.
+    """
+    obj_def = """class ExprLike:
+    '''A class that simulates polars.Expr behavior with generic __getattr__.'''
+    def __getattr__(self, name):
+        # Return self for any attribute, simulating polars Expr behavior
+        return self
+    """
+    ip.run_cell(obj_def)
+    ip.run_cell("expr_like = ExprLike()")
+
+    # This should not raise TypeError
+    ip.run_cell("expr_like.some_attr?")
+    captured = capsys.readouterr()
+    # Should get some output without crashing
+    assert "ExprLike" in captured.out or "Class" in captured.out
+
+
 def test_pinfo_magic():
     with AssertPrints("Docstring:"):
         ip._inspect("pinfo", "lsmagic", detail_level=0)


### PR DESCRIPTION
Cherry-picked the first commit from #15237.

- **oinspect:** guard the `__custom_documentations__` lookup with `isinstance(dict)` so objects like polars `Expr` (which return `self` for any attribute access via `__getattr__`) no longer raise `TypeError` when inspected with `?`. Fixes #15072.
- **oinspect:** fix the `inspect.Parameter.empty` comparison in the MIME-hook path; the previous code accidentally compared against the property descriptor object rather than the sentinel, making the required-parameter filter a no-op.
- **test_interactiveshell:** wrap `sys.executable` and `self.fname` in `shlex.quote()` so `test_exit_code_signal` survives when the source path contains spaces. Fixes #15100.