### PR TITLE
Disable emacs_bindings_in_vi_insert_mode by default

### DIFF
--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -261,7 +261,7 @@ class TerminalInteractiveShell(InteractiveShell):
     ).tag(config=True)
 
     emacs_bindings_in_vi_insert_mode = Bool(
-        True,
+        False,
         help="Add shortcuts from 'emacs' insert mode to 'vi' insert mode.",
     ).tag(config=True)
 


### PR DESCRIPTION
Consider disabling emacs_bindings_in_vi_insert_mode by default. **It delays entering normal mode**. And if you forget to wait or double-tap ESC and **press H, J, K, or L, it goes back or forward in history or deletes everything before or after your cursor**, which **makes the VI mode completely useless** for the average VI enjoyer and **causes unnecessary confusion**. I am not sure if this behavior is intended. **Users have expressed this in past issues** as well, so I recommend just turning it off by default while **keeping it as an option** in the IPython config file.

As of now it just degrades the experience with VI mode on IPython.