### PR TITLE
Switch darker to 3.0, use ruff formatter, bump reformat commit

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,10 +35,9 @@ jobs:
         uv pip install --system darker==3.0.0 ruff
     - name: Lint with darker
       run: |
-        # disabling darker for now, I can't get it to format the same locally and on CI.
-        # darker --formatter=ruff -r f51c0b1b6b8e48e228a4eaf62dda382f7e4ba0da --check --diff . || (
-        # echo "Changes need auto-formatting. Run:"
-        # echo "    darker --formatter=ruff -r f51c0b1b6b8e48e228a4eaf62dda382f7e4ba0da ."
-        # echo "then commit and push changes to fix."
-        # exit 1
-        # )
+        darker --formatter=ruff -r f51c0b1b6b8e48e228a4eaf62dda382f7e4ba0da --check --diff . || (
+        echo "Changes need auto-formatting. Run:"
+        echo "    darker --formatter=ruff -r f51c0b1b6b8e48e228a4eaf62dda382f7e4ba0da ."
+        echo "then commit and push changes to fix."
+        exit 1
+        )

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,13 +32,13 @@ jobs:
     - name: Install dependencies
       run: |
         # when changing the versions please update CONTRIBUTING.md too
-        uv pip install --system darker==2.1.1 black==24.10.0
+        uv pip install --system darker==3.0.0 ruff
     - name: Lint with darker
       run: |
         # disabling darker for now, I can't get it to format the same locally and on CI.
-        # darker -r 60625f241f298b5039cb2debc365db38aa7bb522 --check --diff . || (
+        # darker --formatter=ruff -r f51c0b1b6b8e48e228a4eaf62dda382f7e4ba0da --check --diff . || (
         # echo "Changes need auto-formatting. Run:"
-        # echo "    darker -r 60625f241f298b5039cb2debc365db38aa7bb522 ."
+        # echo "    darker --formatter=ruff -r f51c0b1b6b8e48e228a4eaf62dda382f7e4ba0da ."
         # echo "then commit and push changes to fix."
         # exit 1
         # )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,8 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/akaihola/darker
-    rev: 1.7.2
+    rev: v3.0.0
     hooks:
     -   id: darker
-        additional_dependencies: [isort, mypy, flake8]
+        args: [--formatter=ruff]
+        additional_dependencies: [ruff, isort, mypy, flake8]


### PR DESCRIPTION
- Bump darker to 3.0.0 in pre-commit config and CI workflow
- Use ruff as the darker formatter (--formatter=ruff)
- Bump the reformat base revision to the current main sha

🤖 🍆

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017cnqsGk7Wf4y4uFsrwknme