### PR TITLE
Fix the remaining forkpty warnings in the test suite

### DIFF
--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -11,6 +11,7 @@ import os
 import signal
 import sys
 import time
+import weakref
 from codecs import getincrementaldecoder
 from subprocess import CalledProcessError
 from threading import Thread
@@ -134,13 +135,24 @@ class ScriptMagics(Magics):
         super().__init__(shell=shell)
         self._generate_script_magics()
         self.bg_processes = []
-        self._event_loop_thread = None
+        self._event_loop_finalizer = None
         atexit.register(self.kill_bg_processes)
-        atexit.register(self.stop_event_loop)
 
     def __del__(self):
         self.kill_bg_processes()
-        self.stop_event_loop()
+
+    @staticmethod
+    def _shutdown_event_loop(event_loop, thread):
+        """Stop ``event_loop``, wait for ``thread`` to notice, and close it.
+
+        Kept free of any reference to the ``ScriptMagics`` instance so it can
+        be handed to :func:`weakref.finalize` without keeping that instance
+        alive.
+        """
+        if not event_loop.is_closed():
+            event_loop.call_soon_threadsafe(event_loop.stop)
+            thread.join()
+            event_loop.close()
 
     def stop_event_loop(self):
         """Stop the background event loop and the thread running it.
@@ -151,15 +163,14 @@ class ScriptMagics(Magics):
         the socketpair it uses for its self-pipe) unclosed, and keeps the
         process multi-threaded, which ``os.fork()`` warns about since
         Python 3.12. Safe to call more than once.
+
+        The same shutdown runs on its own if this object is garbage collected,
+        and at interpreter exit, through the finalizer ``shebang`` registers.
         """
-        event_loop, self.event_loop = self.event_loop, None
-        thread, self._event_loop_thread = self._event_loop_thread, None
-        if event_loop is None:
-            return
-        event_loop.call_soon_threadsafe(event_loop.stop)
-        if thread is not None:
-            thread.join()
-        event_loop.close()
+        finalizer, self._event_loop_finalizer = self._event_loop_finalizer, None
+        self.event_loop = None
+        if finalizer is not None:
+            finalizer()
 
     def _generate_script_magics(self):
         cell_magics = self.magics['cell']
@@ -233,7 +244,11 @@ class ScriptMagics(Magics):
             # start the loop in a background thread
             asyncio_thread = Thread(target=event_loop.run_forever, daemon=True)
             asyncio_thread.start()
-            self._event_loop_thread = asyncio_thread
+            # ... and make sure it is stopped again, at the latest when we are
+            # collected or the interpreter exits
+            self._event_loop_finalizer = weakref.finalize(
+                self, self._shutdown_event_loop, event_loop, asyncio_thread
+            )
         else:
             event_loop = self.event_loop
 

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -134,10 +134,32 @@ class ScriptMagics(Magics):
         super().__init__(shell=shell)
         self._generate_script_magics()
         self.bg_processes = []
+        self._event_loop_thread = None
         atexit.register(self.kill_bg_processes)
+        atexit.register(self.stop_event_loop)
 
     def __del__(self):
         self.kill_bg_processes()
+        self.stop_event_loop()
+
+    def stop_event_loop(self):
+        """Stop the background event loop and the thread running it.
+
+        The loop is started lazily by ``shebang`` and then kept around to be
+        reused; this is the deterministic way to shut it back down. Without it
+        the thread lives until the process exits, which leaves the loop (and
+        the socketpair it uses for its self-pipe) unclosed, and keeps the
+        process multi-threaded, which ``os.fork()`` warns about since
+        Python 3.12. Safe to call more than once.
+        """
+        event_loop, self.event_loop = self.event_loop, None
+        thread, self._event_loop_thread = self._event_loop_thread, None
+        if event_loop is None:
+            return
+        event_loop.call_soon_threadsafe(event_loop.stop)
+        if thread is not None:
+            thread.join()
+        event_loop.close()
 
     def _generate_script_magics(self):
         cell_magics = self.magics['cell']
@@ -211,6 +233,7 @@ class ScriptMagics(Magics):
             # start the loop in a background thread
             asyncio_thread = Thread(target=event_loop.run_forever, daemon=True)
             asyncio_thread.start()
+            self._event_loop_thread = asyncio_thread
         else:
             event_loop = self.event_loop
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include .mailmap
 include .flake8
 include .pre-commit-config.yaml
 include long_description.rst
+include conftest.py
 
 recursive-include tests *
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,28 @@
+"""pytest configuration shared by the test modules and the doctests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stop_script_magics_event_loop():
+    """Shut the ``%%script`` background event loop down after every test.
+
+    ``ScriptMagics`` starts an asyncio loop in a daemon thread the first time a
+    script magic runs, and then keeps it around to be reused. The shell is
+    session-scoped here, so that thread would otherwise outlive the test (or
+    the doctest) that started it and leave every later test running in a
+    multi-threaded process, which makes the ``os.forkpty()`` calls of, e.g.,
+    ``tests/test_process.py`` emit a DeprecationWarning on Python 3.12 and
+    above. The loop is recreated on demand, so stopping it is invisible to the
+    tests that come after.
+    """
+    yield
+
+    from IPython.terminal.interactiveshell import TerminalInteractiveShell
+
+    shell = TerminalInteractiveShell._instance
+    if shell is None:
+        return
+    script_magics = shell.magics_manager.registry.get("ScriptMagics")
+    if script_magics is not None:
+        script_magics.stop_event_loop()

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -1839,7 +1839,10 @@ def test_set_trace_function_with_header(capsys):
 
 
 def _cleanup_terminal_pdb(p):
-    p.thread_executor.shutdown(wait=False)
+    # Wait for the worker thread, if the executor ever started one: leaving it
+    # alive keeps the process multi-threaded for every later test, and
+    # ``os.fork()`` warns about that since Python 3.12.
+    p.thread_executor.shutdown()
     loop = getattr(p, "pt_loop", None)
     if loop is not None:
         loop.close()

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1029,7 +1029,13 @@ def test_notebook_export_json():
 
     # Check if notebook is trusted
     notary = sign.NotebookNotary(algorithm="sha384")
-    is_trusted = notary.check_signature(nb)
+    try:
+        is_trusted = notary.check_signature(nb)
+    finally:
+        # The signature store holds an sqlite connection; closing it here keeps
+        # it from being garbage collected open later on, which would raise a
+        # ResourceWarning in whatever test happens to be running then.
+        notary.store.close()
     assert is_trusted, "Exported notebook should be trusted"
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -167,13 +167,15 @@ def _assert_interrupts(command):
         time.sleep(0.5)
         interrupt_main()
 
-    threading.Thread(target=interrupt).start()
+    thread = threading.Thread(target=interrupt)
+    thread.start()
     start = time.time()
     try:
         result = command()
     except KeyboardInterrupt:
         pass
     end = time.time()
+    thread.join()
     assert end - start < 2, "Process didn't die quickly: %s" % (end - start)
     return result
 
@@ -188,6 +190,11 @@ def test_system_quotes():
     assert status == 0
 
 
+# ``system()`` forks a pty, and this test deliberately does so while the
+# interrupting thread of ``_assert_interrupts`` is alive, which Python 3.12 and
+# above warn about. The interrupt has to come from another thread for the test
+# to mean anything, so the warning is expected here.
+@pytest.mark.filterwarnings("ignore:This process .*is multi-threaded")
 def test_system_interrupt():
     """When interrupted in the way ipykernel interrupts IPython, the subprocess is interrupted."""
     def command():


### PR DESCRIPTION
The last CI run on ubuntu-latest / Python 3.14 ended with 16 warnings, all the same one:

```
pty.py:66: DeprecationWarning: This process (pid=…) is multi-threaded,
use of forkpty() may lead to deadlocks in the child.
```

split over `test_debug_magic` (1), `test_debugger` (8), `test_embed` (1), `test_interactiveshell` (3) and `test_process` (3).

Python 3.12 and above warn when a multi-threaded process forks, so this fires whenever the suite spawns a pty while any thread happens to be alive. Three separate things kept threads alive:

* **`ScriptMagics` never stops its event loop thread.** `shebang` starts an asyncio loop in a background thread the first time a script magic runs and keeps it for reuse, but nothing stops it, so it lives until the process exits — leaving the loop and the socketpair behind its self-pipe unclosed on the way. Its own doctest is collected before `tests/` in a bare `pytest` run, which is why the thread was up for essentially the whole session and accounts for 13 of the 16 warnings.
* **`_cleanup_terminal_pdb` shut the executor down with `wait=False`**, so the worker thread `TerminalPdb.thread_executor` starts when a test drives a real prompt outlived `test_terminal_pdb_prompt_eof_quits`.
* **`test_system_interrupt` forks with a thread on purpose** — the interrupt has to come from another thread for the test to mean anything.

## Changes

* `ScriptMagics` grows `stop_event_loop()`, which stops the loop, waits for its thread and closes the loop. `shebang` registers the same shutdown as a `weakref.finalize`, so it also happens on collection and at interpreter exit; the callback is a staticmethod taking the loop and thread, so it holds no reference back to the instance. The loop is recreated on demand, so stopping it is invisible to whatever runs next.
* A new root `conftest.py` calls `stop_event_loop()` after every test, which covers the doctests too (the old `tests/conftest.py` does not apply to `IPython/`). `MANIFEST.in` gains the file so `check-manifest` still passes.
* `tests/test_debugger.py` waits for the executor's worker thread — it is idle by then, so this costs nothing.
* `tests/test_process.py` joins the interrupting thread and ignores the expected fork warning on that one test.
* `tests/test_magic.py` closes the sqlite store `NotebookNotary` opens. That leak surfaced as an unclosed-database `ResourceWarning`, reported against an unrelated test, once the fork warnings were out of the way.

## Testing

Full suite on CPython 3.14, in CI's collection order: **2777 passed, 107 skipped, 3 xfailed, 0 warnings** (14 warnings before these changes). `mypy`, `flake8` and `check-manifest` are clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197MwgxzgcV8kUvPwjhqQsa

---
_Generated by [Claude Code](https://claude.ai/code/session_0197MwgxzgcV8kUvPwjhqQsa)_