### PR TITLE
Narrow bare except: clauses in oinspect and interactiveshell

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2961,7 +2961,7 @@ class InteractiveShell(SingletonConfigurable):
         try:
             with fname.open("rb"):
                 pass
-        except:
+        except OSError:
             warn('Could not open file <%s> for safe execution.' % fname)
             return
 
@@ -3019,7 +3019,7 @@ class InteractiveShell(SingletonConfigurable):
         try:
             with fname.open("rb"):
                 pass
-        except:
+        except OSError:
             warn('Could not open file <%s> for safe execution.' % fname)
             return
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -425,7 +425,7 @@ class Inspector(Configurable):
             return None
         try:
             return _render_signature(signature(obj), oname)
-        except:
+        except Exception:
             return None
 
     def __head(self, h: str) -> str:


### PR DESCRIPTION
Narrow bare `except:` clauses so control-flow exceptions are no longer silently swallowed.

- **oinspect._getdef**: bare `except:` → `except Exception` so `KeyboardInterrupt` and `SystemExit` are no longer swallowed during signature rendering.
- **interactiveshell.safe_execfile / safe_execfile_ipy**: bare `except:` on file-open probes → `except OSError`, which is the only exception that opening a file can legitimately raise. Prevents masking programmer errors and control-flow exceptions.

Cherry-picked from #15237. Rebased on current `main`.