### PR TITLE
Fix memory leak and handle errors gracefully in LLM autosuggester

### DIFF
--- a/IPython/terminal/shortcuts/auto_suggest.py
+++ b/IPython/terminal/shortcuts/auto_suggest.py
@@ -177,7 +177,7 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
     _init_llm_provider: Callable | None
 
     _llm_provider_instance: Any | None
-    _llm_prefixer: Callable = lambda self, x: "wrong"
+    _llm_prefixer: Callable = lambda self, x: ""
 
     def __init__(self):
         super().__init__()
@@ -193,8 +193,9 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
     def disconnect(self) -> None:
         self._cancel_running_llm_task()
         for pt_app in self._connected_apps:
-            text_insert_event = pt_app.default_buffer.on_text_insert
-            text_insert_event.remove_handler(self.reset_history_position)
+            pt_app.default_buffer.on_text_insert.remove_handler(self.reset_history_position)
+            pt_app.default_buffer.on_cursor_position_changed.remove_handler(self._dismiss)
+        self._connected_apps = []
 
     def connect(self, pt_app: PromptSession) -> None:
         self._connected_apps.append(pt_app)
@@ -363,7 +364,10 @@ class NavigableAutoSuggestFromHistory(AutoSuggestFromHistory):
 
         # here we need a cancellable task so we can't just await the error caught
         self._llm_task = asyncio.create_task(error_catcher(buffer))
-        await self._llm_task
+        try:
+            await self._llm_task
+        except (asyncio.CancelledError, Exception):
+            pass
 
     async def _trigger_llm_core(self, buffer: Buffer):
         """

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -518,3 +518,113 @@ def test_setting_shortcuts_before_pt_app_init():
     ]
     ipython.shortcuts = shortcuts
     assert ipython.shortcuts == shortcuts
+
+
+def test_navigable_provider_disconnect_removes_cursor_handler():
+    provider = NavigableAutoSuggestFromHistory()
+    session = create_session_mock()
+    provider.connect(session)
+
+    # Check that handlers are connected
+    assert len(session.default_buffer.on_text_insert._handlers) > 0
+    assert len(session.default_buffer.on_cursor_position_changed._handlers) > 0
+
+    provider.disconnect()
+
+    # Check that handlers are disconnected
+    assert len(session.default_buffer.on_text_insert._handlers) == 0
+    assert len(session.default_buffer.on_cursor_position_changed._handlers) == 0
+
+
+@pytest.mark.asyncio
+async def test_llm_autosuggestion_cancellation_and_error_handling():
+    import sys
+    import asyncio
+    from unittest.mock import MagicMock, AsyncMock
+
+    # Stub classes to mimic jupyter_ai.completions.models
+    class MockInlineCompletionRequest:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class MockInlineCompletionReply:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class MockInlineCompletionStreamChunk:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    mock_jai_models = MagicMock()
+    mock_jai_models.InlineCompletionRequest = MockInlineCompletionRequest
+    mock_jai_models.InlineCompletionReply = MockInlineCompletionReply
+    mock_jai_models.InlineCompletionStreamChunk = MockInlineCompletionStreamChunk
+
+    mock_jai = MagicMock()
+    mock_completions = MagicMock()
+    mock_jai.completions = mock_completions
+    mock_completions.models = mock_jai_models
+
+    mock_magics = MagicMock()
+
+    modules_to_patch = {
+        "jupyter_ai": mock_jai,
+        "jupyter_ai.completions": mock_completions,
+        "jupyter_ai.completions.models": mock_jai_models,
+        "jupyter_ai_magics": mock_magics,
+    }
+
+    # Use patch.dict to mock the modules during this test
+    with patch.dict(sys.modules, modules_to_patch):
+        provider = NavigableAutoSuggestFromHistory()
+        
+        # Test default prefixer is empty string
+        assert provider._llm_prefixer(None) == ""
+
+        # Setup mock provider instance
+        mock_provider = MagicMock()
+        provider._llm_provider_instance = mock_provider
+
+        # Setup buffer and history
+        ip = get_ipython()
+        buffer = Buffer(history=PtkHistoryAdapter(ip))
+        buffer.text = "test text"
+
+        # 1. Test normal execution
+        async def mock_stream_normal(request):
+            yield MockInlineCompletionReply(
+                list=MagicMock(items=[MagicMock(insertText="suggestion")]),
+                reply_to=request.number
+            )
+
+        mock_provider.stream_inline_completions = mock_stream_normal
+        await provider._trigger_llm(buffer)
+        assert buffer.suggestion.text == "suggestion"
+
+        # 2. Test cancellation
+        async def mock_stream_sleep(request):
+            await asyncio.sleep(5)
+            yield MockInlineCompletionReply(
+                list=MagicMock(items=[MagicMock(insertText="slow")]),
+                reply_to=request.number
+            )
+
+        mock_provider.stream_inline_completions = mock_stream_sleep
+        task = asyncio.create_task(provider._trigger_llm(buffer))
+        await asyncio.sleep(0.01)
+        # Cancel the task using disconnect which calls _cancel_running_llm_task
+        provider.disconnect()
+        # Verify it completes without raising CancelledError
+        await task
+
+        # 3. Test exception handling
+        async def mock_stream_error(request):
+            raise ValueError("API error")
+            yield  # make it a generator
+
+        mock_provider.stream_inline_completions = mock_stream_error
+        # Verify it completes without raising the exception
+        await provider._trigger_llm(buffer)


### PR DESCRIPTION
### Summary
This PR resolves a memory leak in the auto-suggestion subsystem of the terminal interactive shell, fixes an incorrect default value in the prefixer, and improves robustness against cancellations and API errors.

### Changes
1. **Memory Leak Fix**: The `disconnect` method of `NavigableAutoSuggestFromHistory` was updated to remove `_dismiss` from the buffer's `on_cursor_position_changed` event. Previously, only the `on_text_insert` handler was removed, resulting in a leak where the auto-suggester remained referenced by the event.
2. **Default Prefixer Fix**: Changed `_llm_prefixer` default implementation from returning `"wrong"` to `""`.
3. **Execution Robustness**: Wrapped `await self._llm_task` execution in a try-except block to catch `asyncio.CancelledError` and `Exception`. This ensures that natural task cancellations (during cursor movement) or LLM provider errors do not bubble up to prompt_toolkit and crash the prompt.

### Testing Checklist
- [x] Verify `on_cursor_position_changed` handler is removed upon disconnect.
- [x] Verify trigger routine gracefully handles task cancellation without throwing `CancelledError`.
- [x] Verify trigger routine gracefully catches and suppresses provider exceptions.
