### PR TITLE
Configure Codecov to wait for all CI builds before notifying

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,6 +36,12 @@ flag_management:
 codecov:
   require_ci_to_pass: false
   branch: main
+  notify:
+    # Number of coverage reports uploaded by the "test" job matrix in
+    # .github/workflows/test.yml (one per matrix combination that runs
+    # with --cov). Update this if the matrix changes.
+    after_n_builds: 11
+    wait_for_ci: true
 
 ignore:
   - IPython/kernel/*


### PR DESCRIPTION
## Summary
Updated the Codecov configuration to wait for all CI builds to complete before sending coverage notifications.

## Changes
- Added `notify` section to the Codecov configuration with:
  - `after_n_builds: 11` - Specifies that Codecov should wait for 11 coverage reports (matching the number of test job matrix combinations that run with `--cov` in `.github/workflows/test.yml`)
  - `wait_for_ci: true` - Enables waiting for all CI checks to pass before notifying
  - Added documentation comment explaining the purpose and maintenance requirement of the `after_n_builds` value

## Details
This change ensures that Codecov notifications are only sent after all test matrix combinations have completed and uploaded their coverage reports, preventing premature or incomplete coverage notifications. The `after_n_builds` value should be updated if the test matrix configuration changes in the future.

https://claude.ai/code/session_016GWe5bRe6Sjt77fW7UoH8G