### PR TITLE
fix: don't let kitty graphics detection crash IPython startup

### DIFF
--- a/IPython/core/kitty.py
+++ b/IPython/core/kitty.py
@@ -27,10 +27,18 @@ def _supports_kitty_graphics() -> bool:
     }
     import psutil
 
-    process = psutil.Process()
-    while process := process.parent():
-        if process.name() in supported_terminals:
-            return True
+    try:
+        process = psutil.Process()
+        while process := process.parent():
+            if process.name() in supported_terminals:
+                return True
+    except (psutil.Error, OSError):
+        # Walking the process tree can fail when /proc is mounted with
+        # ``hidepid`` on shared multi-user systems (common on HPC clusters):
+        # ancestor processes owned by other users are inaccessible and psutil
+        # raises AccessDenied. Treat as "unsupported" rather than letting it
+        # abort the import of IPython.
+        return False
     return False
 
 

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -15,6 +15,11 @@ class StdoutWithNonCallableIsatty(DummyStdout):
     isatty = False
 
 
+class StdoutTTY(DummyStdout):
+    def isatty(self):
+        return True
+
+
 def test_supports_kitty_graphics_handles_stdout_without_callable_isatty(monkeypatch):
     import platform
 
@@ -48,3 +53,32 @@ import IPython
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_supports_kitty_graphics_handles_psutil_access_denied(monkeypatch):
+    """Detection must not crash when the process tree is inaccessible.
+
+    On shared multi-user systems /proc is often mounted with ``hidepid``
+    (common on HPC clusters), so walking up to an ancestor process owned by
+    another user makes psutil raise AccessDenied. This must be treated as
+    "unsupported" rather than aborting the import of IPython.
+    """
+    import platform
+
+    import psutil
+
+    from IPython.core import kitty
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(sys, "stdout", StdoutTTY())
+
+    class DeniedProcess:
+        def parent(self):
+            raise psutil.AccessDenied(pid=1)
+
+        def name(self):
+            raise psutil.AccessDenied(pid=1)
+
+    monkeypatch.setattr(psutil, "Process", lambda *args, **kwargs: DeniedProcess())
+
+    assert kitty._supports_kitty_graphics() is False


### PR DESCRIPTION
`_supports_kitty_graphics()` walks the process tree with `psutil` at import time to detect a graphics-capable terminal. On shared multi-user systems where `/proc` is mounted with `hidepid` (common on HPC clusters), reaching an ancestor process owned by another user raises `psutil.AccessDenied`, which was unhandled and aborted the entire `import IPython`:

```
$ pixi run ipython
Traceback (most recent call last):
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_pslinux.py", line 1593, in wrapper
    return fun(self, *args, **kwargs)
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_common.py", line 377, in wrapper
    raise err from None
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_common.py", line 375, in wrapper
    return fun(self)
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_pslinux.py", line 1683, in _parse_stat_file
    data = bcat(f"{self._procfs_path}/{self.pid}/stat")
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_common.py", line 730, in bcat
    return cat(fname, fallback=fallback, _open=open_binary)
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_common.py", line 718, in cat
    with _open(fname) as f:
         ~~~~~^^^^^^^
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_common.py", line 682, in open_binary
    return open(fname, "rb", buffering=FILE_READ_BUFFER_SIZE)
PermissionError: [Errno 1] Operation not permitted: '/proc/902595/stat'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/cburr/xxx/.pixi/envs/default/bin/ipython", line 3, in <module>
    from IPython import start_ipython
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/IPython/__init__.py", line 56, in <module>
    from .terminal.embed import embed
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/IPython/terminal/embed.py", line 16, in <module>
    from IPython.terminal.interactiveshell import TerminalInteractiveShell
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/IPython/terminal/interactiveshell.py", line 11, in <module>
    from IPython.core.kitty import (
    ...<2 lines>...
    )
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/IPython/core/kitty.py", line 37, in <module>
    supports_kitty_graphics = _supports_kitty_graphics()
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/IPython/core/kitty.py", line 31, in _supports_kitty_graphics
    while process := process.parent():
                     ~~~~~~~~~~~~~~^^
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/__init__.py", line 607, in parent
    if parent.create_time() <= proc_ctime:
       ~~~~~~~~~~~~~~~~~~^^
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/__init__.py", line 783, in create_time
    self._create_time = self._proc.create_time()
                        ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_pslinux.py", line 1593, in wrapper
    return fun(self, *args, **kwargs)
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_pslinux.py", line 1857, in create_time
    float(self._parse_stat_file()['create_time']) / CLOCK_TICKS
          ~~~~~~~~~~~~~~~~~~~~~^^
  File "/tmp/cburr/xxx/.pixi/envs/default/lib/python3.14t/site-packages/psutil/_pslinux.py", line 1595, in wrapper
    raise AccessDenied(pid, name) from err
psutil.AccessDenied: (pid=902595)
```

Catch errors during the walk and treat them as "graphics unsupported" instead. A real supported terminal is one of the user's own near ancestors and is found before any restricted PID, so detection capability is unchanged.