### PR TITLE
Avoid psutil requirement on Cygwin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "matplotlib-inline>=0.1.6",
     'pexpect>4.6; sys_platform != "win32" and sys_platform != "emscripten"',
     "prompt_toolkit>=3.0.41,<3.1.0",
-    'psutil>=7; sys_platform != "emscripten"',
+    'psutil>=7; sys_platform != "emscripten" and sys_platform != "cygwin"',
     "pygments>=2.14.0", # wheel
     "stack_data>=0.6.0",
     "traitlets>=5.13.0",


### PR DESCRIPTION
Fixes #15245.

This mirrors the approach taken in PR #15190 for emscripten.

`psutil` does not support the `cygwin` platform and causes `pip install ipython` to fail. The only current use of `psutil` in IPython is in `IPython/core/kitty.py` for terminal graphics detection.

That feature is already gated to Darwin and Linux terminals, so it is never exercised on Cygwin. Excluding `psutil` from dependencies on Cygwin restores installation support without affecting runtime behavior.

### Testing

* Verified that `psutil` is only imported from `IPython/core/kitty.py`.
* Confirmed that Kitty support returns early on non-Darwin/non-Linux platforms.
* Followed the same pattern used in PR #15190 for emscripten.
