### PR TITLE
Close nbformat signature store in %notebook (fixes flaky unclosed-database ResourceWarning)

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -46,6 +46,8 @@ from warnings import warn
 from weakref import ref, WeakSet
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from IPython.core.interactiveshell import InteractiveShell
     from traitlets.config import Config as Configuration
 
@@ -351,6 +353,34 @@ class HistoryAccessor(HistoryAccessorBase):
             )
         # success! reset corrupt db count
         self._corrupt_db_counter = 0
+
+    def close(self) -> None:
+        """Close the SQLite database connection.
+
+        Prefer calling this to closing ``self.db`` directly: it gives
+        subclasses (notably :class:`HistoryManager`) a single place to hook in
+        the rest of their teardown. Safe to call more than once.
+        """
+        self.db.close()
+
+    def __enter__(self) -> HistoryAccessor:
+        """Support use as a context manager for deterministic cleanup::
+
+        with HistoryAccessor(hist_file=path) as history:
+            ...
+        # connection is closed here
+
+        :class:`HistoryManager` additionally stops its saving thread on exit.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
 
     def writeout_cache(self) -> None:
         """Overridden by HistoryManager to dump the cache before certain
@@ -728,17 +758,35 @@ class HistoryManager(HistoryAccessor):
         self.init_db()
         self.new_session()
 
-    def __del__(self) -> None:
+    def _stop_save_thread(self) -> None:
+        """Stop the background saving thread, if one is running.
+
+        The thread closes its own database connection as it exits, so this is
+        also what releases that connection.
+        """
         if self.save_thread is not None:
             self.save_thread.stop()
+            self.save_thread = None
+
+    def close(self) -> None:
+        """Stop the saving thread and close the database connection.
+
+        This is the deterministic counterpart to relying on garbage
+        collection: it shuts the saving thread down (which closes its private
+        connection) and then closes the manager's own connection. Safe to call
+        more than once.
+        """
+        self._stop_save_thread()
+        super().close()
+
+    def __del__(self) -> None:
+        self._stop_save_thread()
 
     @classmethod
     def _stop_thread(cls) -> None:
         # Used before forking so the thread isn't running at fork
         for inst in cls._instances:
-            if inst.save_thread is not None:
-                inst.save_thread.stop()
-                inst.save_thread = None
+            inst._stop_save_thread()
 
     def _restart_thread_if_stopped(self) -> None:
         # Start the thread again after it was stopped for forking
@@ -1133,6 +1181,7 @@ class HistorySavingThread(threading.Thread):
     enabled: bool = True
     history_manager: ref[HistoryManager]
     _stopped = False
+    db: sqlite3.Connection | None = None
 
     def __init__(self, history_manager: HistoryManager) -> None:
         super().__init__(name="IPythonHistorySavingThread")
@@ -1144,6 +1193,7 @@ class HistorySavingThread(threading.Thread):
     def run(self) -> None:
         atexit.register(self.stop)
         # We need a separate db connection per thread:
+        self.db = None
         try:
             hm: ReferenceType[HistoryManager]
             with hold(self.history_manager) as hm:
@@ -1158,10 +1208,9 @@ class HistorySavingThread(threading.Thread):
                     if hm() is None:
                         self._stop_now = True
                     if self._stop_now:
-                        self.db.close()
                         return
                     self.save_flag.clear()
-                    if hm() is not None:
+                    if hm() is not None and self.db is not None:
                         hm().writeout_cache(self.db)  # type: ignore [union-attr]
 
         except Exception as e:
@@ -1173,6 +1222,14 @@ class HistorySavingThread(threading.Thread):
                 % repr(e)
             )
         finally:
+            # Always close our per-thread connection, whatever path we exit by
+            # (normal stop, a dropped HistoryManager, or an unexpected error).
+            # Leaving it open lets the sqlite3.Connection be garbage collected
+            # unclosed, which raises a spurious ``ResourceWarning`` in whatever
+            # code happens to be running when the collection occurs.
+            if self.db is not None:
+                self.db.close()
+                self.db = None
             atexit.unregister(self.stop)
 
     def stop(self) -> None:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -4136,11 +4136,8 @@ class InteractiveShell(SingletonConfigurable):
             # history db
             if self.history_manager is not None:
                 self.history_manager.end_session()
-
-                if self.history_manager.save_thread is not None:
-                    self.history_manager.save_thread.stop()
-
-                self.history_manager.db.close()
+                # Stop the saving thread and close the database deterministically
+                self.history_manager.close()
                 self.history_manager = None
     #-------------------------------------------------------------------------
     # Things related to IPython exiting

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -668,7 +668,16 @@ Currently the magic system has the following functions:""",
         # Sign the notebook to make it trusted
         notary = NotebookNotary()
         notary.update_config(self.shell.config)
-        notary.sign(nb)
+        try:
+            notary.sign(nb)
+        finally:
+            # Close the signature store's SQLite connection. NotebookNotary
+            # opens it eagerly but never closes it on its own, so leaving it
+            # open lets the connection be garbage collected unclosed, raising a
+            # spurious "ResourceWarning: unclosed database" in whatever code
+            # happens to be running at collection time (a source of flaky test
+            # failures, notably on the Windows / Python 3.14 CI job).
+            notary.store.close()
         with open(outfname, "w", encoding="utf-8") as f:
             write(nb, f, version=4)
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -131,9 +131,9 @@ def _reap_embedded_shells():
     for hm in set(HistoryManager._instances) - before:
         if hm.save_thread is not None:
             atexit.unregister(hm.save_thread.stop)
-            hm.save_thread.stop()
         if hm.shell is not None:
             atexit.unregister(hm.shell.atexit_operations)
+        hm.close()
         HistoryManager._instances.discard(hm)
     gc.collect()
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -12,7 +12,8 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
-from contextlib import closing
+import time
+from contextlib import ExitStack, closing
 from datetime import datetime
 from pathlib import Path
 
@@ -21,7 +22,12 @@ from tempfile import TemporaryDirectory
 # our own packages
 from traitlets.config.loader import Config
 
-from IPython.core.history import HistoryAccessor, HistoryManager, extract_hist_ranges
+from IPython.core.history import (
+    HistoryAccessor,
+    HistoryManager,
+    HistorySavingThread,
+    extract_hist_ranges,
+)
 
 import pytest
 
@@ -180,11 +186,11 @@ def test_history(hmmax2):
             assert sessid < hist[0]
             assert hist[1:] == (lineno, entry)
         finally:
-            # Ensure saving thread is shut down before we try to clean up the files
+            # Ensure saving thread is shut down before we try to clean up the
+            # files, and close the database deterministically rather than
+            # relying on garbage collection.
             ip.history_manager.end_session()
-            # Forcibly close database rather than relying on garbage collection
-            ip.history_manager.save_thread.stop()
-            ip.history_manager.db.close()
+            ip.history_manager.close()
             # swap back
             ip.history_manager = hist_manager_ori
 
@@ -264,17 +270,10 @@ def test_hist_file_config(hmmax3):
     tfile = tempfile.NamedTemporaryFile(delete=False)
     tfile.close()
     cfg.HistoryManager.hist_file = Path(tfile.name)
-    hm = None
     try:
-        hm = HistoryManager(shell=get_ipython(), config=cfg)
-        assert hm.hist_file == cfg.HistoryManager.hist_file
+        with HistoryManager(shell=get_ipython(), config=cfg) as hm:
+            assert hm.hist_file == cfg.HistoryManager.hist_file
     finally:
-        if hm is not None:
-            hm.end_session()
-            if hm.save_thread is not None:
-                hm.save_thread.stop()
-            hm.db.close()
-        hm = None
         gc.collect()
         try:
             Path(tfile.name).unlink()
@@ -285,36 +284,30 @@ def test_hist_file_config(hmmax3):
 def test_histmanager_memory_fallback_reopens_db(hmmax3, tmp_path, caplog):
     hist_file = tmp_path / "history.sqlite"
     ip = get_ipython()
-    hm1 = None
-    hm2 = None
     lock = None
     try:
-        hm1 = HistoryManager(shell=ip, hist_file=hist_file)
-        hm1.end_session()
-        hm1.save_thread.stop()
-        hm1.db.close()
+        # Create the on-disk database, then release it so we can lock it below.
+        with HistoryManager(shell=ip, hist_file=hist_file) as hm1:
+            hm1.end_session()
 
         lock = sqlite3.connect(hist_file)
         lock.execute("BEGIN IMMEDIATE")
 
-        hm2 = HistoryManager(shell=ip, hist_file=hist_file)
-        assert hm2.hist_file == ":memory:"
-        assert hm2.db.execute("PRAGMA database_list").fetchall() == [(0, "main", "")]
+        with HistoryManager(shell=ip, hist_file=hist_file) as hm2:
+            assert hm2.hist_file == ":memory:"
+            assert hm2.db.execute("PRAGMA database_list").fetchall() == [
+                (0, "main", "")
+            ]
 
-        hm2.store_inputs(1, "a = 1")
-        hm2.writeout_cache()
-        assert list(hm2.get_tail(1, include_latest=True)) == [
-            (hm2.session_number, 1, "a = 1")
-        ]
+            hm2.store_inputs(1, "a = 1")
+            hm2.writeout_cache()
+            assert list(hm2.get_tail(1, include_latest=True)) == [
+                (hm2.session_number, 1, "a = 1")
+            ]
     finally:
-        if hm2 is not None:
-            hm2.end_session()
-            hm2.db.close()
         if lock is not None:
             lock.rollback()
             lock.close()
-        hm1 = None
-        hm2 = None
         caplog.clear()
         gc.collect()
 
@@ -327,9 +320,9 @@ def test_histmanager_thread_start_failure_uses_memory(
 
     monkeypatch.setattr("IPython.core.history.HistorySavingThread.start", fail_start)
 
-    hm = None
-    try:
-        hm = HistoryManager(shell=get_ipython(), hist_file=tmp_path / "history.sqlite")
+    with HistoryManager(
+        shell=get_ipython(), hist_file=tmp_path / "history.sqlite"
+    ) as hm:
         assert hm.hist_file == ":memory:"
         assert hm.db.execute("PRAGMA database_list").fetchall() == [(0, "main", "")]
         assert hm.save_thread is None
@@ -339,13 +332,115 @@ def test_histmanager_thread_start_failure_uses_memory(
         assert list(hm.get_tail(1, include_latest=True)) == [
             (hm.session_number, 1, "a = 1")
         ]
+    caplog.clear()
+    gc.collect()
+
+
+def _wait_for_thread_db(thread, timeout=5.0):
+    """Wait until the saving thread has opened its private connection."""
+    deadline = time.monotonic() + timeout
+    while thread.db is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert thread.db is not None, "saving thread never opened its connection"
+    return thread.db
+
+
+def test_saving_thread_closes_db_on_normal_stop(hmmax2, tmp_path):
+    """A stopped saving thread must close its own sqlite connection.
+
+    The thread keeps a separate connection from the HistoryManager; if it is
+    left open the ``sqlite3.Connection`` gets garbage collected unclosed, which
+    raises a spurious ``ResourceWarning`` in whatever code is running at the
+    time (a source of cross-test flakiness).
+    """
+    hm = HistoryManager(shell=get_ipython(), hist_file=tmp_path / "history.sqlite")
+    try:
+        thread = hm.save_thread
+        assert thread is not None
+        conn = _wait_for_thread_db(thread)
+
+        hm.end_session()
+        thread.stop()
+        assert not thread.is_alive()
+        assert thread.db is None
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
     finally:
-        if hm is not None:
-            hm.end_session()
-            hm.db.close()
+        hm.close()
         hm = None
-        caplog.clear()
         gc.collect()
+
+
+def test_saving_thread_closes_db_on_error(hmmax2, tmp_path):
+    """The saving thread must close its connection even when it errors out.
+
+    ``run()`` used to close the connection only on the clean-stop path, so an
+    unexpected error (more likely on Windows, where a cross-thread sqlite or
+    file-locking failure can surface) left the connection open to be collected
+    later and emit a ``ResourceWarning``.
+    """
+    hm = HistoryManager(shell=get_ipython(), hist_file=tmp_path / "history.sqlite")
+    try:
+        thread = hm.save_thread
+        assert thread is not None
+        conn = _wait_for_thread_db(thread)
+
+        # Force the writeout to raise, driving run() into its except branch.
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        hm.writeout_cache = boom
+        thread.save_flag.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+        # The connection must have been closed by run()'s finally block.
+        assert thread.db is None
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+    finally:
+        hm.close()
+        hm = None
+        gc.collect()
+
+
+def test_history_manager_context_manager(hmmax2, tmp_path):
+    """Using a HistoryManager as a context manager stops the saving thread and
+    closes both connections on exit."""
+    with HistoryManager(
+        shell=get_ipython(), hist_file=tmp_path / "history.sqlite"
+    ) as hm:
+        thread = hm.save_thread
+        assert thread is not None
+        thread_conn = _wait_for_thread_db(thread)
+        hm.store_inputs(1, "a = 1")
+
+    # On exit the thread is stopped and both connections are closed.
+    assert hm.save_thread is None
+    assert not thread.is_alive()
+    with pytest.raises(sqlite3.ProgrammingError):
+        thread_conn.execute("SELECT 1")
+    with pytest.raises(sqlite3.ProgrammingError):
+        hm.db.execute("SELECT 1")
+    hm = None
+    gc.collect()
+
+
+def test_history_accessor_context_manager(hmmax2, tmp_path):
+    """HistoryAccessor closes its connection when used as a context manager."""
+    hist_file = tmp_path / "history.sqlite"
+    # Create the database file first.
+    with HistoryManager(shell=get_ipython(), hist_file=hist_file):
+        pass
+
+    with HistoryAccessor(hist_file=hist_file) as ha:
+        assert ha.db.execute("SELECT 1").fetchone() == (1,)
+        db = ha.db
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        db.execute("SELECT 1")
+    ha = None
+    gc.collect()
 
 
 def test_histmanager_disabled(hmmax2):
@@ -358,16 +453,17 @@ def test_histmanager_disabled(hmmax2):
         hist_manager_ori = ip.history_manager
         hist_file = Path(tmpdir) / "history.sqlite"
         cfg.HistoryManager.hist_file = hist_file
-        try:
-            ip.history_manager = HistoryManager(shell=ip, config=cfg)
-            hist = ["a=1", "def f():\n    test = 1\n    return test", "b='€Æ¾÷ß'"]
-            for i, h in enumerate(hist, start=1):
-                ip.history_manager.store_inputs(i, h)
-            assert ip.history_manager.input_hist_raw == [""] + hist
-            ip.history_manager.reset()
-            ip.history_manager.end_session()
-        finally:
-            ip.history_manager = hist_manager_ori
+        with HistoryManager(shell=ip, config=cfg) as hm:
+            ip.history_manager = hm
+            try:
+                hist = ["a=1", "def f():\n    test = 1\n    return test", "b='€Æ¾÷ß'"]
+                for i, h in enumerate(hist, start=1):
+                    ip.history_manager.store_inputs(i, h)
+                assert ip.history_manager.input_hist_raw == [""] + hist
+                ip.history_manager.reset()
+                ip.history_manager.end_session()
+            finally:
+                ip.history_manager = hist_manager_ori
 
     # hist_file should not be created
     assert hist_file.exists() is False
@@ -384,15 +480,12 @@ def test_get_tail_session_awareness(hmmax3):
         tmp_path = Path(tmpdir)
         hist_file = tmp_path / "history.sqlite"
         get_source = lambda x: x[2]
-        hm1 = None
-        hm2 = None
-        ha = None
-        try:
+        with ExitStack() as stack:
             # hm1 creates a new session and adds history entries,
             # ha catches up
-            hm1 = HistoryManager(shell=ip, hist_file=hist_file)
+            hm1 = stack.enter_context(HistoryManager(shell=ip, hist_file=hist_file))
             hm1_last_sid = hm1.get_last_session_id
-            ha = HistoryAccessor(hist_file=hist_file)
+            ha = stack.enter_context(HistoryAccessor(hist_file=hist_file))
             ha_last_sid = ha.get_last_session_id
 
             hist1 = ["a=1", "b=1", "c=1"]
@@ -406,7 +499,7 @@ def test_get_tail_session_awareness(hmmax3):
 
             # hm2 creates a new session and adds entries,
             # ha catches up
-            hm2 = HistoryManager(shell=ip, hist_file=hist_file)
+            hm2 = stack.enter_context(HistoryManager(shell=ip, hist_file=hist_file))
             hm2_last_sid = hm2.get_last_session_id
 
             hist2 = ["a=2", "b=2", "c=2"]
@@ -440,15 +533,6 @@ def test_get_tail_session_awareness(hmmax3):
             assert hm1_last_sid() == sid1
             assert hm2_last_sid() == sid2
             assert ha_last_sid() == sid2
-        finally:
-            if hm1:
-                hm1.save_thread.stop()
-                hm1.db.close()
-            if hm2:
-                hm2.save_thread.stop()
-                hm2.db.close()
-            if ha:
-                ha.db.close()
 
 
 def test_calling_run_cell(hmmax2):
@@ -457,23 +541,19 @@ def test_calling_run_cell(hmmax2):
         tmp_path = Path(tmpdir)
         hist_manager_ori = ip.history_manager
         hist_file = tmp_path / "history_test_history1.sqlite"
-        try:
-            ip.history_manager = HistoryManager(shell=ip, hist_file=hist_file)
-            import time
-    
-            session_number = ip.history_manager.session_number
-            ip.run_cell(raw_cell="get_ipython().run_cell(raw_cell='1', store_history=True)", store_history=True)
-            while ip.history_manager.db_input_cache:
-                time.sleep(0)
-            new_session_number = ip.history_manager.session_number
-        finally:
-            # Ensure saving thread is shut down before we try to clean up the files
-            ip.history_manager.end_session()
-            # Forcibly close database rather than relying on garbage collection
-            ip.history_manager.save_thread.stop()
-            ip.history_manager.db.close()
-
-            ip.history_manager = hist_manager_ori
+        with HistoryManager(shell=ip, hist_file=hist_file) as hm:
+            ip.history_manager = hm
+            try:
+                session_number = ip.history_manager.session_number
+                ip.run_cell(raw_cell="get_ipython().run_cell(raw_cell='1', store_history=True)", store_history=True)
+                while ip.history_manager.db_input_cache:
+                    time.sleep(0)
+                new_session_number = ip.history_manager.session_number
+            finally:
+                # End the session; the with-block closes the connection and stops
+                # the saving thread deterministically on exit.
+                hm.end_session()
+                ip.history_manager = hist_manager_ori
     assert session_number == new_session_number, ValueError(f"{session_number} != {new_session_number}")
 
 
@@ -482,16 +562,15 @@ def hist_magic_shell(hmmax2, tmp_path):
     """Shell with a fresh HistoryManager, for testing history-related magics."""
     ip = get_ipython()
     hist_manager_ori = ip.history_manager
-    ip.history_manager = HistoryManager(
+    with HistoryManager(
         shell=ip, hist_file=tmp_path / "history_magics.sqlite"
-    )
-    try:
-        yield ip
-    finally:
-        ip.history_manager.end_session()
-        ip.history_manager.save_thread.stop()
-        ip.history_manager.db.close()
-        ip.history_manager = hist_manager_ori
+    ) as hm:
+        ip.history_manager = hm
+        try:
+            yield ip
+        finally:
+            hm.end_session()
+            ip.history_manager = hist_manager_ori
 
 
 def test_history_magic_output_and_prompts(hist_magic_shell, capsys):


### PR DESCRIPTION
## Problem

The `test_extra` CI job (most reliably `windows-latest, 3.14`) intermittently failed with:

```
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x...>
```

attributed to whatever test happened to be running when the collection occurred — very often `tests/test_magics_code.py::test_edit_nonexistent_warns`. Because `pyproject.toml` sets `filterwarnings = ["error::ResourceWarning"]`, a single stray warning fails an unrelated test, so it read as flakiness.

## Root cause

The leaked connection is **not** an IPython history connection. It comes from **`nbformat`**: the `%notebook` magic creates a `NotebookNotary` to sign the exported notebook, and `NotebookNotary` opens an SQLite signature store eagerly (`nbformat.sign.SQLiteSignatureStore`, in the `jupyter/nbformat` repo) but never closes it. The store's connection was garbage collected unclosed, and the `ResourceWarning` surfaced against whichever test was executing at GC time.

The race only manifests on Windows / Python 3.14 (GC + finalization timing), so it is not reproducible on Linux. It was pinned down by instrumenting the CI runner with a connection-leak tracker that printed the creation traceback of any `sqlite3.Connection` collected while still open — which pointed straight at `nbformat/sign.py`.

## Fix

`IPython/core/magics/basic.py` — close the notary's signature store after signing:

```python
notary = NotebookNotary()
notary.update_config(self.shell.config)
try:
    notary.sign(nb)
finally:
    notary.store.close()
```

## Incidental improvements (history teardown)

While investigating I also tidied up `HistoryManager`/`HistoryAccessor` teardown, which is worth keeping on its own merits:

- `HistorySavingThread.run()` now closes its private per-thread connection on **every** exit path (previously only on the clean-stop path; an error in the loop left it open). Regression tests added.
- Consolidated the repeated `save_thread.stop()` + `db.close()` dance into `HistoryManager.close()` / `HistoryAccessor.close()`, used by `__del__`, the shell's atexit path, and the tests.
- Added context-manager support (`with HistoryManager(...) as hm:` / `with HistoryAccessor(...) as ha:`) and converted the test teardowns to use it.

## Notes

- `nbformat` should arguably close the store itself (e.g. a `__del__`/finalizer on `SQLiteSignatureStore`); this PR fixes IPython's side, which is the only place IPython opens a notary. A follow-up upstream in `jupyter/nbformat` would benefit other callers.
- `ipython/ipykernel` carries an `ignore:unclosed database in <sqlite3.Connection:ResourceWarning` filter for the same warning (mis-attributed there to traitlets); once this and/or an nbformat fix land, that ignore can likely be dropped.
- The branch contains a few `TEMP:` diagnostic commits (and a speculative `weakref.finalize` reaper that was reverted) from the investigation; the net diff is clean. Happy to squash the history if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)