### PR TITLE
Fix bare except clauses in tests/test_formatters.py and tests/simpleerr.py

### DIFF
--- a/tests/simpleerr.py
+++ b/tests/simpleerr.py
@@ -21,7 +21,7 @@ def bar(mode):
     elif mode == "exit":
         try:
             stat = int(sys.argv[2])
-        except:
+        except ValueError:
             stat = 1
         sysexit(stat, mode)
     else:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -4,7 +4,7 @@ from math import pi
 
 try:
     import numpy
-except:
+except ImportError:
     numpy = None
 import pytest
 


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types.

**Changes:**
- `tests/test_formatters.py`: `except ImportError:` for the `import numpy` guard
- `tests/simpleerr.py`: `except ValueError:` when parsing `int(sys.argv[2])`

Bare `except:` catches `BaseException` subclasses (including `KeyboardInterrupt`, `SystemExit`). These specific types match the actual exceptions raised by the guarded code.