### PR TITLE
New test: checks timeit cell magic output format for multiline code

### DIFF
--- a/tests/test_interactiveshell.py
+++ b/tests/test_interactiveshell.py
@@ -798,6 +798,24 @@ class TestAstTransform(unittest.TestCase):
             ip.run_cell_magic("timeit", "-n1 f(2)", "f(3)")
         self.assertEqual(called, {-2, -3})
 
+
+    def test_timeit_multiline_cell_magic(self):
+        called = set()
+
+        def f(x):
+            called.add(x)
+
+        ip.push({"f": f})
+
+        code = """
+f(3)
+f(4)
+"""
+        with tt.AssertPrints("std. dev. of"):
+            ip.run_cell_magic("timeit", "-n1 f(2)", code)
+
+        self.assertEqual(called, {-2, -3, -4})
+
     def test_time(self):
         called = []
 
@@ -915,6 +933,25 @@ class TestAstTransform2(unittest.TestCase):
         with tt.AssertPrints("std. dev. of"):
             ip.run_cell_magic("timeit", "-n1 f(2)", "f(3)")
         self.assertEqual(called, {(2,), (3,)})
+
+
+    def test_timeit_multiline_cell_magic(self):
+        called = set()
+
+        def f(x):
+            called.add(x)
+
+        ip.push({"f": f})
+
+        code = """
+f(3)
+f(4)
+"""
+
+        with tt.AssertPrints("std. dev. of"):
+            ip.run_cell_magic("timeit", "-n1 -r2 f(2)", code)
+
+        self.assertEqual(called, {(2,), (3,), (4,)})
 
 
 class ErrorTransformer(ast.NodeTransformer):


### PR DESCRIPTION
added a new test in `test_interactiveshell.py` which checks if the phrases `loop `and `std. dev. of` are in the output of a timeit cell magic to confirm its format

fixes #15044