### PR TITLE
Fix most warnings and resource leaks in the test suite

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -432,7 +432,7 @@ class Pdb(OldPdb):
         """
         # The f_locals dictionary is updated from the actual frame
         # locals whenever the .f_locals accessor is called, so we
-        # avoid calling it here to preserve self.curframe_locals.
+        # avoid calling it here to preserve self._curframe_locals.
         # Furthermore, there is no good reason to hide the current frame.
         ip_hide = [self._hidden_predicate(s[0]) for s in stack]
         ip_start = [i for i, s in enumerate(ip_hide) if s == "__ipython_bottom__"]
@@ -659,6 +659,21 @@ class Pdb(OldPdb):
             # 3.13 and 3.12 don't need any changes.
             super()._pdbcmd_print_frame_status(arg) # type: ignore[misc]
 
+    @property
+    def _curframe_locals(self):
+        """Locals of the frame the debugger currently points at.
+
+        On Python 3.13+, ``frame.f_locals`` is a write-through proxy (PEP 667)
+        which pdb no longer caches, and ``Pdb.curframe_locals`` is deprecated
+        in 3.14 in favor of ``curframe.f_locals``. On older versions
+        ``curframe_locals`` is a snapshot which must be reused, see
+        `_get_frame_locals`.
+        """
+        assert self.curframe is not None
+        if sys.version_info >= (3, 13):
+            return self.curframe.f_locals
+        return self.curframe_locals
+
     def _get_frame_locals(self, frame):
         """ "
         Accessing f_local of current frame reset the namespace, so we want to avoid
@@ -673,11 +688,11 @@ class Pdb(OldPdb):
         ipdb> foo
         "old"
 
-        So if frame is self.current_frame we instead return self.curframe_locals
+        So if frame is self.current_frame we instead return self._curframe_locals
 
         """
         if frame is self.curframe:
-            return self.curframe_locals
+            return self._curframe_locals
         else:
             return frame.f_locals
 
@@ -1000,7 +1015,7 @@ class Pdb(OldPdb):
         sys.settrace(None)
         assert self.curframe is not None
         globals = self.curframe.f_globals
-        locals = self.curframe_locals
+        locals = self._curframe_locals
         p = self.__class__(
             completekey=self.completekey, stdin=self.stdin, stdout=self.stdout
         )
@@ -1018,7 +1033,7 @@ class Pdb(OldPdb):
         The debugger interface to %pdef"""
         assert self.curframe is not None
         namespaces = [
-            ("Locals", self.curframe_locals),
+            ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
         self.shell.find_line_magic("pdef")(arg, namespaces=namespaces)
@@ -1029,7 +1044,7 @@ class Pdb(OldPdb):
         The debugger interface to %pdoc."""
         assert self.curframe is not None
         namespaces = [
-            ("Locals", self.curframe_locals),
+            ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
         self.shell.find_line_magic("pdoc")(arg, namespaces=namespaces)
@@ -1041,7 +1056,7 @@ class Pdb(OldPdb):
         """
         assert self.curframe is not None
         namespaces = [
-            ("Locals", self.curframe_locals),
+            ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
         self.shell.find_line_magic("pfile")(arg, namespaces=namespaces)
@@ -1052,7 +1067,7 @@ class Pdb(OldPdb):
         The debugger interface to %pinfo, i.e., obj?."""
         assert self.curframe is not None
         namespaces = [
-            ("Locals", self.curframe_locals),
+            ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
         self.shell.find_line_magic("pinfo")(arg, namespaces=namespaces)
@@ -1063,7 +1078,7 @@ class Pdb(OldPdb):
         The debugger interface to %pinfo2, i.e., obj??."""
         assert self.curframe is not None
         namespaces = [
-            ("Locals", self.curframe_locals),
+            ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
         self.shell.find_line_magic("pinfo2")(arg, namespaces=namespaces)
@@ -1072,7 +1087,7 @@ class Pdb(OldPdb):
         """Print (or run through pager) the source code for an object."""
         assert self.curframe is not None
         namespaces = [
-            ("Locals", self.curframe_locals),
+            ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
         self.shell.find_line_magic("psource")(arg, namespaces=namespaces)

--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -126,7 +126,7 @@ class TerminalPdb(Pdb):
             if self.cmdqueue:
                 line = self.cmdqueue.pop(0)
             else:
-                self._ptcomp.ipy_completer.namespace = self.curframe_locals
+                self._ptcomp.ipy_completer.namespace = self._curframe_locals
                 self._ptcomp.ipy_completer.global_namespace = self.curframe.f_globals
 
                 # Run the prompt in a different thread.
@@ -156,7 +156,7 @@ class TerminalPdb(Pdb):
         global_ns = self.curframe.f_globals
         ipshell(
             module=sys.modules.get(global_ns["__name__"], None),
-            local_ns=self.curframe_locals,
+            local_ns=self._curframe_locals,
         )
 
 

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -308,12 +308,14 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
         # Make sure there is a space below the banner.
         if self.log_level <= logging.INFO: print()
 
-    def _pylab_changed(self, name, old, new):
+    @observe("pylab")
+    def _pylab_changed(self, change):
         """Replace --pylab='inline' with --pylab='auto'"""
-        if new == 'inline':
-            warnings.warn("'inline' not available as pylab backend, "
-                      "using 'auto' instead.")
-            self.pylab = 'auto'
+        if change["new"] == "inline":
+            warnings.warn(
+                "'inline' not available as pylab backend, using 'auto' instead."
+            )
+            self.pylab = "auto"
 
     def start(self):
         if self.subapp is not None:

--- a/tests/test_async_helpers.py
+++ b/tests/test_async_helpers.py
@@ -4,6 +4,7 @@ Test for async helpers.
 Should only trigger on python 3.5+ or will have syntax errors.
 """
 
+import contextlib
 import sys
 from itertools import chain, repeat
 from textwrap import dedent, indent
@@ -26,6 +27,19 @@ def iprc(x):
 
 def iprc_nr(x):
     return ip.run_cell(dedent(x))
+
+
+def _finally_return_warning():
+    """Context manager for the ``{val}="return"`` + ``"finally"`` test case.
+
+    Compiling a ``return`` that exits a ``finally`` block emits
+    ``SyntaxWarning: 'return' in a 'finally' block`` starting with Python
+    3.14 (PEP 765). That warning does not exist on older Pythons, so only
+    assert it there; on earlier versions this is a no-op.
+    """
+    if sys.version_info >= (3, 14):
+        return pytest.warns(SyntaxWarning, match="'return' in a 'finally' block")
+    return contextlib.nullcontext()
 
 
 @pytest.fixture(autouse=True)
@@ -245,14 +259,15 @@ def test_top_level_return_error():
         ),
     )
 
-    for test_name, test_case in tl_err_test_cases:
-        # This example should work if 'pass' is used as the value
-        iprc(test_case.format(val="pass"))
+    with _finally_return_warning():
+        for test_name, test_case in tl_err_test_cases:
+            # This example should work if 'pass' is used as the value
+            iprc(test_case.format(val="pass"))
 
-        # It should fail with all the values
-        for val in vals:
-            with pytest.raises(SyntaxError):
-                iprc(test_case.format(val=val))
+            # It should fail with all the values
+            for val in vals:
+                with pytest.raises(SyntaxError):
+                    iprc(test_case.format(val=val))
 
 
 def test_in_func_no_error():
@@ -341,18 +356,19 @@ def test_in_func_no_error():
 
     tests = chain(success_tests, failure_tests)
 
-    for context_name, async_func, context in func_contexts:
-        for (test_name, test_case), should_fail in tests:
-            nested_case = nest_case(context, test_case)
+    with _finally_return_warning():
+        for context_name, async_func, context in func_contexts:
+            for (test_name, test_case), should_fail in tests:
+                nested_case = nest_case(context, test_case)
 
-            for val in vals:
-                cell = nested_case.format(val=val)
+                for val in vals:
+                    cell = nested_case.format(val=val)
 
-                if should_fail:
-                    with pytest.raises(SyntaxError):
+                    if should_fail:
+                        with pytest.raises(SyntaxError):
+                            iprc(cell)
+                    else:
                         iprc(cell)
-                else:
-                    iprc(cell)
 
 
 def test_nonlocal():

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -791,6 +791,11 @@ def test_omit__names():
 def test_limit_to__all__False_ok():
     """
     Limit to all is deprecated, once we remove it this test can go away.
+
+    ``limit_to__all__`` has since been removed from ``IPCompleter``, so
+    setting it now triggers traitlets' "not recognized" warning; that is
+    expected here since the point of the test is to make sure the (now
+    unknown) option doesn't break completion.
     """
     ip = get_ipython()
     c = ip.Completer
@@ -799,7 +804,8 @@ def test_limit_to__all__False_ok():
     ip.ex("d=D()")
     cfg = Config()
     cfg.IPCompleter.limit_to__all__ = False
-    c.update_config(cfg)
+    with pytest.warns(UserWarning, match="limit_to__all__.*not recognized"):
+        c.update_config(cfg)
     s, matches = c.complete("d.")
     assert ".x" in matches
 

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -1049,7 +1049,11 @@ def test_pdb_subclass_accepts_mode(cls, mode):
     """The ``mode`` argument (added to ``pdb.Pdb`` in Python 3.14) should be
     accepted on every supported Python version and stored on the instance."""
     inst = cls(mode=mode)
-    assert inst.mode == mode
+    try:
+        assert inst.mode == mode
+    finally:
+        if isinstance(inst, TerminalPdb):
+            _cleanup_terminal_pdb(inst)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -1517,8 +1517,8 @@ def test_list_shows_breakpoint_markers(tmp_path):
 def test_format_stack_entry_return_and_args(tmp_path):
     exc, path = _exec_failing_module(tmp_path)
     p = _post_mortem_pdb(exc)
-    p.curframe_locals["__return__"] = "some-return-value"
-    p.curframe_locals["__args__"] = (1, 2, 3)
+    p._curframe_locals["__return__"] = "some-return-value"
+    p._curframe_locals["__args__"] = (1, 2, 3)
     out = _uncolor(p.format_stack_entry(p.stack[p.curindex]))
     assert "some-return-value" in out
     assert "(1, 2, 3)" in out

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -56,20 +56,20 @@ def test_warning_on_non_existent_path_FileLink():
 
 def test_existing_path_FileLink():
     """FileLink: Calling _repr_html_ functions as expected on existing filepath"""
-    tf = NamedTemporaryFile()
-    fl = display.FileLink(tf.name)
-    actual = fl._repr_html_()
-    expected = "<a href='%s' target='_blank'>%s</a><br>" % (tf.name, tf.name)
-    assert actual == expected
+    with NamedTemporaryFile() as tf:
+        fl = display.FileLink(tf.name)
+        actual = fl._repr_html_()
+        expected = "<a href='%s' target='_blank'>%s</a><br>" % (tf.name, tf.name)
+        assert actual == expected
 
 
 def test_existing_path_FileLink_repr():
     """FileLink: Calling repr() functions as expected on existing filepath"""
-    tf = NamedTemporaryFile()
-    fl = display.FileLink(tf.name)
-    actual = repr(fl)
-    expected = tf.name
-    assert actual == expected
+    with NamedTemporaryFile() as tf:
+        fl = display.FileLink(tf.name)
+        actual = repr(fl)
+        expected = tf.name
+        assert actual == expected
 
 
 def test_error_on_directory_to_FileLink():
@@ -97,100 +97,95 @@ def test_warning_on_non_existent_path_FileLinks():
 def test_existing_path_FileLinks():
     """FileLinks: Calling _repr_html_ functions as expected on existing dir"""
     td = mkdtemp()
-    tf1 = NamedTemporaryFile(dir=td)
-    tf2 = NamedTemporaryFile(dir=td)
-    fl = display.FileLinks(td)
-    actual = fl._repr_html_()
-    actual = actual.split("\n")
-    actual.sort()
-    # the links should always have forward slashes, even on windows, so replace
-    # backslashes with forward slashes here
-    expected = [
-        "%s/<br>" % td,
-        "&nbsp;&nbsp;<a href='%s' target='_blank'>%s</a><br>"
-        % (tf2.name.replace("\\", "/"), split(tf2.name)[1]),
-        "&nbsp;&nbsp;<a href='%s' target='_blank'>%s</a><br>"
-        % (tf1.name.replace("\\", "/"), split(tf1.name)[1]),
-    ]
-    expected.sort()
-    # We compare the sorted list of links here as that's more reliable
-    assert actual == expected
+    with NamedTemporaryFile(dir=td) as tf1, NamedTemporaryFile(dir=td) as tf2:
+        fl = display.FileLinks(td)
+        actual = fl._repr_html_()
+        actual = actual.split("\n")
+        actual.sort()
+        # the links should always have forward slashes, even on windows, so replace
+        # backslashes with forward slashes here
+        expected = [
+            "%s/<br>" % td,
+            "&nbsp;&nbsp;<a href='%s' target='_blank'>%s</a><br>"
+            % (tf2.name.replace("\\", "/"), split(tf2.name)[1]),
+            "&nbsp;&nbsp;<a href='%s' target='_blank'>%s</a><br>"
+            % (tf1.name.replace("\\", "/"), split(tf1.name)[1]),
+        ]
+        expected.sort()
+        # We compare the sorted list of links here as that's more reliable
+        assert actual == expected
 
 
 def test_existing_path_FileLinks_alt_formatter():
     """FileLinks: Calling _repr_html_ functions as expected w/ an alt formatter"""
     td = mkdtemp()
-    tf1 = NamedTemporaryFile(dir=td)
-    tf2 = NamedTemporaryFile(dir=td)
+    with NamedTemporaryFile(dir=td) as tf1, NamedTemporaryFile(dir=td) as tf2:
 
-    def fake_formatter(dirname, fnames, included_suffixes):
-        return ["hello", "world"]
+        def fake_formatter(dirname, fnames, included_suffixes):
+            return ["hello", "world"]
 
-    fl = display.FileLinks(td, notebook_display_formatter=fake_formatter)
-    actual = fl._repr_html_()
-    actual = actual.split("\n")
-    actual.sort()
-    expected = ["hello", "world"]
-    expected.sort()
-    # We compare the sorted list of links here as that's more reliable
-    assert actual == expected
+        fl = display.FileLinks(td, notebook_display_formatter=fake_formatter)
+        actual = fl._repr_html_()
+        actual = actual.split("\n")
+        actual.sort()
+        expected = ["hello", "world"]
+        expected.sort()
+        # We compare the sorted list of links here as that's more reliable
+        assert actual == expected
 
 
 def test_existing_path_FileLinks_repr():
     """FileLinks: Calling repr() functions as expected on existing directory"""
     td = mkdtemp()
-    tf1 = NamedTemporaryFile(dir=td)
-    tf2 = NamedTemporaryFile(dir=td)
-    fl = display.FileLinks(td)
-    actual = repr(fl)
-    actual = actual.split("\n")
-    actual.sort()
-    expected = ["%s/" % td, "  %s" % split(tf1.name)[1], "  %s" % split(tf2.name)[1]]
-    expected.sort()
-    # We compare the sorted list of links here as that's more reliable
-    assert actual == expected
+    with NamedTemporaryFile(dir=td) as tf1, NamedTemporaryFile(dir=td) as tf2:
+        fl = display.FileLinks(td)
+        actual = repr(fl)
+        actual = actual.split("\n")
+        actual.sort()
+        expected = ["%s/" % td, "  %s" % split(tf1.name)[1], "  %s" % split(tf2.name)[1]]
+        expected.sort()
+        # We compare the sorted list of links here as that's more reliable
+        assert actual == expected
 
 
 def test_existing_path_FileLinks_repr_alt_formatter():
     """FileLinks: Calling repr() functions as expected w/ alt formatter"""
     td = mkdtemp()
-    tf1 = NamedTemporaryFile(dir=td)
-    tf2 = NamedTemporaryFile(dir=td)
+    with NamedTemporaryFile(dir=td) as tf1, NamedTemporaryFile(dir=td) as tf2:
 
-    def fake_formatter(dirname, fnames, included_suffixes):
-        return ["hello", "world"]
+        def fake_formatter(dirname, fnames, included_suffixes):
+            return ["hello", "world"]
 
-    fl = display.FileLinks(td, terminal_display_formatter=fake_formatter)
-    actual = repr(fl)
-    actual = actual.split("\n")
-    actual.sort()
-    expected = ["hello", "world"]
-    expected.sort()
-    # We compare the sorted list of links here as that's more reliable
-    assert actual == expected
+        fl = display.FileLinks(td, terminal_display_formatter=fake_formatter)
+        actual = repr(fl)
+        actual = actual.split("\n")
+        actual.sort()
+        expected = ["hello", "world"]
+        expected.sort()
+        # We compare the sorted list of links here as that's more reliable
+        assert actual == expected
 
 
 def test_error_on_file_to_FileLinks():
     """FileLinks: Raises error when passed file"""
     td = mkdtemp()
-    tf1 = NamedTemporaryFile(dir=td)
-    pytest.raises(ValueError, display.FileLinks, tf1.name)
+    with NamedTemporaryFile(dir=td) as tf1:
+        pytest.raises(ValueError, display.FileLinks, tf1.name)
 
 
 def test_recursive_FileLinks():
     """FileLinks: Does not recurse when recursive=False"""
     td = mkdtemp()
-    tf = NamedTemporaryFile(dir=td)
     subtd = mkdtemp(dir=td)
-    subtf = NamedTemporaryFile(dir=subtd)
-    fl = display.FileLinks(td)
-    actual = str(fl)
-    actual = actual.split("\n")
-    assert len(actual) == 4, actual
-    fl = display.FileLinks(td, recursive=False)
-    actual = str(fl)
-    actual = actual.split("\n")
-    assert len(actual) == 2, actual
+    with NamedTemporaryFile(dir=td) as tf, NamedTemporaryFile(dir=subtd) as subtf:
+        fl = display.FileLinks(td)
+        actual = str(fl)
+        actual = actual.split("\n")
+        assert len(actual) == 4, actual
+        fl = display.FileLinks(td, recursive=False)
+        actual = str(fl)
+        actual = actual.split("\n")
+        assert len(actual) == 2, actual
 
 
 def test_audio_from_file():

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -6,7 +6,7 @@ import pytest
 
 from IPython.core.error import TryNext
 from IPython.utils import generics
-from IPython.utils.generics import complete_object, inspect_object
+from IPython.utils.generics import complete_object
 
 
 def test_inspect_object_deprecated():
@@ -23,6 +23,8 @@ def test_complete_object_not_deprecated():
 
 
 def test_inspect_object_default_raises_trynext():
+    with pytest.warns(DeprecationWarning, match="inspect_object is deprecated"):
+        inspect_object = generics.inspect_object
     with pytest.raises(TryNext):
         inspect_object(object())
 
@@ -38,12 +40,14 @@ def test_inspect_object_custom_dispatch():
 
     called_with = []
 
-    @inspect_object.register(MyType)
-    def _(obj):
-        called_with.append(obj)
+    with pytest.warns(DeprecationWarning, match="inspect_object is deprecated"):
+        @generics.inspect_object.register(MyType)
+        def _(obj):
+            called_with.append(obj)
 
     obj = MyType()
-    inspect_object(obj)
+    with pytest.warns(DeprecationWarning, match="inspect_object is deprecated"):
+        generics.inspect_object(obj)
     assert called_with == [obj]
 
 

--- a/tests/test_inputtransformer2.py
+++ b/tests/test_inputtransformer2.py
@@ -182,10 +182,14 @@ def test_check_make_token_by_line_never_ends_empty():
     """
     from string import printable
 
-    for c in printable:
-        assert make_tokens_by_line(c)[-1] != []
-        for k in printable:
-            assert make_tokens_by_line(c + k)[-1] != []
+    # Most of the two-character combinations below are missing a line
+    # ending, which `make_tokens_by_line` deliberately warns about; assert
+    # on that warning instead of letting it leak into the test output.
+    with pytest.warns(UserWarning, match="do not have lineending markers"):
+        for c in printable:
+            assert make_tokens_by_line(c)[-1] != []
+            for k in printable:
+                assert make_tokens_by_line(c + k)[-1] != []
 
 
 def check_find(transformer, case, match=True):

--- a/tests/test_interactiveshell.py
+++ b/tests/test_interactiveshell.py
@@ -1277,7 +1277,10 @@ def test_run_cell_async():
     coro = ip.run_cell_async(raw_cell, transformed_cell=ip.transform_cell(raw_cell))
     assert asyncio.iscoroutine(coro)
     loop = asyncio.new_event_loop()
-    result = loop.run_until_complete(coro)
+    try:
+        result = loop.run_until_complete(coro)
+    finally:
+        loop.close()
     assert isinstance(result, interactiveshell.ExecutionResult)
     assert result.result == 5
 

--- a/tests/test_ipapp.py
+++ b/tests/test_ipapp.py
@@ -160,7 +160,8 @@ def test_exec_lines_run_and_are_hidden(make_app):
     app = make_app(
         [
             "--no-banner",
-            "--InteractiveShellApp.exec_lines=['zzz_el = 99', 'zzz_el2 = zzz_el + 1']",
+            "--InteractiveShellApp.exec_lines=zzz_el = 99",
+            "--InteractiveShellApp.exec_lines=zzz_el2 = zzz_el + 1",
         ]
     )
     assert app.shell.user_ns["zzz_el"] == 99
@@ -172,7 +173,11 @@ def test_exec_lines_run_and_are_hidden(make_app):
 
 def test_exec_lines_error_continues(make_app):
     app = make_app(
-        ["--no-banner", "--InteractiveShellApp.exec_lines=['1/0', 'zzz_after = 5']"]
+        [
+            "--no-banner",
+            "--InteractiveShellApp.exec_lines=1/0",
+            "--InteractiveShellApp.exec_lines=zzz_after = 5",
+        ]
     )
     # an error in one line doesn't prevent the next from running
     assert app.shell.user_ns["zzz_after"] == 5
@@ -187,7 +192,8 @@ def test_exec_files(tmp_path, make_app):
     app = make_app(
         [
             "--no-banner",
-            "--InteractiveShellApp.exec_files=['%s', '%s']" % (pyfile, ipyfile),
+            "--InteractiveShellApp.exec_files=%s" % pyfile,
+            "--InteractiveShellApp.exec_files=%s" % ipyfile,
         ]
     )
     assert app.shell.user_ns["zzz_exec_py"] == 1
@@ -196,7 +202,7 @@ def test_exec_files(tmp_path, make_app):
 
 def test_exec_files_missing_is_only_a_warning(make_app):
     app = make_app(
-        ["--no-banner", "--InteractiveShellApp.exec_files=['zzz_no_such_file.py']"]
+        ["--no-banner", "--InteractiveShellApp.exec_files=zzz_no_such_file.py"]
     )
     # a missing exec_file is not fatal
     assert app.shell is not None
@@ -242,9 +248,7 @@ def test_startup_file_error_is_not_fatal(tmp_path, make_app, monkeypatch, capsys
 def test_exec_files_error_is_not_fatal(tmp_path, make_app, capsys):
     bad = tmp_path / "zzz_bad_exec.py"
     bad.write_text("raise ValueError('zzz-bad-exec-file')\n")
-    app = make_app(
-        ["--no-banner", "--InteractiveShellApp.exec_files=['%s']" % bad]
-    )
+    app = make_app(["--no-banner", "--InteractiveShellApp.exec_files=%s" % bad])
     assert app.shell is not None
     out, err = capsys.readouterr()
     assert "zzz-bad-exec-file" in out + err

--- a/tests/test_ipapp.py
+++ b/tests/test_ipapp.py
@@ -396,7 +396,7 @@ def test_pylab_inline_replaced_by_auto(make_app):
     pytest.importorskip("matplotlib")
     app = make_app(["--no-banner"])
     with pytest.warns(UserWarning, match="'inline' not available"):
-        app._pylab_changed("pylab", None, "inline")
+        app.pylab = "inline"
     assert app.pylab == "auto"
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -264,11 +264,11 @@ def test_get_xdg_dir_3(monkeypatch):
 
 def test_filefind():
     """Various tests for filefind"""
-    f = tempfile.NamedTemporaryFile()
-    # print('fname:',f.name)
-    alt_dirs = paths.get_ipython_dir()
-    t = path.filefind(f.name, alt_dirs)
-    # print('found:',t)
+    with tempfile.NamedTemporaryFile() as f:
+        # print('fname:',f.name)
+        alt_dirs = paths.get_ipython_dir()
+        t = path.filefind(f.name, alt_dirs)
+        # print('found:',t)
 
 
 @dec.skip_if_not_win32

--- a/tests/test_ultratb.py
+++ b/tests/test_ultratb.py
@@ -316,9 +316,12 @@ def test_exception_during_handling_error():
 
 
 def test_sysexit_while_handling_error():
-    with tt.AssertPrints(["SystemExit", "to see the full traceback"]):
-        with tt.AssertNotPrints(["another exception"], suppress=False):
-            ip.run_cell(_SYS_EXIT_WITH_CONTEXT_CODE)
+    # Raising SystemExit from user code deliberately makes IPython emit its
+    # "To exit: use 'exit', 'quit', or Ctrl-D." reminder; that is expected.
+    with pytest.warns(UserWarning, match="To exit: use 'exit', 'quit', or Ctrl-D."):
+        with tt.AssertPrints(["SystemExit", "to see the full traceback"]):
+            with tt.AssertNotPrints(["another exception"], suppress=False):
+                ip.run_cell(_SYS_EXIT_WITH_CONTEXT_CODE)
 
 
 def test_suppress_exception_chaining():


### PR DESCRIPTION
Brings the pytest warnings summary from **114 warnings down to 16** on Python 3.14, and to 0 on 3.11.

Verified locally against CPython 3.11, 3.13 and 3.14 (the `curframe_locals` and PEP 765 warnings only appear on 3.14, so a 3.14 interpreter was needed to reproduce the CI output).

## Library fixes

- **`IPython/core/debugger.py`, `IPython/terminal/debugger.py`** — `Pdb.curframe_locals` is deprecated in Python 3.14 in favour of `curframe.f_locals`, which since PEP 667 is a write-through proxy that pdb no longer caches. Added a `Pdb._curframe_locals` helper that returns `curframe.f_locals` on 3.13+ and the old cached snapshot on older versions, and used it at every call site. The snapshot workaround in `_get_frame_locals` is still needed on 3.11/3.12, so the behaviour there is unchanged. This accounted for roughly 50 of the warnings.
- **`IPython/terminal/ipapp.py`** — `TerminalIPythonApp._pylab_changed` still used the traitlets 4.0 magic `_<name>_changed` method signature. It is now registered with `@observe("pylab")` and takes a `change` dict, matching the other observers in that class. Confirmed the observer still fires exactly once and still rewrites `--pylab=inline` to `auto`.

## Test fixes

- **`tests/test_display.py`, `tests/test_path.py`** — `NamedTemporaryFile`s were left to the garbage collector; they are now closed via `with` blocks (13 `ResourceWarning`s).
- **`tests/test_debugger.py`, `tests/test_interactiveshell.py`** — `test_pdb_subclass_accepts_mode` and `test_run_cell_async` each leaked an asyncio event loop and its socketpair. The former now reuses the existing `_cleanup_terminal_pdb` helper, the latter closes its loop in a `finally`. These were the source of the scattered `unclosed <socket.socket fd=NN>` warnings: pytest's unraisable plugin attributes them to whichever test happens to trigger the collection, which is why they showed up under unrelated tests such as `test_display_2` and `test_interactivshell` in the CI log.
- **`tests/test_ipapp.py`** — `exec_lines`/`exec_files` were passed as Python list literals on the command line, which traitlets 5 deprecates; they are now passed as repeated options.
- **`tests/test_generics.py`, `tests/test_completer.py`, `tests/test_inputtransformer2.py`, `tests/test_async_helpers.py`, `tests/test_ultratb.py`** — warnings these tests deliberately trigger are now asserted with `pytest.warns` instead of leaking into the summary: the deprecated `inspect_object`, the unrecognized `limit_to__all__` config option, `make_tokens_by_line` receiving lines without line endings, PEP 765 `return` in a `finally` block, and the "To exit: use 'exit', 'quit', or Ctrl-D." reminder. The PEP 765 assertion is guarded on `sys.version_info >= (3, 14)` since the warning does not exist on earlier interpreters.

## Not addressed

The remaining 16 warnings are all `pty.py: DeprecationWarning: This process is multi-threaded, use of forkpty() may lead to deadlocks in the child`, which needs a change to how the pty is spawned rather than a local cleanup.

Two things noticed along the way and deliberately left alone:

- `TerminalPdb.pt_init` assigns `self.pt_loop = asyncio.new_event_loop()`, but `pt_loop` is never read anywhere in IPython and never closed, so every `TerminalPdb` instance leaks a loop and a socketpair. This PR only cleans it up in the tests, since removing the attribute would be a public API change that `ipdb`/`madbg` may depend on.
- `test_completer.py::test_limit_to__all__False_ok` is now vestigial — `limit_to__all__` has been removed from `IPCompleter`, so the test only checks that an unknown config key does not break completion. Its docstring already says "once we remove it this test can go away"; deleting it seemed out of scope here.

## Testing

Full suite run on each interpreter:

| Python | Result | Warnings |
| --- | --- | --- |
| 3.11 | 2669 passed, 157 skipped, 3 xfailed | 0 |
| 3.13 | 2658 passed, 166 skipped, 3 xfailed | 16 (`forkpty` only) |
| 3.14 | 2657 passed, 167 skipped, 3 xfailed | 16 (`forkpty` only) |

`mypy IPython` passes, and `darker --formatter=ruff` reports no changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4ZHXstKBDzAzLPzzSdoqG)_