### PR TITLE
Fix three small correctness bugs (display_trap comment, dead flag, no-op expandtabs)

### DIFF
--- a/IPython/core/builtin_trap.py
+++ b/IPython/core/builtin_trap.py
@@ -90,4 +90,3 @@ class BuiltinTrap(Configurable):
         for key, val in self._orig_builtins.items():
             remove_builtin(key, val)
         self._orig_builtins.clear()
-        self._builtins_added = False

--- a/IPython/core/display_trap.py
+++ b/IPython/core/display_trap.py
@@ -40,7 +40,7 @@ class DisplayTrap(Configurable):
     def __init__(self, hook=None):
         super().__init__(hook=hook, config=None)
         self.old_hook = None
-        # We define this to track if a single BuiltinTrap is nested.
+        # We define this to track if a single DisplayTrap is nested.
         # Only turn off the trap when the outermost call to __exit__ is made.
         self._nested_level = 0
 

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -947,9 +947,7 @@ class Inspector(Configurable):
                 ostr = str(obj)
                 if not detail_level and len(ostr) > string_max:
                     ostr = ostr[:shalf] + ' <...> ' + ostr[-shalf:]
-                    # TODO: `'string_form'.expandtabs()` seems wrong, but
-                    # it was (nearly) like this since the first commit ever.
-                    ostr = ("\n" + " " * len("string_form".expandtabs())).join(
+                    ostr = ("\n" + " " * len("string_form")).join(
                         q.strip() for q in ostr.split("\n")
                     )
                 out["string_form"] = ostr

--- a/tests/test_oinspect.py
+++ b/tests/test_oinspect.py
@@ -628,3 +628,17 @@ long_function(
         expected = expected.replace("Optional[str]", "str | None")
 
     assert sig == expected
+
+
+def test_pinfo_long_string_form_truncated():
+    """Objects with repr > 200 chars should be truncated with <...> in pinfo (?)."""
+    class LongRepr:
+        def __repr__(self):
+            return "x" * 250
+
+    obj = LongRepr()
+    info = inspector.info(obj, detail_level=0)
+    assert "<...>" in info["string_form"]
+    # detail_level=1 (??) should not truncate
+    info_detail = inspector.info(obj, detail_level=1)
+    assert "<...>" not in info_detail["string_form"]


### PR DESCRIPTION
Three independent small correctness fixes, each self-contained.

## `display_trap.py` — wrong copy-paste comment

`DisplayTrap.__init__` had a comment that said *"single `BuiltinTrap` is nested"*. The class is `DisplayTrap`; the comment was copied from `builtin_trap.py` and never updated.

## `builtin_trap.py` — dead `_builtins_added` flag

`deactivate()` set `self._builtins_added = False`, but the attribute is never initialised in `__init__` and never read anywhere in the codebase. It is a leftover from an older implementation and silently does nothing (and silently creates a stray instance attribute on every deactivate call).

## `oinspect.py` — no-op `.expandtabs()` + test

In the `string_form` truncation path:

```python
# before
ostr = ("\n" + " " * len("string_form".expandtabs())).join(...)

# after
ostr = ("\n" + " " * len("string_form")).join(...)
```

`"string_form"` contains no tab characters, so `.expandtabs()` always returned it unchanged and `len()` was always 11. The call was a no-op that added noise and a misleading TODO comment. Removed it so the intent (indent continuation lines by the label width) is clear.

Also adds `test_pinfo_long_string_form_truncated`, which covers this truncation code path for the first time: objects whose `repr` exceeds 200 chars should get `<...>` inserted in `?` mode but not `??` (`detail_level=1`).


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZibX3PPfLajPhVQ8WrHuy)_