### PR TITLE
Extract 5 simple test-only commits from #15237 for easier review

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -213,7 +213,7 @@ class TestAudioDataWithNumpy(TestCase):
 
     @skipif_not_numpy
     def test_audio_from_numpy_array_without_rate_raises(self):
-        self.assertRaises(ValueError, display.Audio, get_test_tone())
+        pytest.raises(ValueError, display.Audio, get_test_tone())
 
     @skipif_not_numpy
     def test_audio_data_normalization(self):
@@ -235,12 +235,8 @@ class TestAudioDataWithNumpy(TestCase):
             assert actual_max_value == expected_max_value
 
     def test_audio_data_without_normalization_raises_for_invalid_data(self):
-        self.assertRaises(
-            ValueError, lambda: display.Audio([1.001], rate=44100, normalize=False)
-        )
-        self.assertRaises(
-            ValueError, lambda: display.Audio([-1.001], rate=44100, normalize=False)
-        )
+        pytest.raises(ValueError, display.Audio, [1.001], rate=44100, normalize=False)
+        pytest.raises(ValueError, display.Audio, [-1.001], rate=44100, normalize=False)
 
 
 def simulate_numpy_not_installed():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 from unittest.mock import Mock
 
 from IPython.core import events
@@ -15,68 +15,74 @@ def event_with_argument(argument):
     pass
 
 
-class CallbackTests(unittest.TestCase):
-    def setUp(self):
-        self.em = events.EventManager(
-            get_ipython(),
-            {
-                "ping_received": ping_received,
-                "event_with_argument": event_with_argument,
-            },
-        )
+@pytest.fixture
+def em():
+    return events.EventManager(
+        get_ipython(),
+        {
+            "ping_received": ping_received,
+            "event_with_argument": event_with_argument,
+        },
+    )
 
-    def test_register_unregister(self):
-        cb = Mock()
 
-        self.em.register("ping_received", cb)
-        self.em.trigger("ping_received")
-        self.assertEqual(cb.call_count, 1)
+def test_register_unregister(em):
+    cb = Mock()
 
-        self.em.unregister("ping_received", cb)
-        self.em.trigger("ping_received")
-        self.assertEqual(cb.call_count, 1)
+    em.register("ping_received", cb)
+    em.trigger("ping_received")
+    assert cb.call_count == 1
 
-    def test_bare_function_missed_unregister(self):
-        def cb1():
-            ...
+    em.unregister("ping_received", cb)
+    em.trigger("ping_received")
+    assert cb.call_count == 1
 
-        def cb2():
-            ...
 
-        self.em.register("ping_received", cb1)
-        self.assertRaises(ValueError, self.em.unregister, "ping_received", cb2)
-        self.em.unregister("ping_received", cb1)
+def test_bare_function_missed_unregister(em):
+    def cb1():
+        ...
 
-    def test_cb_error(self):
-        cb = Mock(side_effect=ValueError)
-        self.em.register("ping_received", cb)
-        with tt.AssertPrints("Error in callback"):
-            self.em.trigger("ping_received")
+    def cb2():
+        ...
 
-    def test_cb_keyboard_interrupt(self):
-        cb = Mock(side_effect=KeyboardInterrupt)
-        self.em.register("ping_received", cb)
-        with tt.AssertPrints("Error in callback"):
-            self.em.trigger("ping_received")
+    em.register("ping_received", cb1)
+    with pytest.raises(ValueError):
+        em.unregister("ping_received", cb2)
+    em.unregister("ping_received", cb1)
 
-    def test_unregister_during_callback(self):
-        invoked = [False] * 3
 
-        def func1(*_):
-            invoked[0] = True
-            self.em.unregister("ping_received", func1)
-            self.em.register("ping_received", func3)
+def test_cb_error(em):
+    cb = Mock(side_effect=ValueError)
+    em.register("ping_received", cb)
+    with tt.AssertPrints("Error in callback"):
+        em.trigger("ping_received")
 
-        def func2(*_):
-            invoked[1] = True
-            self.em.unregister("ping_received", func2)
 
-        def func3(*_):
-            invoked[2] = True
+def test_cb_keyboard_interrupt(em):
+    cb = Mock(side_effect=KeyboardInterrupt)
+    em.register("ping_received", cb)
+    with tt.AssertPrints("Error in callback"):
+        em.trigger("ping_received")
 
-        self.em.register("ping_received", func1)
-        self.em.register("ping_received", func2)
 
-        self.em.trigger("ping_received")
-        self.assertEqual([True, True, False], invoked)
-        self.assertEqual([func3], self.em.callbacks["ping_received"])
+def test_unregister_during_callback(em):
+    invoked = [False] * 3
+
+    def func1(*_):
+        invoked[0] = True
+        em.unregister("ping_received", func1)
+        em.register("ping_received", func3)
+
+    def func2(*_):
+        invoked[1] = True
+        em.unregister("ping_received", func2)
+
+    def func3(*_):
+        invoked[2] = True
+
+    em.register("ping_received", func1)
+    em.register("ping_received", func2)
+
+    em.trigger("ping_received")
+    assert [True, True, False] == invoked
+    assert [func3] == em.callbacks["ping_received"]

--- a/tests/test_inputtransformer2_line.py
+++ b/tests/test_inputtransformer2_line.py
@@ -21,10 +21,8 @@ get_ipython().run_cell_magic('foo', 'arg', 'body 1\\nbody 2\\n')
 
 
 def test_cell_magic():
-    for sample, expected in [CELL_MAGIC]:
-        assert ipt2.cell_magic(sample.splitlines(keepends=True)) == expected.splitlines(
-            keepends=True
-        )
+    sample, expected = CELL_MAGIC
+    assert ipt2.cell_magic(sample.splitlines(keepends=True)) == expected.splitlines(keepends=True)
 
 
 CLASSIC_PROMPT = (
@@ -99,19 +97,17 @@ CLASSIC_PROMPT_STANDALONE_CONTINUATION = (
 )
 
 
-def test_classic_prompt():
-    for sample, expected in [
-        CLASSIC_PROMPT,
-        CLASSIC_PROMPT_L2,
-        CLASSIC_PROMPT_L3,
-        CLASSIC_PROMPT_DEDENT_SINGLE_LINE,
-        CLASSIC_PROMPT_DEDENT_LEADING_WS,
-        CLASSIC_PROMPT_MULTILINE_DOCTEST,
-        CLASSIC_PROMPT_STANDALONE_CONTINUATION,
-    ]:
-        assert ipt2.classic_prompt(
-            sample.splitlines(keepends=True)
-        ) == expected.splitlines(keepends=True)
+@pytest.mark.parametrize("sample,expected", [
+    CLASSIC_PROMPT,
+    CLASSIC_PROMPT_L2,
+    CLASSIC_PROMPT_L3,
+    CLASSIC_PROMPT_DEDENT_SINGLE_LINE,
+    CLASSIC_PROMPT_DEDENT_LEADING_WS,
+    CLASSIC_PROMPT_MULTILINE_DOCTEST,
+    CLASSIC_PROMPT_STANDALONE_CONTINUATION,
+])
+def test_classic_prompt(sample, expected):
+    assert ipt2.classic_prompt(sample.splitlines(keepends=True)) == expected.splitlines(keepends=True)
 
 
 IPYTHON_PROMPT = (
@@ -170,16 +166,14 @@ def a():
 )
 
 
-def test_ipython_prompt():
-    for sample, expected in [
-        IPYTHON_PROMPT,
-        IPYTHON_PROMPT_L2,
-        IPYTHON_PROMPT_VI_INS,
-        IPYTHON_PROMPT_VI_NAV,
-    ]:
-        assert ipt2.ipython_prompt(
-            sample.splitlines(keepends=True)
-        ) == expected.splitlines(keepends=True)
+@pytest.mark.parametrize("sample,expected", [
+    IPYTHON_PROMPT,
+    IPYTHON_PROMPT_L2,
+    IPYTHON_PROMPT_VI_INS,
+    IPYTHON_PROMPT_VI_NAV,
+])
+def test_ipython_prompt(sample, expected):
+    assert ipt2.ipython_prompt(sample.splitlines(keepends=True)) == expected.splitlines(keepends=True)
 
 
 INDENT_SPACES = (
@@ -205,11 +199,9 @@ if True:
 )
 
 
-def test_leading_indent():
-    for sample, expected in [INDENT_SPACES, INDENT_TABS]:
-        assert ipt2.leading_indent(
-            sample.splitlines(keepends=True)
-        ) == expected.splitlines(keepends=True)
+@pytest.mark.parametrize("sample,expected", [INDENT_SPACES, INDENT_TABS])
+def test_leading_indent(sample, expected):
+    assert ipt2.leading_indent(sample.splitlines(keepends=True)) == expected.splitlines(keepends=True)
 
 
 INDENT_SPACES_COMMENT = (
@@ -292,16 +284,14 @@ ONLY_EMPTY_LINES = (
 )
 
 
-def test_leading_empty_lines():
-    for sample, expected in [LEADING_EMPTY_LINES, ONLY_EMPTY_LINES]:
-        assert ipt2.leading_empty_lines(
-            sample.splitlines(keepends=True)
-        ) == expected.splitlines(keepends=True)
+@pytest.mark.parametrize("sample,expected", [LEADING_EMPTY_LINES, ONLY_EMPTY_LINES])
+def test_leading_empty_lines(sample, expected):
+    assert ipt2.leading_empty_lines(sample.splitlines(keepends=True)) == expected.splitlines(keepends=True)
 
 
 CRLF_MAGIC = (["%%ls\r\n"], ["get_ipython().run_cell_magic('ls', '', '')\n"])
 
 
 def test_crlf_magic():
-    for sample, expected in [CRLF_MAGIC]:
-        assert ipt2.cell_magic(sample) == expected
+    sample, expected = CRLF_MAGIC
+    assert ipt2.cell_magic(sample) == expected

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -11,9 +11,6 @@ import pytest
 import types
 import string
 import sys
-import unittest
-
-import pytest
 
 from IPython.lib import pretty
 
@@ -220,44 +217,30 @@ class SB(SA):
     pass
 
 
-class TestsPretty(unittest.TestCase):
-    def test_super_repr(self):
-        # "<super: module_name.SA, None>"
-        output = pretty.pretty(super(SA))
-        self.assertRegex(output, r"<super: \S+.SA, None>")
+def test_super_repr():
+    import re
+    output = pretty.pretty(super(SA))
+    assert re.search(r"<super: \S+.SA, None>", output)
 
-        # "<super: module_name.SA, <module_name.SB at 0x...>>"
-        sb = SB()
-        output = pretty.pretty(super(SA, sb))
-        self.assertRegex(output, r"<super: \S+.SA,\s+<\S+.SB at 0x\S+>>")
+    sb = SB()
+    output = pretty.pretty(super(SA, sb))
+    assert re.search(r"<super: \S+.SA,\s+<\S+.SB at 0x\S+>>", output)
 
-    def test_long_list(self):
-        lis = list(range(10000))
-        p = pretty.pretty(lis)
-        last2 = p.rsplit("\n", 2)[-2:]
-        self.assertEqual(last2, [" 999,", " ...]"])
 
-    def test_long_set(self):
-        s = set(range(10000))
-        p = pretty.pretty(s)
-        last2 = p.rsplit("\n", 2)[-2:]
-        self.assertEqual(last2, [" 999,", " ...}"])
+@pytest.mark.parametrize("obj,expected_last2", [
+    (list(range(10000)), [" 999,", " ...]"]),
+    (set(range(10000)), [" 999,", " ...}"]),
+    (tuple(range(10000)), [" 999,", " ...)"]),
+    ({n: n for n in range(10000)}, [" 999: 999,", " ...}"]),
+])
+def test_long_collection_repr(obj, expected_last2):
+    p = pretty.pretty(obj)
+    assert p.rsplit("\n", 2)[-2:] == expected_last2
 
-    def test_long_tuple(self):
-        tup = tuple(range(10000))
-        p = pretty.pretty(tup)
-        last2 = p.rsplit("\n", 2)[-2:]
-        self.assertEqual(last2, [" 999,", " ...)"])
 
-    def test_long_dict(self):
-        d = {n: n for n in range(10000)}
-        p = pretty.pretty(d)
-        last2 = p.rsplit("\n", 2)[-2:]
-        self.assertEqual(last2, [" 999: 999,", " ...}"])
-
-    def test_unbound_method(self):
-        output = pretty.pretty(MyObj.somemethod)
-        self.assertIn("MyObj.somemethod", output)
+def test_unbound_method():
+    output = pretty.pretty(MyObj.somemethod)
+    assert "MyObj.somemethod" in output
 
 
 class MetaClass(type):

--- a/tests/test_pylabtools.py
+++ b/tests/test_pylabtools.py
@@ -129,21 +129,21 @@ def test_select_figure_formats_kwargs():
     assert png_bytes.startswith(_PNG)
 
 
-def test_select_figure_formats_set():
+@pytest.mark.parametrize("fmts", [
+    {"png", "svg"},
+    ["png"],
+    ("jpeg", "pdf", "retina"),
+    {"svg"},
+])
+def test_select_figure_formats_set(fmts):
     ip = get_ipython()
-    for fmts in [
-        {"png", "svg"},
-        ["png"],
-        ("jpeg", "pdf", "retina"),
-        {"svg"},
-    ]:
-        active_mimes = {_fmt_mime_map[fmt] for fmt in fmts}
-        pt.select_figure_formats(ip, fmts)
-        for mime, f in ip.display_formatter.formatters.items():
-            if mime in active_mimes:
-                assert Figure in f
-            else:
-                assert Figure not in f
+    active_mimes = {_fmt_mime_map[fmt] for fmt in fmts}
+    pt.select_figure_formats(ip, fmts)
+    for mime, f in ip.display_formatter.formatters.items():
+        if mime in active_mimes:
+            assert Figure in f
+        else:
+            assert Figure not in f
 
 
 def test_select_figure_formats_bad():
@@ -301,9 +301,9 @@ def test_backend_module_name_case_sensitive(shell_pylab_fixture):
         s.run_line_magic("matplotlib", some_uppercase)
 
 
-def test_no_gui_backends():
-    for k in ["agg", "svg", "pdf", "ps"]:
-        assert k not in pt.backend2gui
+@pytest.mark.parametrize("backend", ["agg", "svg", "pdf", "ps"])
+def test_no_gui_backends(backend):
+    assert backend not in pt.backend2gui
 
 
 def test_figure_no_canvas():


### PR DESCRIPTION
## Summary

#15237 is an 81-commit, 156-file modernization sweep, which makes it hard to review as a whole. This PR cherry-picks 5 small, self-contained, test-only commits from that branch — each touches exactly one test file, makes no production-code changes, and applies cleanly on top of current `main`.

Commits included (smallest to largest diff):

- `tests: modernize test_display.py - replace self.assertRaises with pytest.raises` — replace `self.assertRaises` with `pytest.raises` in `TestAudioDataWithNumpy`
- `tests: parametrize test_pylabtools.py figure format and backend tests` — convert two for-loop test bodies to `@pytest.mark.parametrize`
- `tests: parametrize test_inputtransformer2_line.py transformer tests` — convert for-loop test patterns to `@pytest.mark.parametrize`, unwrap single-item loops
- `tests: convert test_pretty.py TestsPretty to pytest with parametrize` — replace the `TestsPretty(unittest.TestCase)` class with plain functions, parametrize the long-collection tests
- `tests: convert test_events.py to pytest fixtures` — replace `unittest.TestCase` `setUp` with a `@pytest.fixture` for the `EventManager`

All are part of the broader pytest-migration effort described in #15237's summary but can be reviewed and merged independently of the rest of that PR.

## Test plan

- [x] `python -m pytest tests/test_events.py tests/test_pretty.py tests/test_inputtransformer2_line.py tests/test_display.py tests/test_pylabtools.py -q` — 95 passed, 13 skipped


---
_Generated by [Claude Code](https://claude.ai/code/session_01HCVaHvbee2Xs6eVAd8USMa)_