### PR TITLE
Add version information to deprecation warnings

### DIFF
--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -804,7 +804,7 @@ class InteractiveShell(SingletonConfigurable):
         new = proposal["value"]
         if not new == new.lower():
             warn(
-                f"`TerminalInteractiveShell.colors` is now lowercase: `{new.lower()}`,"
+                f"`TerminalInteractiveShell.colors` is now lowercase since IPython 9.0: `{new.lower()}`,"
                 " non lowercase, may be invalid in the future.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -530,7 +530,7 @@ class VerboseTB(TBTools):
             if theme_name != _default:
                 warnings.warn(
                     "You passed both `theme_name` and `color_scheme` "
-                    "(deprecated) to VerboseTB constructor. `theme_name` will "
+                    "(deprecated since IPython 9.0) to VerboseTB constructor. `theme_name` will "
                     "be ignored for the time being.",
                     stacklevel=2,
                     category=DeprecationWarning,


### PR DESCRIPTION
- Added 'since IPython 9.0' to TerminalInteractiveShell.colors deprecation warning
- Added 'since IPython 9.0' to VerboseTB color_scheme deprecation warning

These warnings were missing version information, making it unclear when the
deprecation was introduced or when the deprecated functionality will be removed.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code