### PR TITLE
Modernize remaining type annotations

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -203,7 +203,6 @@ from types import SimpleNamespace
 from typing import (
     Union,
     Any,
-    Optional,
     TYPE_CHECKING,
     TypeVar,
     Literal,

--- a/IPython/core/completerlib.py
+++ b/IPython/core/completerlib.py
@@ -36,8 +36,6 @@ from ..utils._process_common import arg_split
 # FIXME: this should be pulled in with the right call via the component system
 from IPython import get_ipython
 
-from typing import List
-
 #-----------------------------------------------------------------------------
 # Globals and constants
 #-----------------------------------------------------------------------------

--- a/IPython/core/crashhandler.py
+++ b/IPython/core/crashhandler.py
@@ -32,7 +32,6 @@ from IPython.utils.sysinfo import sys_info
 
 from IPython.core.release import __version__ as version
 
-from typing import Optional, Dict
 import types
 
 #-----------------------------------------------------------------------------

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from os.path import splitext
 from pathlib import Path, PurePath
 
-from typing import Optional, TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Self
 
 from IPython.testing.skipdoctest import skip_doctest
 from . import display_functions

--- a/IPython/core/doctb.py
+++ b/IPython/core/doctb.py
@@ -3,7 +3,7 @@ import linecache
 import sys
 from collections.abc import Sequence
 from types import TracebackType
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Callable
 
 import stack_data

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -6,7 +6,6 @@ from typing import (
     Literal,
     NamedTuple,
     NewType,
-    Optional,
     Protocol,
     TypeGuard,
     Union,

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -15,7 +15,7 @@ from codeop import CommandCompiler, Compile
 import re
 import sys
 import tokenize
-from typing import List, Tuple, Optional, Any
+from typing import Any
 import warnings
 from textwrap import dedent
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -34,7 +34,7 @@ from io import open as io_open
 from logging import error
 from pathlib import Path
 from collections.abc import Callable
-from typing import List as ListType, Any as AnyType
+from typing import Any as AnyType
 from typing import Literal
 from collections.abc import Sequence
 from warnings import warn
@@ -1661,7 +1661,7 @@ class InteractiveShell(SingletonConfigurable):
     # Things related to object introspection
     #-------------------------------------------------------------------------
     @staticmethod
-    def _find_parts(oname: str) -> tuple[bool, ListType[str]]:
+    def _find_parts(oname: str) -> tuple[bool, list[str]]:
         """
         Given an object name, return a list of parts of this object name.
 
@@ -3619,7 +3619,7 @@ class InteractiveShell(SingletonConfigurable):
 
     async def run_ast_nodes(
         self,
-        nodelist: ListType[stmt],
+        nodelist: list[stmt],
         cell_name: str,
         interactivity="last_expr",
         compiler=compile,

--- a/IPython/core/kitty.py
+++ b/IPython/core/kitty.py
@@ -2,7 +2,6 @@
 
 from base64 import b64encode, b64decode
 import sys
-from typing import Union
 
 def _supports_kitty_graphics() -> bool:
     import platform

--- a/IPython/core/magics/ast_mod.py
+++ b/IPython/core/magics/ast_mod.py
@@ -192,8 +192,6 @@ from ast import (
 import ast
 import copy
 
-from typing import Dict, Optional, Union
-
 
 mangle_all = lambda name: False if name in ("__ret__", "__code__") else True
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -18,7 +18,7 @@ import shlex
 import sys
 import time
 import timeit
-from typing import Dict, Any
+from typing import Any
 from ast import (
     Module,
 )

--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -13,8 +13,6 @@ from ..paths import get_ipython_package_dir
 from ..utils.path import expand_path, ensure_dir_exists
 from traitlets import Unicode, Bool, observe
 
-from typing import Optional
-
 #-----------------------------------------------------------------------------
 # Module errors
 #-----------------------------------------------------------------------------

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -5,7 +5,7 @@ import sys
 import types
 import warnings
 from types import TracebackType
-from typing import Any, Optional, Tuple
+from typing import Any
 from collections.abc import Callable
 
 import stack_data

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -75,7 +75,7 @@ import types
 import warnings
 from collections.abc import Sequence
 from types import TracebackType
-from typing import Any, Optional
+from typing import Any
 from collections.abc import Callable
 
 import stack_data

--- a/IPython/external/__init__.py
+++ b/IPython/external/__init__.py
@@ -2,6 +2,4 @@
 This package contains all third-party modules bundled with IPython.
 """
 
-from typing import List
-
 __all__: list[str] = []

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -8,7 +8,6 @@ from os import walk, sep, fsdecode
 
 from IPython.core.display import DisplayObject, TextDisplayObject
 
-from typing import Tuple, Optional
 from collections.abc import Iterable
 
 __all__ = ['Audio', 'IFrame', 'YouTubeVideo', 'VimeoVideo', 'ScribdDocument',

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -104,8 +104,6 @@ from collections import deque
 from inspect import signature
 from io import StringIO
 
-from typing import Dict
-
 # Allow pretty-printing of functions with PEP-649 annotations
 if sys.version_info >= (3, 14):
     from annotationlib import Format

--- a/IPython/sphinxext/ipython_directive.py
+++ b/IPython/sphinxext/ipython_directive.py
@@ -195,7 +195,7 @@ import ast
 import warnings
 import shutil
 from io import StringIO
-from typing import Any, Dict, Set
+from typing import Any
 
 # Third-party
 from docutils.parsers.rst import directives

--- a/IPython/terminal/embed.py
+++ b/IPython/terminal/embed.py
@@ -18,8 +18,6 @@ from IPython.terminal.ipapp import load_default_config
 from traitlets import Bool, CBool, Unicode
 from IPython.utils.io import ask_yes_no
 
-from typing import Set
-
 
 class _EmbedGlobals(dict):
     """Globals namespace for an embedded shell.

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -4,7 +4,6 @@ import os
 import sys
 import inspect
 from warnings import warn
-from typing import Union as UnionType, Optional
 
 from IPython.core.async_helpers import get_asyncio_loop
 from IPython.core.interactiveshell import InteractiveShell, InteractiveShellABC
@@ -220,12 +219,10 @@ class TerminalInteractiveShell(InteractiveShell):
         "menus, decrease for short and wide.",
     ).tag(config=True)
 
-    pt_app: UnionType[PromptSession, None] = None
-    auto_suggest: UnionType[
-        AutoSuggestFromHistory,
-        NavigableAutoSuggestFromHistory,
-        None,
-    ] = None
+    pt_app: PromptSession | None = None
+    auto_suggest: (
+        AutoSuggestFromHistory | NavigableAutoSuggestFromHistory | None
+    ) = None
     debugger_history = None
 
     debugger_history_file = Unicode(

--- a/IPython/terminal/prompts.py
+++ b/IPython/terminal/prompts.py
@@ -8,7 +8,7 @@ from IPython.core.displayhook import DisplayHook
 from prompt_toolkit.formatted_text import fragment_list_width, PygmentsTokens
 from prompt_toolkit.shortcuts import print_formatted_text
 from prompt_toolkit.enums import EditingMode
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from IPython.terminal.interactiveshell import TerminalInteractiveShell

--- a/IPython/terminal/pt_inputhooks/__init__.py
+++ b/IPython/terminal/pt_inputhooks/__init__.py
@@ -1,6 +1,5 @@
 import importlib
 import os
-from typing import Tuple
 from collections.abc import Callable
 
 aliases = {

--- a/IPython/terminal/shortcuts/__init__.py
+++ b/IPython/terminal/shortcuts/__init__.py
@@ -11,7 +11,7 @@ import signal
 import sys
 import warnings
 from dataclasses import dataclass
-from typing import Any, Optional, List
+from typing import Any
 from collections.abc import Callable
 
 from prompt_toolkit.application.current import get_app

--- a/IPython/terminal/shortcuts/filters.py
+++ b/IPython/terminal/shortcuts/filters.py
@@ -9,7 +9,6 @@ import ast
 import re
 import signal
 import sys
-from typing import Optional, Dict, Union
 from collections.abc import Callable
 
 from prompt_toolkit.application.current import get_app

--- a/IPython/testing/decorators.py
+++ b/IPython/testing/decorators.py
@@ -9,7 +9,6 @@ import pytest
 # Expose the unittest-driven decorators
 from .ipunittest import ipdoctest, ipdocstring
 from _pytest.mark.structures import MarkDecorator
-from typing import Optional
 
 def skipif(skip_condition: bool, msg: str | None=None) -> MarkDecorator:
     """Make function raise SkipTest exception if skip_condition is true

--- a/IPython/testing/tools.py
+++ b/IPython/testing/tools.py
@@ -29,7 +29,6 @@ from IPython.utils.encoding import DEFAULT_ENCODING
 from . import decorators as dec
 from . import skipdoctest
 from types import TracebackType
-from typing import List, Optional, Tuple, Type
 
 
 # The docstring for full_path doctests differently on win32 (different path

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -5,7 +5,7 @@ import token
 import tokenize
 import warnings
 from io import StringIO
-from typing import Any, Type, TypeAlias
+from typing import Any, TypeAlias
 
 import pygments
 from pygments.formatters.terminal256 import Terminal256Formatter

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -18,7 +18,7 @@ import os
 import shlex
 import subprocess
 import sys
-from typing import IO, List, TypeVar, Union
+from typing import IO, TypeVar
 from collections.abc import Callable
 
 _T = TypeVar("_T")

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -13,7 +13,6 @@ from ctypes.wintypes import HLOCAL, LPCWSTR
 from subprocess import STDOUT
 from threading import Thread
 from types import TracebackType
-from typing import List, Optional
 
 from ._process_common import arg_split as py_arg_split
 

--- a/IPython/utils/capture.py
+++ b/IPython/utils/capture.py
@@ -7,7 +7,7 @@
 import sys
 from io import StringIO
 from types import TracebackType
-from typing import Any, List, Optional, Type
+from typing import Any
 
 #-----------------------------------------------------------------------------
 # Classes and functions

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from .capture import CapturedIO, capture_output
 from io import StringIO
-from typing import Union
 
 
 class Tee:

--- a/IPython/utils/tempdir.py
+++ b/IPython/utils/tempdir.py
@@ -9,7 +9,6 @@ from io import BufferedWriter
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import TracebackType
-from typing import Optional, Type
 
 
 class NamedFileInTemporaryDirectory:


### PR DESCRIPTION
## Summary

A small, focused cleanup of the remaining type-annotation modernization on `main`. Most annotation bodies were already converted to PEP 604 / builtin generics in a prior pass; what was left were leftover unused `typing` imports and a couple of genuine old-style conversions. The net result is small and safe (32 files, +19/−46).

## What this PR does

**Remove now-unused deprecated `typing` imports** (`Optional`, `Union`, `List`, `Dict`, `Tuple`, `Type`, `Set`) across 32 files. These import lines were the leftover tails after the annotations themselves were already converted to PEP 604 / builtin generics. Removing them clears **53 ruff `F401` warnings**.

**Convert the few genuine remaining old-style annotations:**
- `core/interactiveshell.py`: `typing.List[...]` (imported as `ListType`) → `list[...]`
- `terminal/interactiveshell.py`: `Union[...]` → `X | Y | None` for the `pt_app` and `auto_suggest` class attributes

## Deliberately preserved
- Runtime uses of `Union` keep their imports: `guarded_eval.py` (`origin is Union` identity check) and `completer.py` (`_JediCompletionLike` module-level alias evaluated at import).
- All `traitlets` descriptors (`List`/`Dict`/`Set`/`Union`/`Instance`/…) left untouched — they are not `typing` generics.

## Verification
- All changed files `py_compile` and import cleanly; the top-level `IPython` package imports.
- Converted annotations evaluate correctly at runtime (checked `__annotations__`).
- `ruff --select F401` on the changed files: 53 deprecated-`typing` warnings removed; the only remaining `F401`s are pre-existing, non-typing re-export imports outside the scope of this change.
- No `super()` call, f-string, string, comment, or logic was modified — the diff is purely import removals plus the two annotation conversions noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaD24gWKox6ezGLhqNSZq2