### PR TITLE
Add opt-in terminal postfix completions

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -302,6 +302,47 @@ class TerminalInteractiveShell(InteractiveShell):
         """,
     ).tag(config=True)
 
+    postfix_completion = Bool(
+        False,
+        help="Enable postfix completion in the terminal prompt.",
+    ).tag(config=True)
+
+    postfix_completion_trigger = Unicode(
+        ".",
+        help="Character sequence used to trigger postfix completion templates.",
+    ).tag(config=True)
+
+    postfix_completion_templates = List(
+        Unicode(),
+        default_value=[
+            "not",
+            "par",
+            "return",
+            "if",
+            "while",
+            "print",
+            "len",
+            "raise",
+            "yield",
+            "str",
+            "list",
+            "set",
+            "dict",
+            "tuple",
+        ],
+        help="Postfix completion templates enabled in the terminal prompt.",
+    ).tag(config=True)
+
+    postfix_completion_style = Unicode(
+        "bg:#44475a #f8f8f2",
+        help="Style used for postfix completion menu entries.",
+    ).tag(config=True)
+
+    postfix_completion_selected_style = Unicode(
+        "bg:#6272a4 #ffffff",
+        help="Style used for the selected postfix completion menu entry.",
+    ).tag(config=True)
+
     mouse_support = Bool(False,
         help="Enable mouse support in the prompt\n(Note: prevents selecting text with the mouse)"
     ).tag(config=True)

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -137,8 +137,10 @@ class IPythonPTCompleter(Completer):
         Private equivalent of get_completions() use only for unit_testing.
         """
         debug = getattr(ipyc, 'debug', False)
-        completions = _deduplicate_completions(
-            body, ipyc.completions(body, offset))
+        completions = list(
+            _deduplicate_completions(body, ipyc.completions(body, offset))
+        )
+        min_elide = 30 if self.shell is None else self.shell.min_elide
         for c in completions:
             if not c.text:
                 # Guard against completion machinery giving us an empty string.
@@ -169,7 +171,6 @@ class IPythonPTCompleter(Completer):
             adjusted_text = _adjust_completion_text_based_on_context(
                 c.text, body, offset
             )
-            min_elide = 30 if self.shell is None else self.shell.min_elide
             if c.type == "function":
                 yield Completion(
                     adjusted_text,
@@ -192,6 +193,31 @@ class IPythonPTCompleter(Completer):
                     ),
                     display_meta=c.type,
                 )
+
+        shell = self.shell if self.shell is not None else get_ipython()
+        if not getattr(shell, "postfix_completion", False):
+            return
+
+        from IPython.terminal.shortcuts.postfix import postfix_completions
+
+        line_before_cursor = body[:offset].split("\n")[-1]
+        for completion in postfix_completions(
+            line_before_cursor,
+            shell.postfix_completion_trigger,
+            shell.postfix_completion_templates,
+        ):
+            yield Completion(
+                completion.expansion.text,
+                start_position=completion.start_position,
+                display=_elide(
+                    completion.key,
+                    completion.prefix,
+                    min_elide=min_elide,
+                ),
+                display_meta="postfix",
+                style=shell.postfix_completion_style,
+                selected_style=shell.postfix_completion_selected_style,
+            )
 
 
 class IPythonPTLexer(Lexer):

--- a/IPython/terminal/shortcuts/__init__.py
+++ b/IPython/terminal/shortcuts/__init__.py
@@ -27,6 +27,7 @@ from prompt_toolkit.filters import Condition
 from IPython.core.getipython import get_ipython
 from . import auto_match as match
 from . import auto_suggest
+from . import postfix
 from .filters import filter_from_string
 from IPython.utils.decorators import undoc
 
@@ -608,6 +609,16 @@ KEY_BINDINGS = [
         indent_buffer,
         ["tab"],  # Ctrl+I == Tab
         "default_buffer_focused & ~has_selection & insert_mode & cursor_in_leading_ws",
+    ),
+    Binding(
+        postfix.postfix_completion,
+        ["tab"],  # Ctrl+I == Tab
+        "default_buffer_focused"
+        " & ~has_selection"
+        " & insert_mode"
+        " & ~cursor_in_leading_ws"
+        " & postfix_completion_enabled"
+        " & pass_through",
     ),
     Binding(newline_autoindent, ["c-o"], "default_buffer_focused & emacs_insert_mode"),
     Binding(open_input_in_editor, ["f2"], "default_buffer_focused"),

--- a/IPython/terminal/shortcuts/filters.py
+++ b/IPython/terminal/shortcuts/filters.py
@@ -85,6 +85,12 @@ def auto_match():
     return shell.auto_match
 
 
+@Condition
+def postfix_completion_enabled():
+    shell = get_ipython()
+    return shell.postfix_completion
+
+
 def all_quotes_paired(quote, buf):
     paired = True
     i = 0
@@ -255,6 +261,7 @@ KEYBINDING_FILTERS = {
     "supports_suspend": supports_suspend,
     "is_windows_os": is_windows_os,
     "auto_match": auto_match,
+    "postfix_completion_enabled": postfix_completion_enabled,
     "focused_insert": (vi_insert_mode | emacs_insert_mode) & default_buffer_focused,
     "not_inside_unclosed_string": not_inside_unclosed_string,
     "readline_like_completions": readline_like_completions,

--- a/IPython/terminal/shortcuts/postfix.py
+++ b/IPython/terminal/shortcuts/postfix.py
@@ -1,0 +1,190 @@
+"""Postfix completions for the terminal prompt."""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import annotations
+
+import ast
+import re
+import tokenize
+from dataclasses import dataclass
+from io import StringIO
+from typing import Callable
+
+from prompt_toolkit.key_binding import KeyPressEvent
+
+from IPython.core.getipython import get_ipython
+
+from .filters import pass_through
+
+
+@dataclass(frozen=True)
+class PostfixExpansion:
+    text: str
+    start_position: int
+
+
+@dataclass(frozen=True)
+class PostfixCompletion:
+    key: str
+    prefix: str
+    expansion: PostfixExpansion
+
+    @property
+    def start_position(self) -> int:
+        return self.expansion.start_position
+
+
+PostfixTemplate = Callable[[str, str], str]
+
+
+def _block(keyword: str) -> PostfixTemplate:
+    def template(expr: str, indent: str) -> str:
+        return f"{keyword} {expr}:\n{indent}    "
+
+    return template
+
+
+def _call(function: str) -> PostfixTemplate:
+    def template(expr: str, indent: str) -> str:
+        return f"{function}({expr})"
+
+    return template
+
+
+POSTFIX_TEMPLATES: dict[str, PostfixTemplate] = {
+    "not": lambda expr, indent: f"not {expr}",
+    "par": lambda expr, indent: f"({expr})",
+    "return": lambda expr, indent: f"return {expr}",
+    "if": _block("if"),
+    "while": _block("while"),
+    "print": _call("print"),
+    "len": _call("len"),
+    "raise": lambda expr, indent: f"raise {expr}",
+    "yield": lambda expr, indent: f"yield {expr}",
+    "str": _call("str"),
+    "list": _call("list"),
+    "set": _call("set"),
+    "dict": _call("dict"),
+    "tuple": _call("tuple"),
+}
+
+
+def _is_valid_expression(expr: str) -> bool:
+    try:
+        tokens = tokenize.generate_tokens(StringIO(expr).readline)
+        if any(
+            token.type in {tokenize.COMMENT, tokenize.ERRORTOKEN} for token in tokens
+        ):
+            return False
+    except tokenize.TokenError:
+        return False
+    try:
+        ast.parse(expr, mode="eval")
+    except SyntaxError:
+        return False
+    return True
+
+
+def _match_postfix(
+    line_before_cursor: str,
+    trigger: str,
+    *,
+    key_required: bool,
+) -> re.Match[str] | None:
+    if not trigger:
+        return None
+
+    key_pattern = (
+        r"(?P<key>[A-Za-z_]\w*)"
+        if key_required
+        else r"(?P<key>[A-Za-z_]\w*)?"
+    )
+    pattern = (
+        r"^(?P<indent>[ \t]*)(?P<expr>.+?)"
+        + re.escape(trigger)
+        + key_pattern
+        + r"$"
+    )
+    return re.match(pattern, line_before_cursor)
+
+
+def _valid_postfix_expression(expr: str) -> bool:
+    return bool(expr) and _is_valid_expression(expr)
+
+
+def postfix_completions(
+    line_before_cursor: str,
+    trigger: str,
+    enabled_templates: list[str] | tuple[str, ...],
+) -> list[PostfixCompletion]:
+    """Return postfix template completions for the current line."""
+    match = _match_postfix(line_before_cursor, trigger, key_required=False)
+    if match is None:
+        return []
+
+    expr = match.group("expr").strip()
+    if not _valid_postfix_expression(expr):
+        return []
+
+    prefix = match.group("key") or ""
+    indent = match.group("indent")
+    return [
+        PostfixCompletion(
+            key,
+            prefix,
+            PostfixExpansion(
+                text=indent + POSTFIX_TEMPLATES[key](expr, indent),
+                start_position=-len(line_before_cursor),
+            ),
+        )
+        for key in enabled_templates
+        if key.startswith(prefix) and key in POSTFIX_TEMPLATES
+    ]
+
+
+def expand_postfix(
+    line_before_cursor: str,
+    trigger: str,
+    enabled_templates: list[str] | tuple[str, ...],
+) -> PostfixExpansion | None:
+    """Expand a postfix template in the current line before the cursor."""
+    match = _match_postfix(line_before_cursor, trigger, key_required=True)
+    if match is None:
+        return None
+
+    key = match.group("key")
+    if key not in enabled_templates:
+        return None
+
+    template = POSTFIX_TEMPLATES.get(key)
+    if template is None:
+        return None
+
+    indent = match.group("indent")
+    expr = match.group("expr").strip()
+    if not _valid_postfix_expression(expr):
+        return None
+
+    return PostfixExpansion(
+        text=indent + template(expr, indent),
+        start_position=-len(line_before_cursor),
+    )
+
+
+def postfix_completion(event: KeyPressEvent) -> None:
+    """Expand a postfix template or pass Tab through to normal completion."""
+    shell = get_ipython()
+    document = event.current_buffer.document
+    expansion = expand_postfix(
+        document.current_line_before_cursor,
+        shell.postfix_completion_trigger,
+        shell.postfix_completion_templates,
+    )
+    if expansion is None:
+        pass_through.reply(event)
+        return
+
+    event.current_buffer.delete_before_cursor(-expansion.start_position)
+    event.current_buffer.insert_text(expansion.text)

--- a/tests/test_interactivshell.py
+++ b/tests/test_interactivshell.py
@@ -6,13 +6,18 @@
 import sys
 import unittest
 import os
+from types import SimpleNamespace
 
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 
 
 from IPython.testing import tools as tt
 
-from IPython.terminal.ptutils import _elide, _adjust_completion_text_based_on_context
+from IPython.terminal.ptutils import (
+    IPythonPTCompleter,
+    _adjust_completion_text_based_on_context,
+    _elide,
+)
 from IPython.terminal.shortcuts.auto_suggest import NavigableAutoSuggestFromHistory
 
 
@@ -98,6 +103,92 @@ class TestContextAwareCompletion(unittest.TestCase):
         self.assertEqual(
             _adjust_completion_text_based_on_context("func2", "func1(a=)", 7), "func2"
         )
+
+
+class DummyCompleter:
+    debug = False
+
+    def __init__(self, completions=()):
+        self._completions = completions
+
+    def completions(self, body, offset):
+        return self._completions
+
+
+def test_postfix_prompt_toolkit_completions():
+    ip = get_ipython()
+    old_enabled = ip.postfix_completion
+    old_style = ip.postfix_completion_style
+    old_selected_style = ip.postfix_completion_selected_style
+    try:
+        ip.postfix_completion = True
+        ip.postfix_completion_style = "bg:#111111 #eeeeee"
+        ip.postfix_completion_selected_style = "bg:#222222 #ffffff"
+        completer = IPythonPTCompleter(shell=ip)
+
+        completions = list(
+            completer._get_completions(
+                "x.pri", len("x.pri"), len("x.pri"), DummyCompleter()
+            )
+        )
+
+        assert len(completions) == 1
+        assert completions[0].text == "print(x)"
+        assert completions[0].start_position == -len("x.pri")
+        assert completions[0].display_text == "print"
+        assert completions[0].display_meta_text == "postfix"
+        assert completions[0].style == "bg:#111111 #eeeeee"
+        assert completions[0].selected_style == "bg:#222222 #ffffff"
+    finally:
+        ip.postfix_completion = old_enabled
+        ip.postfix_completion_style = old_style
+        ip.postfix_completion_selected_style = old_selected_style
+
+
+def test_postfix_prompt_toolkit_completions_follow_normal_completions():
+    ip = get_ipython()
+    old_enabled = ip.postfix_completion
+    try:
+        ip.postfix_completion = True
+        completer = IPythonPTCompleter(shell=ip)
+        normal = SimpleNamespace(
+            start=2,
+            end=5,
+            text="private",
+            type="instance",
+            signature="",
+        )
+
+        completions = list(
+            completer._get_completions(
+                "x.pri", len("x.pri"), len("x.pri"), DummyCompleter([normal])
+            )
+        )
+
+        assert [completion.text for completion in completions] == [
+            "private",
+            "print(x)",
+        ]
+    finally:
+        ip.postfix_completion = old_enabled
+
+
+def test_postfix_prompt_toolkit_completions_disabled():
+    ip = get_ipython()
+    old_enabled = ip.postfix_completion
+    try:
+        ip.postfix_completion = False
+        completer = IPythonPTCompleter(shell=ip)
+
+        completions = list(
+            completer._get_completions(
+                "x.pri", len("x.pri"), len("x.pri"), DummyCompleter()
+            )
+        )
+
+        assert completions == []
+    finally:
+        ip.postfix_completion = old_enabled
 
 
 # Decorator for interaction loop tests -----------------------------------------

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -16,6 +16,11 @@ from IPython.terminal.shortcuts.auto_suggest import (
 )
 from IPython.terminal.shortcuts.auto_match import skip_over
 from IPython.terminal.shortcuts import create_ipython_shortcuts, reset_search_buffer
+from IPython.terminal.shortcuts.postfix import (
+    expand_postfix,
+    postfix_completion,
+    postfix_completions,
+)
 from IPython.testing import decorators as dec
 
 from prompt_toolkit.history import InMemoryHistory
@@ -518,3 +523,123 @@ def test_setting_shortcuts_before_pt_app_init():
     ]
     ipython.shortcuts = shortcuts
     assert ipython.shortcuts == shortcuts
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("x.not", "not x"),
+        ("x.par", "(x)"),
+        ("x.return", "return x"),
+        ("x.if", "if x:\n    "),
+        ("x.while", "while x:\n    "),
+        ("x.print", "print(x)"),
+        ("items.len", "len(items)"),
+        ("err.raise", "raise err"),
+        ("x.yield", "yield x"),
+        ("x.str", "str(x)"),
+        ("x.list", "list(x)"),
+        ("x.set", "set(x)"),
+        ("x.dict", "dict(x)"),
+        ("x.tuple", "tuple(x)"),
+        ("    value.if", "    if value:\n        "),
+        ("foo(a + b).print", "print(foo(a + b))"),
+    ],
+)
+def test_postfix_expansion(text, expected):
+    expansion = expand_postfix(
+        text,
+        ".",
+        [
+            "not",
+            "par",
+            "return",
+            "if",
+            "while",
+            "print",
+            "len",
+            "raise",
+            "yield",
+            "str",
+            "list",
+            "set",
+            "dict",
+            "tuple",
+        ],
+    )
+    assert expansion is not None
+    assert expansion.text == expected
+    assert expansion.start_position == -len(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "obj.items",
+        "x = 1.print",
+        "x # comment.print",
+        "'x.print",
+        "# x.print",
+        "x.print",
+        "x.not",
+    ],
+)
+def test_postfix_expansion_rejects_non_matches(text):
+    expansion = expand_postfix(text, ".", ["print"])
+    if text == "x.print":
+        assert expansion is not None
+    else:
+        assert expansion is None
+
+
+def test_postfix_expansion_custom_trigger():
+    expansion = expand_postfix("x!not", "!", ["not"])
+    assert expansion is not None
+    assert expansion.text == "not x"
+    assert expand_postfix("x.not", "!", ["not"]) is None
+
+
+def test_postfix_completions_filter_by_prefix():
+    completions = postfix_completions("x.pri", ".", ["print", "par", "return"])
+    assert [completion.key for completion in completions] == ["print"]
+    assert completions[0].prefix == "pri"
+    assert completions[0].expansion.text == "print(x)"
+    assert completions[0].start_position == -len("x.pri")
+
+
+def test_postfix_completions_empty_prefix():
+    completions = postfix_completions("x.", ".", ["print", "par"])
+    assert [completion.key for completion in completions] == ["print", "par"]
+    assert completions[0].expansion.text == "print(x)"
+    assert completions[0].start_position == -len("x.")
+
+
+def test_postfix_completions_reject_invalid_expression():
+    assert postfix_completions("x = 1.pri", ".", ["print"]) == []
+    assert postfix_completions("x # comment.pri", ".", ["print"]) == []
+
+
+def test_postfix_completion_shortcut_defaults_off(ipython_with_prompt):
+    matched = find_bindings_by_command(postfix_completion)
+    assert len(matched) == 1
+    assert not ipython_with_prompt.postfix_completion
+
+
+def test_postfix_completion_handler_expands(ipython_with_prompt):
+    ipython_with_prompt.postfix_completion = True
+    event = make_event("x.print", len("x.print"), "")
+    event.current_buffer.delete_before_cursor = Mock()
+    event.current_buffer.insert_text = Mock()
+
+    postfix_completion(event)
+
+    event.current_buffer.delete_before_cursor.assert_called_once_with(len("x.print"))
+    event.current_buffer.insert_text.assert_called_once_with("print(x)")
+    ipython_with_prompt.postfix_completion = False
+
+
+def test_postfix_completion_handler_passes_through(ipython_with_prompt):
+    event = make_event("x.unknown", len("x.unknown"), "")
+    with patch("IPython.terminal.shortcuts.postfix.pass_through.reply") as reply:
+        postfix_completion(event)
+    reply.assert_called_once_with(event)


### PR DESCRIPTION
## Summary

This adds opt-in postfix completions to the terminal prompt. The feature is disabled by default and only participates when `TerminalInteractiveShell.postfix_completion` is enabled.

It supports both direct postfix expansion and menu-driven postfix completion:

- `x.print<Tab>` expands to `print(x)`.
- `x.pri<Tab>` can accept the `print` postfix item directly and expand to `print(x)`.
- `x.<Tab>` shows normal attribute/method completions plus available postfix templates.
- Postfix menu entries use configurable prompt_toolkit styles so they can be visually distinguished from regular completions.

Refs #13587

## How to enable

In `ipython_config.py`:

```python
c.TerminalInteractiveShell.postfix_completion = True
```

Optional configuration:

```python
c.TerminalInteractiveShell.postfix_completion_trigger = "."
c.TerminalInteractiveShell.postfix_completion_templates = [
    "not",
    "par",
    "return",
    "if",
    "while",
    "print",
    "len",
    "raise",
    "yield",
    "str",
    "list",
    "set",
    "dict",
    "tuple",
]
c.TerminalInteractiveShell.postfix_completion_style = "bg:#44475a #f8f8f2"
c.TerminalInteractiveShell.postfix_completion_selected_style = "bg:#6272a4 #ffffff"
```

## Supported templates

| Postfix | Example input | Expansion |
| --- | --- | --- |
| `.not` | `x.not` | `not x` |
| `.par` | `x.par` | `(x)` |
| `.return` | `x.return` | `return x` |
| `.if` | `x.if` | `if x:` followed by an indented line |
| `.while` | `x.while` | `while x:` followed by an indented line |
| `.print` | `x.print` | `print(x)` |
| `.len` | `items.len` | `len(items)` |
| `.raise` | `err.raise` | `raise err` |
| `.yield` | `x.yield` | `yield x` |
| `.str` | `x.str` | `str(x)` |
| `.list` | `x.list` | `list(x)` |
| `.set` | `x.set` | `set(x)` |
| `.dict` | `x.dict` | `dict(x)` |
| `.tuple` | `x.tuple` | `tuple(x)` |

## Behavior details

- Postfix expansion only applies to the current input line before the cursor.
- The expression before the postfix trigger must parse as a Python expression.
- Lines containing comments, tokenizer errors, or incomplete expressions are ignored and fall back to normal Tab behavior.
- Normal IPython completions are yielded first; postfix entries are appended after them.
- Selecting a postfix completion from the menu inserts the expanded form immediately, rather than first completing the postfix key and requiring another Tab.
- The trigger is configurable, so users can avoid conflicts with dot-based attribute completion if desired.

## Validation

```bash
python -m pytest tests/test_shortcuts.py tests/test_interactivshell.py tests/test_completer.py -q
```

Result:

```text
374 passed, 3 skipped, 3 xfailed
```
