### PR TITLE
Refactor autogen scripts to use main() function pattern

### DIFF
--- a/docs/autogen_api.py
+++ b/docs/autogen_api.py
@@ -15,7 +15,7 @@ from apigen import ApiDocWriter
 source = pjoin(here, 'source')
 
 #*****************************************************************************
-if __name__ == '__main__':
+def main():
     package = 'IPython'
     outdir = pjoin(source, 'api', 'generated')
     docwriter = ApiDocWriter(package,rst_extension='.rst')
@@ -63,3 +63,7 @@ if __name__ == '__main__':
                           relative_to = pjoin(source, 'api')
                           )
     print ('%d files written' % len(docwriter.written_modules))
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -111,8 +111,12 @@ def write_doc(name, title, app, preamble=None):
             f.write('\n')
 
 
-if __name__ == '__main__':
+def main():
     # Touch this file for the make target
     Path(generated).write_text("", encoding="utf-8")
 
     write_doc('terminal', 'Terminal IPython options', TerminalIPythonApp())
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/autogen_magics.py
+++ b/docs/autogen_magics.py
@@ -4,8 +4,6 @@ from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.magic import MagicAlias
 from IPython.utils.text import dedent, indent
 
-shell = InteractiveShell.instance()
-magics = shell.magics_manager.magics
 
 def _strip_underline(line):
     chars = set(line.strip())
@@ -22,45 +20,54 @@ def format_docstring(func):
     lines = [_strip_underline(l) for l in docstring.splitlines()]
     return "\n".join(lines)
 
-output = [
-"Line magics",
-"===========",
-"",
-]
-
 # Case insensitive sort by name
 def sortkey(s): return s[0].lower()
 
-for name, func in sorted(magics["line"].items(), key=sortkey):
-    if isinstance(func, Alias) or isinstance(func, MagicAlias):
-        # Aliases are magics, but shouldn't be documented here
-        # Also skip aliases to other magics
-        continue
-    output.extend([".. magic:: {}".format(name),
-                   "",
-                   format_docstring(func),
-                   ""])
 
-output.extend([
-"Cell magics",
-"===========",
-"",
-])
+def main():
+    shell = InteractiveShell.instance()
+    magics = shell.magics_manager.magics
 
-for name, func in sorted(magics["cell"].items(), key=sortkey):
-    if name == "!":
-        # Special case - don't encourage people to use %%!
-        continue
-    if func == magics["line"].get(name, "QQQP"):
-        # Don't redocument line magics that double as cell magics
-        continue
-    if isinstance(func, MagicAlias):
-        continue
-    output.extend([".. cellmagic:: {}".format(name),
-                   "",
-                   format_docstring(func),
-                   ""])
+    output = [
+        "Line magics",
+        "===========",
+        "",
+    ]
 
-src_path = Path(__file__).parent
-dest = src_path.joinpath("source", "interactive", "magics-generated.txt")
-dest.write_text("\n".join(output), encoding="utf-8")
+    for name, func in sorted(magics["line"].items(), key=sortkey):
+        if isinstance(func, Alias) or isinstance(func, MagicAlias):
+            # Aliases are magics, but shouldn't be documented here
+            # Also skip aliases to other magics
+            continue
+        output.extend([".. magic:: {}".format(name),
+                       "",
+                       format_docstring(func),
+                       ""])
+
+    output.extend([
+        "Cell magics",
+        "===========",
+        "",
+    ])
+
+    for name, func in sorted(magics["cell"].items(), key=sortkey):
+        if name == "!":
+            # Special case - don't encourage people to use %%!
+            continue
+        if func == magics["line"].get(name, "QQQP"):
+            # Don't redocument line magics that double as cell magics
+            continue
+        if isinstance(func, MagicAlias):
+            continue
+        output.extend([".. cellmagic:: {}".format(name),
+                       "",
+                       format_docstring(func),
+                       ""])
+
+    src_path = Path(__file__).parent
+    dest = src_path.joinpath("source", "interactive", "magics-generated.txt")
+    dest.write_text("\n".join(output), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/autogen_shortcuts.py
+++ b/docs/autogen_shortcuts.py
@@ -182,7 +182,11 @@ def format_prompt_keys(keys: str, add_alternatives=True) -> str:
     return result
 
 
-if __name__ == "__main__":
+def _sort_key(binding: Binding):
+    return binding.handler.identifier, binding.shortcut.filter
+
+
+def main():
     here = Path(__file__).parent
     dest = here / "source" / "config" / "shortcuts"
 
@@ -197,12 +201,8 @@ if __name__ == "__main__":
 
     bindings = bindings_from_prompt_toolkit(prompt_bindings)
 
-    def sort_key(binding: Binding):
-        return binding.handler.identifier, binding.shortcut.filter
-
-    filters = []
     with (dest / "table.tsv").open("w", encoding="utf-8") as csv:
-        for binding in sorted(bindings, key=sort_key):
+        for binding in sorted(bindings, key=_sort_key):
             sequence = ", ".join(
                 [format_prompt_keys(keys) for keys in binding.shortcut.keys_sequence]
             )
@@ -223,3 +223,7 @@ if __name__ == "__main__":
                 )
                 + "\n"
             )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Refactored four documentation autogeneration scripts to follow the standard Python pattern of wrapping executable code in a `main()` function and calling it from an `if __name__ == "__main__":` guard.

## Key Changes
- **docs/autogen_magics.py**: Moved all module-level code into a `main()` function, including shell initialization and output generation logic
- **docs/autogen_shortcuts.py**: Extracted `sort_key()` function to module-level as `_sort_key()` and wrapped the main execution logic in a `main()` function
- **docs/autogen_api.py**: Moved the main execution block into a `main()` function
- **docs/autogen_config.py**: Moved the main execution block into a `main()` function

## Implementation Details
- All scripts now follow the standard Python entry point pattern with `if __name__ == "__main__": main()`
- This change improves code organization and allows these modules to be imported without executing their side effects
- The `_sort_key()` function in autogen_shortcuts.py was made module-level (with underscore prefix to indicate internal use) to avoid redefining it on each iteration
- No functional changes to the actual logic or output of any script

https://claude.ai/code/session_018nNby6984MKmWHxWxkftUk