### PR TITLE
Remove rstvalidator from docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,10 @@ jobs:
         sudo apt-get install graphviz
     - name: Install Python dependencies
       run: |
-        uv pip install --system setuptools coverage rstvalidator
+        uv pip install --system setuptools coverage
         uv pip install --system -r docs/requirements.txt
     - name: Build docs
       run: |
-        python -m rstvalidator long_description.rst
         python tools/fixup_whats_new_pr.py
         make -C docs/ html SPHINXOPTS="-W" \
           PYTHON="coverage run -a" \


### PR DESCRIPTION
rstvalidator has been deleted from PyPI and is no longer needed for
building the documentation.