### PR TITLE
fix: clarify tk simple-prompt gui message

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -1064,12 +1064,18 @@ class TerminalInteractiveShell(InteractiveShell):
             gui = _convert_gui_from_matplotlib(gui)
 
         if self.simple_prompt is True and gui is not None:
-            print(
-                f'Cannot install event loop hook for "{gui}" when running with `--simple-prompt`.'
-            )
-            print(
-                "NOTE: Tk is supported natively; use Tk apps and Tk backends with `--simple-prompt`."
-            )
+            if gui == "tk":
+                print(
+                    "Tk is supported natively when running with `--simple-prompt`; "
+                    "no event loop hook will be installed."
+                )
+            else:
+                print(
+                    f'Cannot install event loop hook for "{gui}" when running with `--simple-prompt`.'
+                )
+                print(
+                    "NOTE: Tk is supported natively; use Tk apps and Tk backends with `--simple-prompt`."
+                )
             return
 
         if self._inputhook is None and gui is None:

--- a/tests/test_interactiveshell.py
+++ b/tests/test_interactiveshell.py
@@ -1248,6 +1248,21 @@ class TestShowTracebackAttack(unittest.TestCase):
         assert str(result.error_in_exec) == "This should not raise an exception"
 
 
+def test_enable_gui_tk_simple_prompt_message(capsys):
+    simple_prompt = ip.simple_prompt
+    ip.simple_prompt = True
+    try:
+        ip.enable_gui("tk")
+        output = capsys.readouterr().out
+    finally:
+        ip.simple_prompt = simple_prompt
+
+    assert output == (
+        "Tk is supported natively when running with `--simple-prompt`; "
+        "no event loop hook will be installed.\n"
+    )
+
+
 @skip_if_not_osx
 def test_enable_gui_osx():
     simple_prompt = ip.simple_prompt


### PR DESCRIPTION
## Summary
- avoid the contradictory generic event-loop warning for Tk when `--simple-prompt` is active
- explain that Tk is natively supported and no event loop hook is installed
- add a regression test for the Tk simple-prompt message

## Testing
- `python -m pytest tests/test_interactiveshell.py::test_enable_gui_tk_simple_prompt_message -q`
- `python -m pytest tests/test_interactiveshell.py::test_enable_gui_tk_simple_prompt_message tests/test_interactiveshell.py::test_enable_gui_osx -q`

Fixes #14904