### PR TITLE
Assorted self-contained bug fixes (history sqlite handles on Windows, …)

### DIFF
--- a/IPython/core/historyapp.py
+++ b/IPython/core/historyapp.py
@@ -6,6 +6,7 @@ To be invoked as the `ipython history` subcommand.
 """
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 from traitlets.config.application import Application
@@ -50,8 +51,10 @@ class HistoryTrim(BaseIPythonApplication):
     def start(self):
         profile_dir = Path(self.profile_dir.location)
         hist_file = profile_dir / "history.sqlite"
-        with sqlite3.connect(hist_file) as con:
-
+        # Connections must be closed, not merely committed, before the file
+        # shuffling below: Windows refuses to unlink or rename a database
+        # that still has open handles.
+        with closing(sqlite3.connect(hist_file)) as con:
             # Grab the recent history from the current database.
             inputs = list(con.execute('SELECT session, line, source, source_raw FROM '
                                     'history ORDER BY session DESC, line DESC LIMIT ?', (self.keep+1,)))
@@ -78,7 +81,7 @@ class HistoryTrim(BaseIPythonApplication):
             # Make sure we don't interfere with an existing file.
             i += 1
             new_hist_file = profile_dir / ("history.sqlite.new" + str(i))
-        with sqlite3.connect(new_hist_file) as new_db:
+        with closing(sqlite3.connect(new_hist_file)) as new_db:
             new_db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer
                                 primary key autoincrement, start timestamp,
                                 end timestamp, num_cmds integer, remark text)""")

--- a/IPython/extensions/deduperreload/deduperreload.py
+++ b/IPython/extensions/deduperreload/deduperreload.py
@@ -9,6 +9,7 @@ import pickle
 import platform
 import sys
 import textwrap
+import tokenize
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from collections.abc import Generator, Iterable
@@ -215,7 +216,9 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
                 self.source_by_modname[new_modname] = ""
                 continue
             try:
-                with open(fname, "r", encoding="utf8") as f:
+                # tokenize.open honors PEP 263 coding cookies and defaults
+                # to utf-8, like the import system does.
+                with tokenize.open(fname) as f:
                     self.source_by_modname[new_modname] = f.read()
             except Exception as e:
                 logger = logging.getLogger("autoreload")
@@ -552,7 +555,7 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
         if (fname := get_module_file_name(module)) is None:
             return False
         try:
-            with open(fname, "r", encoding="utf8") as f:
+            with tokenize.open(fname) as f:
                 new_source_code = f.read()
         except Exception as e:
             logger = logging.getLogger("autoreload")

--- a/IPython/extensions/tests/test_deduperreload.py
+++ b/IPython/extensions/tests/test_deduperreload.py
@@ -935,6 +935,36 @@ class AutoreloadHookSuite(ShellFixture):
         mod = sys.modules[mod_name]
         assert mod.foo(0) == 5
 
+    def test_deduperreloader_pep263_encoding(self):
+        """Source with a non-utf-8 PEP 263 coding cookie can be read (gh-15193)."""
+        self.shell.magic_autoreload("2")
+        mod_name, mod_fn = self.get_module()
+        code_v1 = squish_text(
+            '''
+            # -*- coding: latin-1 -*-
+            CAFE = "café"
+            def foo(y):
+                return y + 3
+            '''
+        )
+        with open(mod_fn, "wb") as f:
+            f.write(code_v1.encode("latin-1"))
+        self.created_temp_modules.add(mod_name)
+        self.shell.run_code("import %s" % mod_name)
+        self.shell.run_code("pass")
+        # The latin-1 encoded source is not valid utf-8, but must still be
+        # readable for the deduper to consider the module patchable.
+        deduper = self.shell.auto_magics._reloader.deduper_reloader
+        assert deduper.source_by_modname[mod_name] != ""
+        if platform.system().lower() != "darwin":
+            time.sleep(1.05)
+        with open(mod_fn, "wb") as f:
+            f.write(code_v1.replace("y + 3", "y + 5").encode("latin-1"))
+        self.shell.run_code("pass")
+        mod = sys.modules[mod_name]
+        assert mod.foo(0) == 5
+        assert mod.CAFE == "café"
+
     def test_super(self):
         self.shell.magic_autoreload("2")
         mod_name, mod_fn = self.new_module(

--- a/IPython/utils/generics.py
+++ b/IPython/utils/generics.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 from IPython.core.error import TryNext
@@ -10,9 +11,28 @@ from functools import singledispatch
 
 
 @singledispatch
-def inspect_object(obj: Any) -> None:
-    """Called when you do obj?"""
+def _inspect_object(obj: Any) -> None:
+    """Called when you do obj?
+
+    .. deprecated:: 9.15
+        `inspect_object` is deprecated and will be removed in a future
+        version. It is no longer used within IPython, so registering
+        handlers on it has no effect.
+    """
     raise TryNext
+
+
+def __getattr__(name: str) -> Any:
+    if name == "inspect_object":
+        warnings.warn(
+            "inspect_object is deprecated since IPython 9.15 and will be "
+            "removed in a future version. It is no longer used within "
+            "IPython, so registering handlers on it has no effect.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _inspect_object
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @singledispatch

--- a/docs/source/whatsnew/pr/deprecate-inspect-object.rst
+++ b/docs/source/whatsnew/pr/deprecate-inspect-object.rst
@@ -1,0 +1,7 @@
+Deprecation of ``IPython.utils.generics.inspect_object``
+=========================================================
+
+``IPython.utils.generics.inspect_object`` is deprecated since IPython 9.15 and
+will be removed in a future version. It is no longer used within IPython, so
+registering handlers on it has no effect. ``complete_object`` is unaffected.
+See :ghissue:`15068`.

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,22 @@
+"""Tests for IPython.utils.generics."""
+
+import warnings
+
+import pytest
+
+from IPython.core.error import TryNext
+from IPython.utils import generics
+
+
+def test_inspect_object_deprecated():
+    with pytest.warns(DeprecationWarning, match="inspect_object is deprecated"):
+        func = generics.inspect_object
+    # The returned object still behaves as before.
+    with pytest.raises(TryNext):
+        func(object())
+
+
+def test_complete_object_not_deprecated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert callable(generics.complete_object)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -263,10 +263,18 @@ def test_hist_file_config(hmmax3):
     cfg = Config()
     tfile = tempfile.NamedTemporaryFile(delete=False)
     cfg.HistoryManager.hist_file = Path(tfile.name)
+    hm = None
     try:
         hm = HistoryManager(shell=get_ipython(), config=cfg)
         assert hm.hist_file == cfg.HistoryManager.hist_file
     finally:
+        if hm is not None:
+            # Stop the saving thread and close the database, otherwise the
+            # thread can briefly hold a strong reference to the manager,
+            # making the instance-leak check in the fixture teardown flaky
+            # (gh-15161).
+            hm.save_thread.stop()
+            hm.db.close()
         try:
             Path(tfile.name).unlink()
         except OSError:
@@ -274,7 +282,6 @@ def test_hist_file_config(hmmax3):
             # On Windows, even though we close the file, we still can't
             # delete it.  I have no clue why
             pass
-            HistoryManager.__max_inst = 1
 
 
 def test_histmanager_memory_fallback_reopens_db(hmmax3, tmp_path, caplog):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -9,8 +9,10 @@ import io
 import gc
 import os
 import sqlite3
+import subprocess
 import sys
 import tempfile
+from contextlib import closing
 from datetime import datetime
 from pathlib import Path
 
@@ -468,3 +470,67 @@ def test_calling_run_cell(hmmax2):
 
             ip.history_manager = hist_manager_ori
     assert session_number == new_session_number, ValueError(f"{session_number} != {new_session_number}")
+
+
+def _make_history_db(hist_file: Path, n_entries: int) -> None:
+    """Create a history database with the standard schema and some entries."""
+    with closing(sqlite3.connect(hist_file)) as con:
+        con.execute(
+            """CREATE TABLE sessions (session integer
+                primary key autoincrement, start timestamp,
+                end timestamp, num_cmds integer, remark text)"""
+        )
+        con.execute(
+            """CREATE TABLE history
+                (session integer, line integer, source text, source_raw text,
+                PRIMARY KEY (session, line))"""
+        )
+        con.execute(
+            """CREATE TABLE output_history
+                (session integer, line integer, output text,
+                PRIMARY KEY (session, line))"""
+        )
+        now = datetime.now().isoformat(sep=" ")
+        con.execute(
+            "INSERT INTO sessions VALUES (1, ?, ?, ?, '')", (now, now, n_entries)
+        )
+        con.executemany(
+            "INSERT INTO history VALUES (1, ?, ?, ?)",
+            [(i, "code %d" % i, "code %d" % i) for i in range(n_entries)],
+        )
+        con.commit()
+
+
+@pytest.mark.parametrize(
+    "subcommand, kept",
+    [
+        (["trim", "--keep=2"], 2),
+        (["clear", "-f"], 0),
+    ],
+)
+def test_history_trim_cli(tmp_path, subcommand, kept):
+    """`ipython history trim/clear` must replace the database file.
+
+    All sqlite connections to the old database have to be closed before it is
+    unlinked, otherwise this fails on Windows and leaves a stray
+    ``history.sqlite.new`` file behind (gh-15241).
+    """
+    profile_dir = tmp_path / "profile_default"
+    profile_dir.mkdir()
+    hist_file = profile_dir / "history.sqlite"
+    _make_history_db(hist_file, 5)
+
+    env = os.environ.copy()
+    env["IPYTHONDIR"] = str(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, "-m", "IPython", "history"] + subcommand,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert list(profile_dir.glob("history.sqlite.new*")) == []
+    with closing(sqlite3.connect(hist_file)) as con:
+        rows = list(con.execute("SELECT source FROM history"))
+    assert len(rows) == kept

--- a/tests/test_ultratb.py
+++ b/tests/test_ultratb.py
@@ -263,6 +263,18 @@ bar_syntax_error_test_2()
             with tt.AssertPrints("QWERTY"):
                 ip.showsyntaxerror()
 
+    def test_syntaxerror_subclass_without_text(self):
+        # SyntaxError subclasses may leave .text set to None, e.g.
+        # xml.etree.ElementTree.ParseError; rendering them must not
+        # raise (gh-15024).
+        from xml.etree import ElementTree
+
+        try:
+            ElementTree.fromstring("hello")
+        except ElementTree.ParseError:
+            with tt.AssertPrints("ParseError"):
+                ip.showsyntaxerror()
+
 
 import sys
 


### PR DESCRIPTION
A series of independent, self-contained fixes — one issue per commit, pushed separately so every commit gets its own complete `test.yml` run and is easy to review (and cherry-pick) individually.

### Commits

1. **Close sqlite connections before replacing history database** — fixes #15241.
   `sqlite3.Connection` used as a context manager only commits/rolls back, it does not close. `ipython history trim`/`clear` therefore still had open handles on `history.sqlite` while unlinking/renaming it, which fails with `PermissionError` on Windows and leaves `history.sqlite.new*` debris behind. Both connections are now wrapped in `contextlib.closing`, and a regression test runs the `trim` and `clear` subcommands in a subprocess (exercised on Windows CI). *(all workflows green on this SHA)*

2. **Make `test_hist_file_config` teardown deterministic** — fixes #15161.
   The test created a `HistoryManager` backed by a real file but never stopped its `HistorySavingThread`; the thread briefly holds a strong reference to the manager inside its polling loop, so the instance could survive the `gc.collect()` in the `hmmax` fixture teardown and trip the instance-leak assertion intermittently (~3/10 Fedora builds). The test now stops the thread and closes the db like the other tests in the file. *(all workflows green on this SHA)*

3. **Use `tokenize.open` to read source files in deduperreload** — closes #15193.
   Honor PEP 263 coding cookies when reading module sources for the autoreload diffing logic, the way the import system does. (The original cp1252 `UnicodeDecodeError` crash in that issue was already fixed by reading with an explicit utf-8 encoding; this handles the remaining non-utf-8 sources, which were silently treated as unpatchable with a noisy logged traceback.) The regression test fails with the previous explicit-utf-8 reading.

4. **Deprecate `IPython.utils.generics.inspect_object`** — first step towards #15068.
   `inspect_object` is not called anywhere in IPython anymore and no public external users were found (unlike `complete_object`, which pyflyby/riptable/maiev register completers on, and which is unchanged). The `DeprecationWarning` is emitted through a module `__getattr__`, so simply importing the name warns — covering consumers that only call `.register()`.

5. **Add regression test for SyntaxError subclasses without `text`** — closes #15024.
   `xml.etree.ElementTree.ParseError` leaves `.text` as `None`; 9.6.0 raised an `AssertionError` rendering it. The guard landed with #15012 but had no test; this locks the behavior in (the test fails if the `None` check in `ListTB._format_exception_only` is removed).

### Notes from triage

- #15250 (pretty printer ignores inherited `_repr_pretty_`) could **not** be reproduced on current `main`: the MRO walk in `RepresentationPrinter.pretty` finds parent-class `_repr_pretty_` (also covered by `test_callability_checking` in `tests/test_pretty.py`). That issue can probably be closed.
- #15214 (`-P`/safe_path drops CWD from `sys.path`): analysis done, needs a maintainer decision. `sys.flags.safe_path` is currently a hard override in `InteractiveShellApp.init_path` — even an explicit `--no-ignore-cwd` cannot restore CWD. If the Fedora use case (`-P` in shebangs meaning "keep the *script dir* off sys.path") should be supported, the minimal fix is to let an explicitly-set `ignore_cwd=False` win over `safe_path`; happy to implement that in a follow-up if desired.
- #15000, #15132, #15154, #14987, #15072 were considered but already have open PRs (#15243, #15158, #15168, #15032, #15237/#15246), so they are deliberately not duplicated here.

https://claude.ai/code/session_01AtmUVnQwZfjDBuUzF7TdGh