### PR TITLE
fix: add __kwdefaults__, __annotations__, __type_params__ to autorelo…

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -353,6 +353,9 @@ func_attrs = [
     "__closure__",
     "__globals__",
     "__dict__",
+    "__kwdefaults__",
+    "__annotations__",
+    "__type_params__",  # PEP 695, Python 3.12+
 ]
 
 


### PR DESCRIPTION
…ad func_attrs

Fixes #14968

autoreload's update_function() was not patching __kwdefaults__, __annotations__, or __type_params__ when reloading a changed function. This meant that after editing a module, keyword-only argument defaults, type annotations, and PEP 695 type params would remain stale until the session was restarted.

__kwdefaults__ and __annotations__ are patched unconditionally; __type_params__ (Python 3.12+, PEP 695) is handled safely by the existing try/except (AttributeError, TypeError) in update_function().