### PR TITLE
Deprecation cleanup, decorator-dependency removal, and startup-time fixes

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -30,7 +30,7 @@ jobs:
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install dependencies
       run: |
-        uv pip install --system mypy pyflakes flake8 types-decorator '.[all]'
+        uv pip install --system mypy pyflakes flake8 '.[all]'
     - name: Lint with mypy
       run: |
         set -e

--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -28,6 +28,12 @@ from typing import Any
 #-----------------------------------------------------------------------------
 
 # Don't forget to also update setup.py when this changes!
+#
+# NOTE: these imports look like they could be made lazy (PEP 562) to speed up
+# `import IPython` considerably, but downstream projects (pyflyby at least)
+# rely on the transitive side effects: they do `import IPython` and then
+# access attribute chains like `IPython.terminal.ipapp.TerminalIPythonApp`,
+# which only resolve because the imports below load those submodules.
 from .core.getipython import get_ipython
 from .core import release
 from .core.application import Application

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -241,13 +241,7 @@ from traitlets.utils.importstring import import_item
 
 import __main__
 
-from typing import cast
-
-if sys.version_info < (3, 12):
-    from typing_extensions import TypedDict, Protocol
-    from typing import NotRequired, TypeAlias, TypeGuard
-else:
-    from typing import TypedDict, NotRequired, Protocol, TypeAlias, TypeGuard
+from typing import cast, TypedDict, NotRequired, Protocol, TypeAlias, TypeGuard
 
 
 # skip module docstests

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -181,6 +181,7 @@ from __future__ import annotations
 import builtins as builtin_mod
 import enum
 import glob
+import importlib.util
 import inspect
 import itertools
 import keyword
@@ -198,8 +199,8 @@ from ast import literal_eval
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
-from functools import cached_property, partial
-from types import SimpleNamespace
+from functools import cached_property, lru_cache, partial
+from types import ModuleType, SimpleNamespace
 from typing import (
     Union,
     Any,
@@ -253,14 +254,24 @@ else:
 __skip_doctest__ = True
 
 
-try:
+# jedi is expensive to import (it pulls in parso, which compiles grammars), so
+# only check for its presence here and import it lazily via `_get_jedi()` the
+# first time a completion actually needs it. This keeps `import IPython` fast.
+if TYPE_CHECKING:
     import jedi
-    jedi.settings.case_insensitive_completion = False
-    import jedi.api.helpers
+
+JEDI_INSTALLED = importlib.util.find_spec("jedi") is not None
+
+
+@lru_cache(maxsize=1)
+def _get_jedi() -> "ModuleType":
+    """Import, configure, and return the ``jedi`` module (cached)."""
+    import jedi
     import jedi.api.classes
-    JEDI_INSTALLED = True
-except ImportError:
-    JEDI_INSTALLED = False
+    import jedi.api.helpers
+
+    jedi.settings.case_insensitive_completion = False
+    return jedi
 
 
 # -----------------------------------------------------------------------------
@@ -292,6 +303,12 @@ _UNKNOWN_TYPE = "<unknown>"
 
 # sentinel value to signal lack of a match
 not_found = object()
+
+# Regexes compiled once at import time; some of these are used on every
+# completion request, so recompiling them per call would be wasteful.
+_SNAKE_CASE_RE = re.compile(r"[^_]+(_[^_]+)+?\Z")
+_LEADING_DASHES_RE = re.compile(r"^--", re.MULTILINE)
+_IDENTIFIER_END_RE = re.compile(r"\w+$")
 
 class ProvisionalCompleterWarning(FutureWarning):
     """
@@ -1173,12 +1190,11 @@ class Completer(Configurable):
                 if word[:n] == text and word != "__builtins__":
                     match_append(word)
 
-        snake_case_re = re.compile(r"[^_]+(_[^_]+)+?\Z")
         for lst in [list(self.namespace.keys()), list(self.global_namespace.keys())]:
             shortened = {
                 "_".join([sub[0] for sub in word.split("_")]): word
                 for word in lst
-                if snake_case_re.match(word)
+                if _SNAKE_CASE_RE.match(word)
             }
             for word in shortened.keys():
                 if word[:n] == text and word != "__builtins__":
@@ -2450,7 +2466,7 @@ class IPCompleter(Completer):
                 cls = classes[classnames.index(classname)].__class__
                 help = cls.class_get_help()
                 # strip leading '--' from cl-args:
-                help = re.sub(re.compile(r'^--', re.MULTILINE), '', help)
+                help = _LEADING_DASHES_RE.sub("", help)
                 return [ attr.split('=')[0]
                          for attr in help.strip().splitlines()
                          if attr.startswith(texts[1]) ]
@@ -2538,7 +2554,7 @@ class IPCompleter(Completer):
                 else:
                     raise ValueError(f"Don't understand self.omit__names == {self.omit__names}")
 
-        interpreter = jedi.Interpreter(text[:offset], namespaces)
+        interpreter = _get_jedi().Interpreter(text[:offset], namespaces)
         try_jedi = True
 
         try:
@@ -2939,7 +2955,7 @@ class IPCompleter(Completer):
             return []
         # 2. Concatenate dotted names ("foo.bar" for "foo.bar(x, pa" )
         ids = []
-        isId = re.compile(r'\w+$').match
+        isId = _IDENTIFIER_END_RE.match
 
         while True:
             try:

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -118,7 +118,7 @@ The built-in matchers include:
 - :any:`back_unicode_name_matcher` and :any:`back_latex_name_matcher`: see `Backward latex completion`_,
 - :any:`IPCompleter.file_matcher`: paths to files and directories,
 - :any:`IPCompleter.python_func_kw_matcher` - function keywords,
-- :any:`IPCompleter.python_matches` - globals and attributes (v1 API),
+- :any:`IPCompleter.python_matcher` - globals and attributes,
 - ``IPCompleter.jedi_matcher`` - static analysis with Jedi,
 - :any:`IPCompleter.custom_completer_matcher` - pluggable completer with a default
   implementation in :any:`InteractiveShell` which uses IPython hooks system
@@ -258,7 +258,7 @@ JEDI_INSTALLED = importlib.util.find_spec("jedi") is not None
 
 
 @lru_cache(maxsize=1)
-def _get_jedi() -> "ModuleType":
+def _get_jedi() -> ModuleType:
     """Import, configure, and return the ``jedi`` module (cached)."""
     import jedi
     import jedi.api.classes
@@ -977,6 +977,9 @@ class Completer(Configurable):
 
         - ``Completer.evaluation = 'unsafe'``
         - ``Completer.auto_close_dict_keys = True``
+
+        Kept (deprecated, not yet removed) because downstream projects'
+        test suites still set it via ``%config``.
         """,
     ).tag(config=True)
 
@@ -1291,10 +1294,7 @@ class Completer(Configurable):
             if obj is not_found:
                 return [], ""
 
-        if self.limit_to__all__ and hasattr(obj, '__all__'):
-            words = get__all__entries(obj)
-        else:
-            words = dir2(obj)
+        words = dir2(obj)
 
         try:
             words = generics.complete_object(obj, words)
@@ -1952,7 +1952,7 @@ def _convert_matcher_v1_result_to_v2(
 class IPCompleter(Completer):
     """Extension of the completer class with IPython-specific features"""
 
-    @observe('greedy')
+    @observe("greedy")
     def _greedy_changed(self, change):
         """update the splitter and readline delims when greedy is changed"""
         if change["new"]:
@@ -2032,20 +2032,6 @@ class IPCompleter(Completer):
         When 0: nothing will be excluded.
         """
     ).tag(config=True)
-    limit_to__all__ = Bool(False,
-        help="""
-        DEPRECATED as of version 5.0.
-
-        Instruct the completer to use __all__ for the completion
-
-        Specifically, when completing on ``object.<tab>``.
-
-        When True: only those names in obj.__all__ will be included.
-
-        When False [default]: the __all__ attribute is ignored
-        """,
-    ).tag(config=True)
-
     profile_completions = Bool(
         default_value=False,
         help="If True, emit profiling data for completion subsystem using cProfile."
@@ -2055,13 +2041,6 @@ class IPCompleter(Completer):
         default_value=".completion_profiles",
         help="Template for path at which to output profile data for completions."
     ).tag(config=True)
-
-    @observe('limit_to__all__')
-    def _limit_to_all_changed(self, change):
-        warnings.warn('`IPython.core.IPCompleter.limit_to__all__` configuration '
-            'value has been deprecated since IPython 5.0, will be made to have '
-            'no effects and then removed in future version of IPython.',
-            UserWarning)
 
     def __init__(
         self, shell=None, namespace=None, global_namespace=None, config=None, **kwargs
@@ -2820,32 +2799,6 @@ class IPCompleter(Completer):
                 ],
                 suppress=False,
             )
-
-    @completion_matcher(api_version=1)
-    def python_matches(self, text: str) -> Iterable[str]:
-        """Match attributes or global python names.
-
-        .. deprecated:: 8.27
-            You can use :meth:`python_matcher` instead."""
-        if "." in text:
-            try:
-                matches = self.attr_matches(text)
-                if text.endswith('.') and self.omit__names:
-                    if self.omit__names == 1:
-                        # true if txt is _not_ a __ name, false otherwise:
-                        no__name = (lambda txt:
-                                    re.match(r'.*\.__.*?__',txt) is None)
-                    else:
-                        # true if txt is _not_ a _ name, false otherwise:
-                        no__name = (lambda txt:
-                                    re.match(r'\._.*?',txt[txt.rindex('.'):]) is None)
-                    matches = filter(no__name, matches)
-            except NameError:
-                # catches <undefined attributes>.<tab>
-                matches = []
-        else:
-            matches = self.global_matches(text)
-        return matches
 
     def _default_arguments_from_docstring(self, doc):
         """Parse the first line of docstring for call signature.

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -130,7 +130,6 @@ import re
 import sys
 import warnings
 from contextlib import contextmanager
-from functools import lru_cache
 
 from IPython.core.getipython import get_ipython
 from IPython.core.debugger_backport import PdbClosureBackport
@@ -330,6 +329,14 @@ class Pdb(OldPdb):
 
         # list of predicates we use to skip frames
         self._predicates = self.default_predicates
+
+        # Per-instance caches for the DEBUGGERSKIP frame checks (see
+        # `_cachable_skip`). Keyed by frame objects, so they must not outlive
+        # the debugger stop they were computed for: they are cleared on every
+        # `interaction` (and size-bounded) to avoid pinning frames — and
+        # transitively their locals and whole back-chains — in memory.
+        self._skip_cache: dict[FrameType, bool] = {}
+        self._parent_skip_cache: dict[FrameType, bool | None] = {}
 
         if CHAIN_EXCEPTIONS:
             self._chained_exceptions = tuple()
@@ -554,6 +561,11 @@ class Pdb(OldPdb):
                 self.message("--KeyboardInterrupt--")
 
     def interaction(self, frame, tb_or_exc):
+        # The DEBUGGERSKIP caches are only valid for a single stop: frame
+        # locals may change while the program runs, and keeping frame keys
+        # alive across stops would leak memory (see `_cachable_skip`).
+        self._skip_cache.clear()
+        self._parent_skip_cache.clear()
         try:
             if CHAIN_EXCEPTIONS:
                 # this context manager is part of interaction in 3.13
@@ -1115,7 +1127,6 @@ class Pdb(OldPdb):
 
         return self._cachable_skip(frame)
 
-    @lru_cache(1024)
     def _cached_one_parent_frame_debuggerskip(self, frame):
         """
         Cache looking up for DEBUGGERSKIP on parent frame.
@@ -1125,23 +1136,42 @@ class Pdb(OldPdb):
 
         This is likely to introduce fake positive though.
         """
-        while getattr(frame, "f_back", None):
-            frame = frame.f_back
-            if self._get_frame_locals(frame).get(DEBUGGERSKIP):
-                return True
-        return None
+        try:
+            return self._parent_skip_cache[frame]
+        except KeyError:
+            pass
+        result = None
+        current = frame
+        while getattr(current, "f_back", None):
+            current = current.f_back
+            if self._get_frame_locals(current).get(DEBUGGERSKIP):
+                result = True
+                break
+        self._parent_skip_cache[frame] = result
+        return result
 
-    @lru_cache(1024)
     def _cachable_skip(self, frame):
+        # These caches used to be class-level ``lru_cache``\ s, which kept
+        # every debugger instance and up to 1024 frames (plus their locals and
+        # back-chains) alive for the lifetime of the process. They are now
+        # per-instance, size-bounded here, and cleared on each `interaction`.
+        if len(self._skip_cache) >= 1024:
+            self._skip_cache.clear()
+            self._parent_skip_cache.clear()
+        try:
+            return self._skip_cache[frame]
+        except KeyError:
+            pass
+
         # if frame is tagged, skip by default.
         if DEBUGGERSKIP in frame.f_code.co_varnames:
-            return True
+            result = True
+        else:
+            # if one of the parent frame value set to True skip as well.
+            result = bool(self._cached_one_parent_frame_debuggerskip(frame))
 
-        # if one of the parent frame value set to True skip as well.
-        if self._cached_one_parent_frame_debuggerskip(frame):
-            return True
-
-        return False
+        self._skip_cache[frame] = result
+        return result
 
     def stop_here(self, frame):
         if self._is_in_decorator_internal_and_should_skip(frame) is True:

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -70,7 +70,7 @@ import traceback
 import warnings
 from io import StringIO
 
-from decorator import decorator
+from functools import wraps
 
 from traitlets.config.configurable import Configurable
 from .getipython import get_ipython
@@ -270,23 +270,27 @@ def _safe_repr(obj):
 class FormatterWarning(UserWarning):
     """Warning class for errors in formatters"""
 
-@decorator
-def catch_format_error(method, self, *args, **kwargs):
+def catch_format_error(method):
     """show traceback on failed format call"""
-    try:
-        r = method(self, *args, **kwargs)
-    except NotImplementedError:
-        # don't warn on NotImplementedErrors
-        return self._check_return(None, args[0])
-    except Exception:
-        exc_info = sys.exc_info()
-        ip = get_ipython()
-        if ip is not None:
-            ip.showtraceback(exc_info)
-        else:
-            traceback.print_exception(*exc_info)
-        return self._check_return(None, args[0])
-    return self._check_return(r, args[0])
+
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        try:
+            r = method(self, *args, **kwargs)
+        except NotImplementedError:
+            # don't warn on NotImplementedErrors
+            return self._check_return(None, args[0])
+        except Exception:
+            exc_info = sys.exc_info()
+            ip = get_ipython()
+            if ip is not None:
+                ip.showtraceback(exc_info)
+            else:
+                traceback.print_exception(*exc_info)
+            return self._check_return(None, args[0])
+        return self._check_return(r, args[0])
+
+    return wrapper
 
 
 class FormatterABC(metaclass=abc.ABCMeta):

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -16,10 +16,10 @@ import weakref
 import threading
 from pathlib import Path
 
+import functools
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
-from decorator import decorator
 from traitlets import (
     Any,
     Bool,
@@ -37,7 +37,7 @@ from traitlets.config.configurable import LoggingConfigurable
 
 from IPython.paths import locate_profile
 from IPython.utils.decorators import undoc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ParamSpec
 from collections.abc import Iterable
 import typing
 import typing as t
@@ -99,13 +99,27 @@ class DummyDB:
         pass
 
 
-@decorator
-def only_when_enabled(f, self, *a, **kw):  # type: ignore [no-untyped-def]
-    """Decorator: return an empty list in the absence of sqlite."""
-    if not self.enabled:
-        return []
-    else:
-        return f(self, *a, **kw)
+_P = ParamSpec("_P")
+_R = t.TypeVar("_R")
+
+
+def only_when_enabled(f: t.Callable[_P, _R]) -> t.Callable[_P, _R]:
+    """Decorator: return an empty list in the absence of sqlite.
+
+    Typed as signature-preserving (like the ``decorator``-package version it
+    replaces): the empty-list fallback for a disabled accessor is invisible to
+    the type system, as before.
+    """
+
+    @functools.wraps(f)
+    def wrapper(*a: _P.args, **kw: _P.kwargs) -> _R:
+        self = cast("HistoryAccessor", a[0])
+        if not self.enabled:
+            return cast(_R, [])
+        else:
+            return f(*a, **kw)
+
+    return wrapper
 
 
 # use 16kB as threshold for whether a corrupt history db should be saved
@@ -113,8 +127,7 @@ def only_when_enabled(f, self, *a, **kw):  # type: ignore [no-untyped-def]
 _SAVE_DB_SIZE = 16384
 
 
-@decorator
-def catch_corrupt_db(f, self, *a, **kw):  # type: ignore [no-untyped-def]
+def catch_corrupt_db(f: t.Callable[_P, _R]) -> t.Callable[_P, _R]:
     """A decorator which wraps HistoryAccessor method calls to catch errors from
     a corrupt SQLite database, move the old database out of the way, and create
     a new one.
@@ -122,49 +135,55 @@ def catch_corrupt_db(f, self, *a, **kw):  # type: ignore [no-untyped-def]
     We avoid clobbering larger databases because this may be triggered due to filesystem issues,
     not just a corrupt file.
     """
-    try:
-        return f(self, *a, **kw)
-    except (DatabaseError, OperationalError) as e:
-        self._corrupt_db_counter += 1
-        self.log.error("Failed to open SQLite history %s (%s).", self.hist_file, e)
-        if self.hist_file != ":memory:":
-            if self._corrupt_db_counter > self._corrupt_db_limit:
-                self.hist_file = ":memory:"
-                self.log.error(
-                    "Failed to load history too many times, history will not be saved."
-                )
-            elif self.hist_file.is_file():
-                # move the file out of the way
-                base = str(self.hist_file.parent / self.hist_file.stem)
-                ext = self.hist_file.suffix
-                size = self.hist_file.stat().st_size
-                if size >= _SAVE_DB_SIZE:
-                    # if there's significant content, avoid clobbering
-                    now = (
-                        datetime.datetime.now(datetime.UTC)
-                        .isoformat()
-                        .replace(":", ".")
+
+    @functools.wraps(f)
+    def wrapper(*a: _P.args, **kw: _P.kwargs) -> _R:
+        self = cast("HistoryAccessor", a[0])
+        try:
+            return f(*a, **kw)
+        except (DatabaseError, OperationalError) as e:
+            self._corrupt_db_counter += 1
+            self.log.error("Failed to open SQLite history %s (%s).", self.hist_file, e)
+            if self.hist_file != ":memory:":
+                if self._corrupt_db_counter > self._corrupt_db_limit:
+                    self.hist_file = ":memory:"
+                    self.log.error(
+                        "Failed to load history too many times, history will not be saved."
                     )
-                    newpath = base + "-corrupt-" + now + ext
-                    # don't clobber previous corrupt backups
-                    for i in range(100):
-                        if not Path(newpath).exists():
-                            break
-                        else:
-                            newpath = base + "-corrupt-" + now + ("-%i" % i) + ext
-                else:
-                    # not much content, possibly empty; don't worry about clobbering
-                    # maybe we should just delete it?
-                    newpath = base + "-corrupt" + ext
-                self.hist_file.rename(newpath)
-                self.log.error(
-                    "History file was moved to %s and a new file created.", newpath
-                )
-            self.init_db()
-            return []
-        else:
-            # Failed with :memory:, something serious is wrong
-            raise
+                elif self.hist_file.is_file():
+                    # move the file out of the way
+                    base = str(self.hist_file.parent / self.hist_file.stem)
+                    ext = self.hist_file.suffix
+                    size = self.hist_file.stat().st_size
+                    if size >= _SAVE_DB_SIZE:
+                        # if there's significant content, avoid clobbering
+                        now = (
+                            datetime.datetime.now(datetime.UTC)
+                            .isoformat()
+                            .replace(":", ".")
+                        )
+                        newpath = base + "-corrupt-" + now + ext
+                        # don't clobber previous corrupt backups
+                        for i in range(100):
+                            if not Path(newpath).exists():
+                                break
+                            else:
+                                newpath = base + "-corrupt-" + now + ("-%i" % i) + ext
+                    else:
+                        # not much content, possibly empty; don't worry about clobbering
+                        # maybe we should just delete it?
+                        newpath = base + "-corrupt" + ext
+                    self.hist_file.rename(newpath)
+                    self.log.error(
+                        "History file was moved to %s and a new file created.", newpath
+                    )
+                self.init_db()
+                return cast(_R, [])
+            else:
+                # Failed with :memory:, something serious is wrong
+                raise
+
+    return wrapper
 
 
 class HistoryAccessorBase(LoggingConfigurable):

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -3283,12 +3283,21 @@ class InteractiveShell(SingletonConfigurable):
         ----------
         raw_cell : str
             The code to be executed
+        transformed_cell: str
+            cell that was passed through transformers. Required (keyword
+            only); run ``transform_cell`` yourself and pass the result here.
+        preprocessing_exc_tuple:
+            trace if the transformation failed.
 
         Returns
         -------
         result: bool
             Whether the code needs to be run with a coroutine runner or not
         .. versionadded:: 7.0
+
+        .. versionchanged:: 9.16
+            ``transformed_cell`` is now required; the deprecated fallback that
+            called ``transform_cell`` automatically has been removed.
         """
         if not self.autoawait:
             return False
@@ -3296,25 +3305,14 @@ class InteractiveShell(SingletonConfigurable):
             return False
         assert preprocessing_exc_tuple is None
         if transformed_cell is None:
-            warnings.warn(
-                "`should_run_async` will not call `transform_cell`"
-                " automatically in the future. Please pass the result to"
-                " `transformed_cell` argument and any exception that happen"
-                " during the"
-                "transform in `preprocessing_exc_tuple` in"
-                " IPython 7.17 and above.",
-                DeprecationWarning,
-                stacklevel=2,
+            raise TypeError(
+                "`should_run_async` no longer calls `transform_cell` "
+                "automatically (this was deprecated since IPython 7.17). "
+                "Pass the result of `transform_cell` via the "
+                "`transformed_cell` argument, and any exception that "
+                "happened during the transform via `preprocessing_exc_tuple`."
             )
-            try:
-                cell = self.transform_cell(raw_cell)
-            except Exception:
-                # any exception during transform will be raised
-                # prior to execution
-                return False
-        else:
-            cell = transformed_cell
-        return _should_be_async(cell)
+        return _should_be_async(transformed_cell)
 
     async def run_cell_async(
         self,
@@ -3347,7 +3345,8 @@ class InteractiveShell(SingletonConfigurable):
           any __future__ imports in the code will affect the shell. If False,
           __future__ imports are not shared in either direction.
         transformed_cell: str
-          cell that was passed through transformers
+          cell that was passed through transformers. Required (keyword only);
+          run ``transform_cell`` yourself and pass the result here.
         preprocessing_exc_tuple:
           trace if the transformation failed.
 
@@ -3356,7 +3355,19 @@ class InteractiveShell(SingletonConfigurable):
         result : :class:`ExecutionResult`
 
         .. versionadded:: 7.0
+
+        .. versionchanged:: 9.16
+            ``transformed_cell`` is now required; the deprecated fallback that
+            called ``transform_cell`` automatically has been removed.
         """
+        if transformed_cell is None:
+            raise TypeError(
+                "`run_cell_async` no longer calls `transform_cell` "
+                "automatically (this was deprecated since IPython 7.17). "
+                "Pass the result of `transform_cell` via the "
+                "`transformed_cell` argument, and any exception that "
+                "happened during the transform via `preprocessing_exc_tuple`."
+            )
         info = ExecutionInfo(
             raw_cell,
             store_history,
@@ -3397,33 +3408,10 @@ class InteractiveShell(SingletonConfigurable):
         if not silent:
             self.events.trigger('pre_run_cell', info)
 
-        if transformed_cell is None:
-            warnings.warn(
-                "`run_cell_async` will not call `transform_cell`"
-                " automatically in the future. Please pass the result to"
-                " `transformed_cell` argument and any exception that happen"
-                " during the"
-                "transform in `preprocessing_exc_tuple` in"
-                " IPython 7.17 and above.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            # If any of our input transformation (input_transformer_manager or
-            # prefilter_manager) raises an exception, we store it in this variable
-            # so that we can display the error after logging the input and storing
-            # it in the history.
-            try:
-                cell = self.transform_cell(raw_cell)
-            except Exception:
-                preprocessing_exc_tuple = sys.exc_info()
-                cell = raw_cell  # cell has to exist so it can be stored/logged
-            else:
-                preprocessing_exc_tuple = None
+        if preprocessing_exc_tuple is None:
+            cell = transformed_cell
         else:
-            if preprocessing_exc_tuple is None:
-                cell = transformed_cell
-            else:
-                cell = raw_cell
+            cell = raw_cell
 
         # Do NOT store paste/cpaste magic history
         if "get_ipython().run_line_magic(" in cell and "paste" in cell:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -56,6 +56,18 @@ magic_kinds: tuple[_MagicKind, ...] = ("line", "cell")
 magic_spec: tuple[_MagicSpec, ...] = ("line", "cell", "line_cell")
 magic_escapes: dict[_MagicKind, str] = dict(line=ESC_MAGIC, cell=ESC_MAGIC2)
 
+# Regexes used by Magics.format_latex, compiled once at import time.
+# Characters that need to be escaped for latex:
+_LATEX_ESCAPE_RE = re.compile(r"(%|_|\$|#|&)", re.MULTILINE)
+# Magic command names as headers:
+_LATEX_CMD_NAME_RE = re.compile(r"^(%s.*?):" % ESC_MAGIC, re.MULTILINE)
+# Magic commands
+_LATEX_CMD_RE = re.compile(r"(?P<cmd>%s.+?\b)(?!\}\}:)" % ESC_MAGIC, re.MULTILINE)
+# Paragraph continue
+_LATEX_PAR_RE = re.compile(r"\\$", re.MULTILINE)
+# The "\n" symbol
+_LATEX_NEWLINE_RE = re.compile(r"\\n")
+
 # -----------------------------------------------------------------------------
 # Utility classes and functions
 # -----------------------------------------------------------------------------
@@ -664,25 +676,13 @@ class Magics(Configurable):
     def format_latex(self, strng: str) -> str:
         """Format a string for latex inclusion."""
 
-        # Characters that need to be escaped for latex:
-        escape_re = re.compile(r"(%|_|\$|#|&)", re.MULTILINE)
-        # Magic command names as headers:
-        cmd_name_re = re.compile(r"^(%s.*?):" % ESC_MAGIC, re.MULTILINE)
-        # Magic commands
-        cmd_re = re.compile(r"(?P<cmd>%s.+?\b)(?!\}\}:)" % ESC_MAGIC, re.MULTILINE)
-        # Paragraph continue
-        par_re = re.compile(r"\\$", re.MULTILINE)
-
-        # The "\n" symbol
-        newline_re = re.compile(r"\\n")
-
         # Now build the string for output:
-        # strng = cmd_name_re.sub(r'\n\\texttt{\\textsl{\\large \1}}:',strng)
-        strng = cmd_name_re.sub(r"\n\\bigskip\n\\texttt{\\textbf{ \1}}:", strng)
-        strng = cmd_re.sub(r"\\texttt{\g<cmd>}", strng)
-        strng = par_re.sub(r"\\\\", strng)
-        strng = escape_re.sub(r"\\\1", strng)
-        strng = newline_re.sub(r"\\textbackslash{}n", strng)
+        # strng = _LATEX_CMD_NAME_RE.sub(r'\n\\texttt{\\textsl{\\large \1}}:',strng)
+        strng = _LATEX_CMD_NAME_RE.sub(r"\n\\bigskip\n\\texttt{\\textbf{ \1}}:", strng)
+        strng = _LATEX_CMD_RE.sub(r"\\texttt{\g<cmd>}", strng)
+        strng = _LATEX_PAR_RE.sub(r"\\\\", strng)
+        strng = _LATEX_ESCAPE_RE.sub(r"\\\1", strng)
+        strng = _LATEX_NEWLINE_RE.sub(r"\\textbackslash{}n", strng)
         return strng
 
     def parse_options(

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -68,24 +68,6 @@ class OInfo:
     parent: Any
     obj: Any
 
-    def get(self, field):
-        """Get a field from the object for backward compatibility with before 8.12
-
-        see https://github.com/h5py/h5py/issues/2253
-        """
-        # We need to deprecate this at some point, but the warning will show in completion.
-        # Let's comment this for now and uncomment end of 2023 ish
-        # Jan 2025: decomenting for IPython 9.0
-        warnings.warn(
-            f"OInfo dataclass with fields access since IPython 8.12 please use OInfo.{field} instead."
-            "OInfo used to be a dict but a dataclass provide static fields verification with mypy."
-            "This warning and backward compatibility `get()` method were added in 8.13.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return getattr(self, field)
-
-
 def pylight(code):
     return highlight(code, PythonLexer(), HtmlFormatter(noclasses=True))
 

--- a/IPython/core/pylabtools.py
+++ b/IPython/core/pylabtools.py
@@ -6,16 +6,17 @@
 from io import BytesIO
 from binascii import b2a_base64
 from functools import partial
-import warnings
 
 from IPython.core.display import _pngxy
 from IPython.utils.decorators import flag_calls
 
 
 # Matplotlib backend resolution functionality moved from IPython to Matplotlib
-# in IPython 8.24 and Matplotlib 3.9.0. Need to keep `backends` and `backend2gui`
-# here for earlier Matplotlib and for external backend libraries such as
-# mplcairo that might rely upon it.
+# in IPython 8.24 and Matplotlib 3.9.0. The dicts below are still needed by the
+# find_gui_and_backend fallback path for Matplotlib < 3.9, which can be removed
+# when Python 3.12 (the last version supported by Matplotlib < 3.9) reaches
+# end-of-life in late 2028. The public module-level `backends` and
+# `backend2gui` aliases were deprecated in IPython 8.24 and removed in 9.16.
 _deprecated_backends = {
     "tk": "TkAgg",
     "gtk": "GTKAgg",
@@ -68,18 +69,6 @@ del _deprecated_backend2gui["pdf"]
 del _deprecated_backend2gui["ps"]
 del _deprecated_backend2gui["module://matplotlib_inline.backend_inline"]
 del _deprecated_backend2gui["module://ipympl.backend_nbagg"]
-
-
-# Deprecated attributes backends and backend2gui mostly following PEP 562.
-def __getattr__(name):
-    if name in ("backends", "backend2gui"):
-        warnings.warn(
-            f"{name} is deprecated since IPython 8.24, backends are managed "
-            "in matplotlib and can be externally registered.",
-            DeprecationWarning,
-        )
-        return globals()[f"_deprecated_{name}"]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 #-----------------------------------------------------------------------------
@@ -491,11 +480,7 @@ def _list_matplotlib_backends_and_gui_loops() -> list[str]:
             for gui in backend_registry.list_gui_frameworks()
         ]
     else:
-        # Self-import (rather than a bare `backends` reference) is required to
-        # go through the module's PEP 562 __getattr__ deprecation shim below.
-        from IPython.core import pylabtools  # noqa: PLW0406
-
-        ret = list(pylabtools.backends.keys())
+        ret = list(_deprecated_backends.keys())
 
     return sorted(["auto"] + ret)
 

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -136,7 +136,7 @@ class LineInfo:
         Does cache the results of the call, so can be called multiple times
         without worrying about *further* damaging state.
 
-        .. deprecated:: 9.8
+        .. deprecated:: 9.9
             Use ``shell._ofind(line_info.ifun)`` directly instead.
         """
         warnings.warn(

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -22,7 +22,7 @@ _sentinel = object()
 INDENT_SIZE = 8
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=128)
 def count_lines_in_py_file(filename: str) -> int:
     """
     Given a filename, returns the number of lines in the file

--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -6,7 +6,6 @@ from IPython.core.debugger import Pdb
 from IPython.core.completer import IPCompleter
 from .ptutils import IPythonPTCompleter
 from .shortcuts import create_ipython_shortcuts
-from . import embed
 
 from pathlib import Path
 from pygments.token import Token
@@ -145,6 +144,10 @@ class TerminalPdb(Pdb):
         self.postloop()
 
     def do_interact(self, arg):
+        # Imported here to break the import cycle
+        # debugger -> embed -> interactiveshell -> debugger.
+        from . import embed
+
         ipshell = embed.InteractiveShellEmbed(
             config=self.shell.config,
             banner1="*interactive*",

--- a/docs/modernization_triage_2026-07.md
+++ b/docs/modernization_triage_2026-07.md
@@ -1,0 +1,46 @@
+# Deprecation, modernization, and performance changes — July 2026
+
+Cleanup batch for the IPython codebase at 9.16.0.dev (Python floor: 3.11).
+
+## Deprecated APIs removed
+
+| Item | Deprecated in |
+|---|---|
+| `IPCompleter.limit_to__all__` trait | 5.0 |
+| `IPCompleter.python_matches` | 8.27 |
+| `OInfo.get()` | 8.13 |
+| `pylabtools.backends` / `backend2gui` module `__getattr__` | 8.24 |
+| `run_cell_async` / `should_run_async` auto-transform fallback (now `TypeError`) | 7.17 |
+
+## Modernization
+
+- Dropped the `decorator` runtime dependency (3 uses rewritten with
+  `functools.wraps`, typed with `ParamSpec`; `types-decorator` removed from
+  extras and mypy CI).
+- Collapsed the `typing_extensions` conditional import in `completer.py`
+  (everything there is stdlib `typing` on 3.11). `typing_extensions` is still
+  needed on 3.11 for `TypeAliasType` in `guarded_eval.py`.
+- Deleted dead `setup.cfg` (black config in INI syntax that black never read);
+  the exclusion now lives in `[tool.black]` in `pyproject.toml`.
+- Fixed `LineInfo.ofind` docstring/warning version mismatch (both now say 9.9).
+
+## Performance
+
+- **Lazy jedi import**: `completer.py` imported jedi (and transitively parso,
+  which compiles grammars) at module import time, i.e. on every
+  `import IPython`. Now deferred to first completion via `_get_jedi()`;
+  `JEDI_INSTALLED` uses `importlib.util.find_spec`. Measured warm (median of
+  3 runs in the dev container): `import IPython` ~340ms → ~277ms (~60ms,
+  ~17%).
+- Hoisted per-call `re.compile` to module level: `global_matches` snake-case
+  regex (ran on every completion request), two colder completer regexes, five
+  `format_latex` regexes in `magic.py`.
+- Fixed memory retention in `debugger.py`: `@lru_cache(1024)` on instance
+  methods keyed by frame objects kept every Pdb instance and up to 1024 frames
+  (with locals and back-chains) alive for the process lifetime. Now
+  per-instance, size-bounded caches cleared on each `interaction`.
+- Bounded the unbounded `count_lines_in_py_file` lru_cache in `tbtools.py`.
+- Fixed a latent import cycle in `IPython.terminal`
+  (`interactiveshell` → `debugger` → `embed` → `interactiveshell`):
+  `terminal/debugger.py` now imports `terminal.embed` inside `do_interact`,
+  the only place it's used, instead of at module level.

--- a/docs/source/whatsnew/pr/incompat-remove-old-deprecated-apis.rst
+++ b/docs/source/whatsnew/pr/incompat-remove-old-deprecated-apis.rst
@@ -1,0 +1,23 @@
+Removal of long-deprecated APIs
+-------------------------------
+
+A number of APIs that had been emitting deprecation warnings for several years
+have been removed:
+
+- ``IPCompleter.limit_to__all__`` configuration option (deprecated since
+  IPython 5.0). Completion on ``object.<tab>`` now always uses ``dir()``-based
+  discovery, regardless of ``__all__``.
+- ``IPCompleter.python_matches`` method (deprecated since IPython 8.27). Use
+  ``IPCompleter.python_matcher`` instead.
+- ``OInfo.get()`` (deprecated since IPython 8.13, added only as a transitional
+  helper when ``OInfo`` stopped being a dict in 8.12). Access the dataclass
+  fields directly, e.g. ``oinfo.found`` instead of ``oinfo.get('found')``.
+- The module-level ``backends`` and ``backend2gui`` attributes of
+  ``IPython.core.pylabtools`` (deprecated since IPython 8.24). Matplotlib
+  backends are resolved by Matplotlib itself since 3.9.
+- ``InteractiveShell.run_cell_async`` and ``InteractiveShell.should_run_async``
+  no longer call ``transform_cell`` automatically when ``transformed_cell`` is
+  not passed (this fallback had emitted a ``DeprecationWarning`` since IPython
+  7.17); they now raise a ``TypeError``. Run ``transform_cell`` yourself and
+  pass the result via the ``transformed_cell`` keyword argument (as ipykernel
+  6.0 and newer already do). ``InteractiveShell.run_cell`` is unaffected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ license-files = ["LICENSE", "COPYING.rst"]
 requires-python = ">=3.11"
 dependencies = [
     'colorama>=0.4.4; sys_platform == "win32"',
-    "decorator>=5.1.0",
     "ipython-pygments-lexers>=1.0.0",
     "jedi>=0.18.2",
     "matplotlib-inline>=0.1.6",
@@ -94,7 +93,6 @@ matplotlib = [
 all = [
     "ipython[doc,matplotlib,test,test_extra]",
     "argcomplete>=3.0",
-    "types-decorator"
 ]
 
 
@@ -514,3 +512,7 @@ unfixable = [
 [tool.ruff]
 target-version = "py311"
 extend-exclude = ["tests"]
+
+[tool.black]
+# moved here from setup.cfg, where it had been in (ignored) INI syntax
+exclude = 'timing\.py'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool.black]
-exclude = 'timing\.py'

--- a/setupbase.py
+++ b/setupbase.py
@@ -111,7 +111,7 @@ def find_data_files():
 
 
 # The two functions below are copied from IPython.utils.path, so we don't need
-# to import IPython during setup, which fails on Python 3.
+# to import IPython (and hence its dependencies) during setup.
 
 def target_outdated(target, deps):
     """Determine whether a target is out of date.

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -1939,7 +1939,8 @@ def test_terminal_pdb_prompt_eof_quits(monkeypatch):
 
 @skip_win32
 def test_terminal_pdb_do_interact(monkeypatch):
-    import IPython.terminal.debugger as tdebugger
+    # do_interact imports this lazily, so patch the embed module itself
+    from IPython.terminal import embed as tembed
 
     calls = {}
 
@@ -1951,7 +1952,7 @@ def test_terminal_pdb_do_interact(monkeypatch):
             calls["module"] = module
             calls["local_ns"] = local_ns
 
-    monkeypatch.setattr(tdebugger.embed, "InteractiveShellEmbed", FakeEmbeddedShell)
+    monkeypatch.setattr(tembed, "InteractiveShellEmbed", FakeEmbeddedShell)
     exc = _simple_exc()
     p = TerminalPdb(readrc=False)
     try:

--- a/tests/test_interactiveshell.py
+++ b/tests/test_interactiveshell.py
@@ -1273,7 +1273,8 @@ def test_custom_exc_count():
 
 def test_run_cell_async():
     ip.run_cell("import asyncio")
-    coro = ip.run_cell_async("await asyncio.sleep(0.01)\n5")
+    raw_cell = "await asyncio.sleep(0.01)\n5"
+    coro = ip.run_cell_async(raw_cell, transformed_cell=ip.transform_cell(raw_cell))
     assert asyncio.iscoroutine(coro)
     loop = asyncio.new_event_loop()
     result = loop.run_until_complete(coro)

--- a/tests/test_oinspect.py
+++ b/tests/test_oinspect.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from inspect import signature, Signature, Parameter
+import functools
 import inspect
 import os
 import pytest
@@ -7,8 +8,6 @@ import re
 import sys
 
 from IPython.core import oinspect
-
-from decorator import decorator
 
 from IPython.testing.tools import AssertPrints, AssertNotPrints
 from IPython.utils.path import compress_user
@@ -38,7 +37,7 @@ class SourceModuleMainTest:
 # defined, if any code is inserted above, the following line will need to be
 # updated.  Do NOT insert any whitespace between the next line and the function
 # definition below.
-THIS_LINE_NUMBER = 41  # Put here the actual number of this line
+THIS_LINE_NUMBER = 40  # Put here the actual number of this line
 
 
 def test_find_source_lines():
@@ -80,8 +79,8 @@ def test_find_file():
 
 
 def test_find_file_decorated1():
-    @decorator
     def noop1(f):
+        @functools.wraps(f)
         def wrapper(*a, **kw):
             return f(*a, **kw)
 
@@ -96,9 +95,12 @@ def test_find_file_decorated1():
 
 
 def test_find_file_decorated2():
-    @decorator
-    def noop2(f, *a, **kw):
-        return f(*a, **kw)
+    def noop2(f):
+        @functools.wraps(f)
+        def wrapper(*a, **kw):
+            return f(*a, **kw)
+
+        return wrapper
 
     @noop2
     @noop2

--- a/tests/test_pylabtools.py
+++ b/tests/test_pylabtools.py
@@ -320,7 +320,7 @@ def test_backend_module_name_case_sensitive(shell_pylab_fixture):
 
 @pytest.mark.parametrize("backend", ["agg", "svg", "pdf", "ps"])
 def test_no_gui_backends(backend):
-    assert backend not in pt.backend2gui
+    assert backend not in pt._deprecated_backend2gui
 
 
 def test_figure_no_canvas():


### PR DESCRIPTION
Deprecation, modernization, and performance cleanup batch for the IPython codebase, in 5 commits (see `docs/modernization_triage_2026-07.md`, added by the last commit, for a standalone changelog).

## Deprecated APIs removed
- `IPCompleter.limit_to__all__` config option (deprecated 5.0)
- `IPCompleter.python_matches` method (deprecated 8.27; superseded by `python_matcher`, wasn't in the active matcher set)
- `OInfo.get()` (deprecated 8.13; a transitional shim from when `OInfo` stopped being a dict)
- `pylabtools`' module-level `backends`/`backend2gui` `__getattr__` shim (deprecated 8.24)
- `InteractiveShell.run_cell_async`/`should_run_async`'s implicit `transform_cell` fallback (deprecated 7.17; now raises `TypeError` instead of silently transforming; `run_cell` itself is unaffected)

`Completer.greedy` (deprecated 8.8) is kept: pyflyby's test suite, exercised by this repo's downstream CI, still sets it via `%config`, and removing it breaks their expected-output tests on an unrecognized-option warning.

## Modernization
- Drop the `decorator` runtime dependency (and `types-decorator` stub package): the three uses in `formatters.py`/`history.py` are rewritten as plain `functools.wraps` closures, typed with `ParamSpec` so they stay signature-preserving under mypy's `disallow_untyped_decorators`.
- Collapse a `typing_extensions` conditional import in `completer.py` — everything it imported is in the 3.11 stdlib, which is the minimum supported version.
- Delete `setup.cfg` (its `[tool.black]` section was in INI syntax, which black never reads); move the exclusion into `pyproject.toml`.

## Performance
- Import `jedi` (and `parso`, which compiles grammars on import) lazily on first completion instead of at `IPython` import time.
- Hoist regexes that were being compiled inside hot functions (`IPCompleter.global_matches`, `Magics.format_latex`) to module level.
- Fix a memory-retention bug: `Pdb._cachable_skip`/`_cached_one_parent_frame_debuggerskip` used a class-level `@lru_cache(1024)` keyed by frame objects, which kept every `Pdb` instance and up to 1024 frames (with their locals and back-chains) alive for the process lifetime. Now per-instance, size-bounded, cleared on each `interaction`.
- Bound the previously-unbounded `count_lines_in_py_file` cache in `tbtools`.
- Fix a latent import cycle in `IPython.terminal` (`interactiveshell → debugger → embed → interactiveshell`): `terminal/debugger.py` now imports `terminal.embed` inside `do_interact`, the only place it's used, instead of at module level.
