### PR TITLE
fix: recognize cell magics after comments

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -36,6 +36,23 @@ def leading_empty_lines(lines):
             return lines[i:]
     return lines
 
+
+def leading_comment_lines(lines):
+    """Remove leading comments before a cell magic.
+
+    Cell magics must be the first meaningful line in a cell. Comments and
+    blank lines preceding a cell magic do not affect its execution, so remove
+    them before detecting the magic.
+    """
+    for i, line in enumerate(lines):
+        if not line.strip() or line.lstrip().startswith('#'):
+            continue
+        if line.startswith('%%'):
+            return lines[i:]
+        break
+    return lines
+
+
 def leading_indent(lines):
     """Remove leading indentation.
 
@@ -668,6 +685,7 @@ class TransformerManager:
         self.cleanup_transforms = [
             leading_empty_lines,
             leading_indent,
+            leading_comment_lines,
             classic_prompt,
             ipython_prompt,
         ]

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -685,9 +685,9 @@ class TransformerManager:
         self.cleanup_transforms = [
             leading_empty_lines,
             leading_indent,
-            leading_comment_lines,
             classic_prompt,
             ipython_prompt,
+            leading_comment_lines,
         ]
         self.line_transforms = [
             cell_magic,

--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -45,9 +45,9 @@ def leading_comment_lines(lines):
     them before detecting the magic.
     """
     for i, line in enumerate(lines):
-        if not line.strip() or line.lstrip().startswith('#'):
+        if not line.strip() or line.lstrip().startswith("#"):
             continue
-        if line.startswith('%%'):
+        if line.startswith("%%"):
             return lines[i:]
         break
     return lines

--- a/docs/source/whatsnew/pr/incompat-leading-comments-cell-magic.rst
+++ b/docs/source/whatsnew/pr/incompat-leading-comments-cell-magic.rst
@@ -1,5 +1,5 @@
 Leading comments before cell magics
-==================================
+===================================
 
 Leading comments and blank lines are ignored before a cell magic, so a cell
 such as ``# setup`` followed by ``%%time`` is treated as a cell magic instead

--- a/docs/source/whatsnew/pr/incompat-leading-comments-cell-magic.rst
+++ b/docs/source/whatsnew/pr/incompat-leading-comments-cell-magic.rst
@@ -1,0 +1,6 @@
+Leading comments before cell magics
+==================================
+
+Leading comments and blank lines are ignored before a cell magic, so a cell
+such as ``# setup`` followed by ``%%time`` is treated as a cell magic instead
+of an invalid line magic.

--- a/tests/test_inputtransformer2_line.py
+++ b/tests/test_inputtransformer2_line.py
@@ -33,6 +33,14 @@ def test_leading_comments_before_cell_magic():
     )
 
 
+def test_leading_prompted_comments_before_cell_magic():
+    cell = "In [1]: # Set up timing\n   ...: %%time\n   ...: pass\n"
+
+    assert ipt2.TransformerManager().transform_cell(cell) == (
+        "get_ipython().run_cell_magic('time', '', 'pass\\n')\n"
+    )
+
+
 CLASSIC_PROMPT = (
     """\
 >>> for a in range(5):

--- a/tests/test_inputtransformer2_line.py
+++ b/tests/test_inputtransformer2_line.py
@@ -25,6 +25,14 @@ def test_cell_magic():
     assert ipt2.cell_magic(sample.splitlines(keepends=True)) == expected.splitlines(keepends=True)
 
 
+def test_leading_comments_before_cell_magic():
+    cell = "# Set up timing\n\n# Measure this expression\n%%time\npass\n"
+
+    assert ipt2.TransformerManager().transform_cell(cell) == (
+        "get_ipython().run_cell_magic('time', '', 'pass\\n')\n"
+    )
+
+
 CLASSIC_PROMPT = (
     """\
 >>> for a in range(5):


### PR DESCRIPTION
## Summary
- recognize a cell magic after leading comments and blank lines
- add a regression test for a commented `%%time` cell
- document the corrected input transformation behavior

## Root cause
Cell-magic detection only examined the first physical line. A leading comment left `%%time` to the escaped-command transformer, which then attempted to invoke an invalid `%time` line magic.

Fixes #15312

## Validation
- `python -m pytest tests/test_inputtransformer2_line.py tests/test_inputtransformer2.py -q` (66 passed)
- `python -m compileall -q IPython/core/inputtransformer2.py`

🤖🍆