### PR TITLE
Fix codecov.yml configuration syntax errors

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,14 +15,17 @@ coverage:
           - '**/tests/**'
           - '**/testing/**'
         threshold: 0.2%
+# Note: an invalid codecov.yml is silently ignored (Codecov falls back to
+# defaults, e.g. notifying before all reports are in). Check changes with:
+#   curl --data-binary @codecov.yml https://codecov.io/validate
 flag_management:
   default_rules:
     statuses:
       - type: patch
-        target: auto%
+        target: auto
         threshold: 0.2%
       - type: project
-        target: auto%
+        target: auto
         threshold: 0.2%
   individual_flags:
     - name: unit-tests


### PR DESCRIPTION
## Summary
Fixed invalid syntax in codecov.yml configuration file and added documentation about validation.

## Key Changes
- Removed invalid `%` suffix from `target: auto%` values in flag_management status rules (changed to `target: auto`)
- Added comment documenting that invalid codecov.yml configurations are silently ignored by Codecov and fall back to defaults
- Included validation command in comments for developers to check codecov.yml changes

## Implementation Details
The `target` field in Codecov status rules should use `auto` without the percent sign. The percent sign was causing invalid configuration that would be silently ignored, potentially leading to unexpected behavior where Codecov would use default notification settings instead of the intended configuration.

https://claude.ai/code/session_01QgJD1PG9byAXXf32Z1kSXV