### PR TITLE
Only substitute ~ in compress_user() on a path-component boundary

### DIFF
--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -68,12 +68,15 @@ def get_long_path_name(path):
 def compress_user(path: str) -> str:
     """Reverse of :func:`os.path.expanduser`"""
     home = os.path.expanduser("~")
-    if path == home:
+    # Windows filesystems are case-insensitive and mix separators, so compare
+    # with normcase (a no-op on POSIX). It preserves length, so len(prefix)
+    # still indexes the original, un-normcased path correctly below.
+    if os.path.normcase(path) == os.path.normcase(home):
         return "~"
     # Compare against home + separator, so that a path which merely shares a
     # prefix with home (/home/alice-backup vs /home/alice) is left alone.
     prefix = os.path.join(home, "")
-    if path.startswith(prefix):
+    if os.path.normcase(path).startswith(os.path.normcase(prefix)):
         path = "~" + os.sep + path[len(prefix) :]
     return path
 

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -68,8 +68,13 @@ def get_long_path_name(path):
 def compress_user(path: str) -> str:
     """Reverse of :func:`os.path.expanduser`"""
     home = os.path.expanduser("~")
-    if path.startswith(home):
-        path =  "~" + path[len(home):]
+    if path == home:
+        return "~"
+    # Compare against home + separator, so that a path which merely shares a
+    # prefix with home (/home/alice-backup vs /home/alice) is left alone.
+    prefix = os.path.join(home, "")
+    if path.startswith(prefix):
+        path = "~" + os.sep + path[len(prefix) :]
     return path
 
 def get_py_filename(name):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -486,6 +486,7 @@ def test_link_twice(link_or_copy_src, tmp_path):
     assert os.stat(str(link_or_copy_src)).st_ino == os.stat(dst).st_ino
 
 
+@skip_win32  # setting $HOME doesn't move expanduser("~"), as in test_get_home_dir_3
 @with_environment
 def test_compress_user(tmp_path):
     """compress_user() only substitutes ~ on a path-component boundary."""

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -484,3 +484,23 @@ def test_link_twice(link_or_copy_src, tmp_path):
     path.link_or_copy(str(link_or_copy_src), dst)
     path.link_or_copy(str(link_or_copy_src), dst)
     assert os.stat(str(link_or_copy_src)).st_ino == os.stat(dst).st_ino
+
+
+@with_environment
+def test_compress_user(tmp_path):
+    """compress_user() only substitutes ~ on a path-component boundary."""
+    home = str(tmp_path / "alice")
+    env["HOME"] = home
+
+    assert path.compress_user(join(home, "proj", "foo.py")) == join(
+        "~", "proj", "foo.py"
+    )
+    assert path.compress_user(home) == "~"
+
+    # A path that merely shares a prefix with home is not under it, so it must
+    # come back untouched: "~-backup/lib" would expanduser to a different
+    # (nonexistent) user's home rather than back to where it started.
+    for sibling in (home + "-backup", home + "s"):
+        p = join(sibling, "lib", "foo.py")
+        assert path.compress_user(p) == p
+        assert os.path.expanduser(path.compress_user(p)) == p


### PR DESCRIPTION
`compress_user()` is documented as "Reverse of `os.path.expanduser`", but it tests `path.startswith(home)` with no path-component boundary:

```python
home = os.path.expanduser("~")
if path.startswith(home):
    path =  "~" + path[len(home):]
```

So a path that merely shares a *string* prefix with `$HOME` gets rewritten into a different, nonexistent path:

```
HOME=/home/alice
/home/alice/proj/foo.py         ->  ~/proj/foo.py           round-trips
/home/alice-backup/lib/foo.py   ->  ~-backup/lib/foo.py     does not
/home/alices/lib/foo.py         ->  ~s/lib/foo.py           does not
```

Neither of the last two survives `expanduser` — `~s/...` resolves against a user named `s` — so the round-trip contract is broken and the path shown to the user points somewhere that doesn't exist. `/home/alice-backup` and `/home/alices` are ordinary sibling directories, not contrivances.

This is the path in the `File "..."` line of every traceback (`tbtools.py:205`), in `obj?` output (`oinspect.py:974`), and in the deprecation warnings from `paths.py:46`. Driving the real `obj?` path with a module under `…/alice-backup/` reports `~-backup/pkg/mymod.py`, which is not a file.

(`completerlib.py` imports a *different* `compress_user` from `.completer`, so it isn't affected.)

## The fix

Compare against `home + os.sep` instead, with an explicit `path == home` case so a bare home still gives `~`. `os.path.join(home, "")` is a no-op when home is already the root, which also fixes `HOME=/` turning `/x/y.py` into `~x/y.py`.

## Verification

Regression test added to `tests/test_path.py`, using the file's existing `@with_environment` / `env["HOME"]` convention: it asserts the sibling paths come back untouched *and* that `expanduser(compress_user(p)) == p`. It fails on master with `assert '~-backup/lib/foo.py' == '/…/alice-backup/lib/foo.py'`.

Worth noting why this went unnoticed: `compress_user` has no unit test today. Its only appearance in the suite is `tests/test_oinspect.py:205`:

```python
assert i["file"].lower() == compress_user(fname).lower()
```

which cannot fail on this bug — `i["file"]` *is* `compress_user(fname)`, so both sides go through the same function.

---

*Disclosure 🤖🍆 — correcting my original wording, which implied a human did the checking: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the reproduction, wrote the test, and wrote this description; the human account holder reviews every change and is accountable for it. The reproduction above is real and re-runnable — it was just done by the AI, not a person. (The 🤖🍆 is per CONTRIBUTING; this spells out what is behind it.)*


