### PR TITLE
Remove stale TODO comment in DisplayObject.reload

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -382,7 +382,6 @@ class DisplayObject:
                         encoding = sub.split('=')[-1].strip()
                         break
             if 'content-encoding' in response.headers:
-                # TODO: do deflate?
                 if 'gzip' in response.headers['content-encoding']:
                     import gzip
                     from io import BytesIO


### PR DESCRIPTION
Removes the `# TODO: do deflate?` comment from `DisplayObject.reload()` in `IPython/core/display.py`. The comment was left as a vague open question with no actionable plan, so it's cleaner to just drop it.