### PR TITLE
Narrow bare except: clauses (extracted from #15237)

### DIFF
--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -260,7 +260,7 @@ class BaseIPythonApplication(Application):
         # ensure current working directory exists
         try:
             os.getcwd()
-        except:
+        except OSError:
             # exit if cwd doesn't exist
             self.log.error("Current working directory doesn't exist.")
             self.exit(1)

--- a/IPython/core/crashhandler.py
+++ b/IPython/core/crashhandler.py
@@ -191,7 +191,7 @@ class CrashHandler:
         # and generate a complete report on disk
         try:
             report = open(report_name, "w", encoding="utf-8")
-        except:
+        except OSError:
             print('Could not create crash report on disk.', file=sys.stderr)
             return
 
@@ -220,7 +220,7 @@ class CrashHandler:
             rpt_add("Application name: %s\n\n" % self.app.name)
             rpt_add("Current user configuration structure:\n\n")
             rpt_add(config)
-        except:
+        except Exception:
             pass
         rpt_add(sec_sep+'Crash traceback:\n\n' + traceback)
 

--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -325,7 +325,7 @@ class ModuleReloader:
                         superreload(m, reload, self.old_objects)
                     if py_filename in self.failed:
                         del self.failed[py_filename]
-                except:
+                except Exception:
                     if not self.hide_errors:
                         logger = logging.getLogger("autoreload")
                         logger.exception(
@@ -577,7 +577,7 @@ def superreload(
 
     try:
         module = reload(module)
-    except:
+    except Exception:
         # restore module dictionary on failed reload
         module.__dict__.update(old_dict)
         raise
@@ -845,7 +845,7 @@ class AutoreloadMagics(Magics):
         if self._reloader.enabled:
             try:
                 self._reloader.check()
-            except:
+            except Exception:
                 pass
 
     def post_execute_hook(self):

--- a/IPython/lib/backgroundjobs.py
+++ b/IPython/lib/backgroundjobs.py
@@ -402,7 +402,7 @@ class BackgroundJobBase(threading.Thread):
         # make a new one
         try:
             make_tb = get_ipython().InteractiveTB.text
-        except:
+        except Exception:
             make_tb = AutoFormattedTB(
                 mode="Context", color_scheme="nocolor", tb_offset=1
             ).text
@@ -429,7 +429,7 @@ class BackgroundJobBase(threading.Thread):
             self.status    = BackgroundJobBase.stat_running
             self.stat_code = BackgroundJobBase.stat_running_c
             self.result    = self.call()
-        except:
+        except Exception:
             self.status    = BackgroundJobBase.stat_dead
             self.stat_code = BackgroundJobBase.stat_dead_c
             self.finished  = None

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -185,7 +185,7 @@ def get_home_dir(require_writable: bool=False) -> str:
                 r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
             ) as key:
                 homedir = wreg.QueryValueEx(key,'Personal')[0]
-        except:
+        except Exception:
             pass
 
     if (not require_writable) or _writable_dir(homedir):
@@ -323,7 +323,7 @@ def link_or_copy(src, dst):
         new_dst = dst + "-temp-%04X" %(random.randint(1, 16**4), )
         try:
             link_or_copy(src, new_dst)
-        except:
+        except Exception:
             try:
                 os.remove(new_dst)
             except OSError:


### PR DESCRIPTION
## Summary

This extracts just the bare `except:` narrowing commits from #15237, which bundles a much larger set of typing/test/pytest changes. Splitting these out so they can be reviewed and merged independently.

Bare `except:` clauses silently swallow everything, including `KeyboardInterrupt` and `SystemExit`. This narrows them to the specific exceptions that can actually occur at each call site:

- `IPython/extensions/autoreload.py`, `IPython/lib/backgroundjobs.py`, `IPython/utils/path.py`: bare `except:` → `except Exception:` around reload/traceback-handler/homedir-lookup/copy-fallback logic.
- `IPython/core/application.py`: `os.getcwd()` → `except OSError:` (only OS-level errors possible here).
- `IPython/core/crashhandler.py`: `open()` → `except OSError:`; config `pformat` → `except Exception:`.

Note: #15237's description also mentions bare-except cleanup in `oinspect.py`, `completer.py`, `page.py`, `magics/execution.py`, `tbtools.py`, `shellapp.py`, and `interactiveshell.py`, but I found no such changes in its actual commits for those files (bare `except:` still exists unmodified in `interactiveshell.py` on that branch, and the others have none to begin with). This PR contains only the bare-except changes that are actually present in #15237.
