### PR TITLE
Close history database during shell shutdown

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -4103,8 +4103,12 @@ class InteractiveShell(SingletonConfigurable):
             # history db
             if self.history_manager is not None:
                 self.history_manager.end_session()
-                self.history_manager = None
 
+                if self.history_manager.save_thread is not None:
+                    self.history_manager.save_thread.stop()
+
+                self.history_manager.db.close()
+                self.history_manager = None
     #-------------------------------------------------------------------------
     # Things related to IPython exiting
     #-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #14985.

When IPython is started via `start_ipython()` inside an existing Python interpreter on Windows, the temporary history SQLite database may remain open during shutdown. Since Windows does not allow deletion of open files, cleanup of temporary history files can fail with:

`PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`

This change explicitly stops the history-saving thread (if present) and closes the history database during `_atexit_once()` before temporary files are removed.
