### PR TITLE
Lazily import many imports to speed up startup. 

### DIFF
--- a/IPython/__init__.py
+++ b/IPython/__init__.py
@@ -34,16 +34,84 @@ from typing import Any
 # rely on the transitive side effects: they do `import IPython` and then
 # access attribute chains like `IPython.terminal.ipapp.TerminalIPythonApp`,
 # which only resolve because the imports below load those submodules.
-from .core.getipython import get_ipython
+#
+# `embed`, `Application` and `get_ipython` are the exceptions, and are
+# deferred via module `__getattr__` below:
+#
+#  - `embed` drags in the whole terminal / prompt_toolkit stack, by far
+#    the most expensive of these imports, and is only needed by code that
+#    calls `IPython.embed()`;
+#  - `Application` is only a re-export of `traitlets.config.application
+#    .Application`, but importing it pulled in `IPython.core.application`
+#    and with it the crash handler; no known downstream imports it from
+#    here (ipykernel imports `BaseIPythonApplication` from
+#    `IPython.core.application` directly);
+#  - `get_ipython` costs nothing to defer -- `IPython.core.getipython`
+#    ends up imported anyway via `IPython.core.magic` -- but is kept
+#    alongside the others so all three top-level names resolve the same
+#    way.
+#
+# This does mean that code relying on `import IPython` to transitively
+# populate `IPython.terminal.embed` / `IPython.core.application` (or
+# submodules only reachable through them) as a side effect will need to
+# import those submodules explicitly instead. `Application` raises a
+# `DeprecationWarning` when accessed here, both because such code is worth
+# spotting and because the name should be imported from traitlets;
+# `embed` and `get_ipython` stay silent, being widely and legitimately
+# used from here.
 from .core import release
-from .core.application import Application
-from .terminal.embed import embed
 
 from .core.interactiveshell import InteractiveShell
 from .utils.sysinfo import sys_info
 from .utils.frame import extract_module_locals
 
 __all__ = ["start_ipython", "embed", "embed_kernel"]
+
+
+# Nothing below is cached in `globals()`: the lookups stay lazy on every
+# access, so that the `Application` warning keeps firing instead of only
+# on the first access, and so that these names never silently turn into
+# plain module attributes that later code could mistake for eagerly
+# imported ones.
+#
+# `Application` is deliberately absent from `_lazy_attrs`, and hence from
+# `__dir__`: anything that walks `dir(IPython)` and getattr()s the result
+# -- our own module completer does, and so do other introspection tools --
+# would otherwise trigger its `DeprecationWarning` without any code
+# actually wanting the name. Explicit `IPython.Application` access still
+# resolves, and still warns, which is the access we want to hear about.
+_lazy_attrs = frozenset({"embed", "get_ipython"})
+
+
+def __getattr__(name: str) -> Any:
+    if name == "embed":
+        from .terminal.embed import embed
+
+        return embed
+    if name == "get_ipython":
+        from .core.getipython import get_ipython
+
+        return get_ipython
+    if name == "Application":
+        warnings.warn(
+            "`IPython.Application` is only a re-export of"
+            " `traitlets.config.application.Application`; import it from"
+            " traitlets directly. Accessing it here triggers an import of"
+            " `IPython.core.application`, which is no longer imported when"
+            " IPython is -- import that module explicitly if you rely on"
+            " that import happening, in particular if you also rely on other"
+            " submodules being transitively imported as a side effect.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from .core.application import Application
+
+        return Application
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return [*globals(), *_lazy_attrs]
 
 # Release data
 __author__ = '{} <{}>'.format(release.author, release.author_email)

--- a/IPython/core/alias.py
+++ b/IPython/core/alias.py
@@ -28,7 +28,6 @@ from traitlets.config.configurable import Configurable
 from .error import UsageError
 
 from traitlets import List, Instance
-from logging import error
 
 
 #-----------------------------------------------------------------------------
@@ -226,6 +225,7 @@ class AliasManager(Configurable):
         try:
             self.define_alias(name, cmd)
         except AliasError as e:
+            from logging import error
             error("Invalid alias: %s" % e)
 
     def define_alias(self, name, cmd):

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -13,7 +13,6 @@ object and then create the configurable objects, passing the config to them.
 
 import atexit
 from copy import deepcopy
-import logging
 import os
 import shutil
 import sys
@@ -30,6 +29,15 @@ from traitlets import (
     List, Unicode, Type, Bool, Set, Instance, Undefined,
     default, observe,
 )
+
+# Values of `logging.DEBUG` and `logging.CRITICAL`, inlined so that this
+# module -- which is on the IPython startup path -- does not have to import
+# `logging` just to spell two integers. The `logging` levels are part of its
+# documented public API and cannot change; `tests/test_application.py`
+# asserts these copies do not drift from it.
+LOGGING_DEBUG = 10
+LOGGING_CRITICAL = 50
+
 
 if os.name == "nt":
     # %PROGRAMDATA% is not safe by default, require opt-in to trust it
@@ -86,11 +94,11 @@ if isinstance(Application.flags, dict):
 base_flags.update(
     dict(
         debug=(
-            {"Application": {"log_level": logging.DEBUG}},
+            {"Application": {"log_level": LOGGING_DEBUG}},
             "set log level to logging.DEBUG (maximize logging output)",
         ),
         quiet=(
-            {"Application": {"log_level": logging.CRITICAL}},
+            {"Application": {"log_level": LOGGING_CRITICAL}},
             "set log level to logging.CRITICAL (minimize logging output)",
         ),
         init=(

--- a/IPython/core/application.py
+++ b/IPython/core/application.py
@@ -14,7 +14,6 @@ object and then create the configurable objects, passing the config to them.
 import atexit
 from copy import deepcopy
 import os
-import shutil
 import sys
 
 from pathlib import Path
@@ -313,6 +312,7 @@ class BaseIPythonApplication(Application):
                 get_ipython_package_dir(), "config", "profile", "README"
             )
             if not os.path.exists(readme) and os.path.exists(readme_src):
+                import shutil
                 shutil.copy(readme_src, readme)
             for d in ("extensions", "nbextensions"):
                 path = os.path.join(new, d)

--- a/IPython/core/async_helpers.py
+++ b/IPython/core/async_helpers.py
@@ -10,10 +10,15 @@ explicitly to actually raise a SyntaxError and stay as close as possible to
 Python semantics.
 """
 
+from __future__ import annotations
+
 import ast
-import asyncio
 import inspect
 from functools import wraps
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import asyncio
 
 _asyncio_event_loop: asyncio.AbstractEventLoop | None = None
 
@@ -31,6 +36,11 @@ def get_asyncio_loop():
 
     .. versionadded:: 8.0
     """
+    # asyncio (and everything it drags in) is only imported the first
+    # time an event loop is actually needed, rather than on every
+    # IPython startup.
+    import asyncio
+
     try:
         return asyncio.get_running_loop()
     except RuntimeError:
@@ -81,6 +91,8 @@ class _AsyncIOProxy:
             # return a threadsafe wrapper onto the _current_ asyncio loop
             @wraps(attr)
             def _wrapped(*args, **kwargs):
+                import asyncio
+
                 concurrent_future = asyncio.run_coroutine_threadsafe(
                     attr(*args, **kwargs), self._event_loop
                 )

--- a/IPython/core/compilerop.py
+++ b/IPython/core/compilerop.py
@@ -35,7 +35,6 @@ import __future__
 from ast import PyCF_ONLY_AST
 import codeop
 import functools
-import hashlib
 import linecache
 import operator
 from contextlib import contextmanager
@@ -60,6 +59,7 @@ def code_name(code: str, number: int = 0) -> str:
 
     This now expects code to be unicode.
     """
+    import hashlib
     hash_digest = hashlib.sha1(code.encode("utf-8"), usedforsecurity=False).hexdigest()
     # Include the number and 12 characters of the hash in the name.  It's
     # pretty much impossible that in a single session we'll have collisions

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -192,8 +192,6 @@ import string
 import sys
 import tokenize
 import time
-import unicodedata
-import uuid
 import warnings
 from ast import literal_eval
 from collections import defaultdict
@@ -210,18 +208,12 @@ from typing import (
 )
 from collections.abc import Iterable, Iterator, Sequence, Sized
 
-from IPython.core.guarded_eval import (
-    guarded_eval,
-    EvaluationContext,
-    _validate_policy_overrides,
-)
 from IPython.core.error import TryNext, UsageError
 from IPython.core.inputtransformer2 import (
     ESC_MAGIC,
     SystemAssign,
     make_tokens_by_line,
 )
-from IPython.core.latex_symbols import latex_symbols, reverse_latex_symbol
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils import generics
 from IPython.utils.PyColorize import theme_table
@@ -1077,12 +1069,16 @@ class Completer(Configurable):
 
     @observe("evaluation")
     def _evaluation_changed(self, _change):
+        from IPython.core.guarded_eval import _validate_policy_overrides
+
         _validate_policy_overrides(
             policy_name=self.evaluation, policy_overrides=self.policy_overrides
         )
 
     @observe("policy_overrides")
     def _policy_overrides_changed(self, _change):
+        from IPython.core.guarded_eval import _validate_policy_overrides
+
         _validate_policy_overrides(
             policy_name=self.evaluation, policy_overrides=self.policy_overrides
         )
@@ -1162,6 +1158,8 @@ class Completer(Configurable):
         defined in self.namespace or self.global_namespace that match.
 
         """
+        from IPython.core.guarded_eval import EvaluationContext, guarded_eval
+
         matches = []
         match_append = matches.append
         n = len(text)
@@ -1387,6 +1385,8 @@ class Completer(Configurable):
         return ""
 
     def _evaluate_expr(self, expr):
+        from IPython.core.guarded_eval import EvaluationContext, guarded_eval
+
         obj = not_found
         done = False
         while not done and expr:
@@ -1779,6 +1779,8 @@ def back_unicode_name_matches(text: str) -> tuple[str, Sequence[str]]:
     - a sequence (of 1), name for the match Unicode character, preceded by
         backslash, or empty if no match.
     """
+    import unicodedata
+
     if len(text)<2:
         return '', ()
     maybe_slash = text[-2]
@@ -1804,6 +1806,8 @@ def back_latex_name_matcher(context: CompletionContext) -> SimpleMatcherResult:
 
     This does ``\\ℵ`` -> ``\\aleph``
     """
+    from IPython.core.latex_symbols import reverse_latex_symbol
+
 
     text = context.text_until_cursor
     no_match = {
@@ -3038,6 +3042,7 @@ class IPCompleter(Completer):
         .. deprecated:: 8.6
             You can use :meth:`dict_key_matcher` instead.
         """
+        from IPython.core.guarded_eval import EvaluationContext, guarded_eval
 
         # Short-circuit on closed dictionary (regular expression would
         # not match anyway, but would take quite a while).
@@ -3161,6 +3166,8 @@ class IPCompleter(Completer):
         Works only on valid python 3 identifier, or on combining characters that
         will combine to form a valid identifier.
         """
+        import unicodedata
+
 
         text = context.text_until_cursor
 
@@ -3202,6 +3209,8 @@ class IPCompleter(Completer):
         .. deprecated:: 8.6
             You can use :meth:`latex_name_matcher` instead.
         """
+        from IPython.core.latex_symbols import latex_symbols
+
         slashpos = text.rfind('\\')
         if slashpos > -1:
             s = text[slashpos:]
@@ -3329,6 +3338,8 @@ class IPCompleter(Completer):
             completions are coming from different sources this function does not
             ensure that each completion object will only be present once.
         """
+        import uuid
+
         warnings.warn("_complete is a provisional API (as of IPython 6.0). "
                       "It may change without warnings. "
                       "Use in corresponding context manager.",
@@ -3845,6 +3856,8 @@ class IPCompleter(Completer):
 
         The list is lazily initialized on first access.
         """
+        import unicodedata
+
         if self._unicode_names is None:
             names = []
             for c in range(0,0x10FFFF + 1):
@@ -3858,6 +3871,8 @@ class IPCompleter(Completer):
 
 
 def _unicode_name_compute(ranges: list[tuple[int, int]]) -> list[str]:
+    import unicodedata
+
     names = []
     for start,stop in ranges:
         for c in range(start, stop) :

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -269,6 +269,19 @@ def _get_jedi() -> ModuleType:
     import jedi.api.helpers
 
     jedi.settings.case_insensitive_completion = False
+
+    # parso, which jedi parses with, logs copiously at DEBUG level; without
+    # this those records reach the user's session whenever IPython runs with
+    # a debug log level. This lived at the top of `IPython.core.logger` --
+    # a module about `%logstart` session transcripts, nothing to do with
+    # jedi -- where it worked only because that module happened to be
+    # imported eagerly at startup. Configure it where jedi itself is
+    # configured instead, which is still before any parso record can be
+    # emitted, since parso is only reached through jedi.
+    import logging
+
+    logging.getLogger("parso").setLevel(logging.WARNING)
+
     return jedi
 
 

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -8,11 +8,8 @@ from __future__ import annotations
 from enum import Enum
 from dataclasses import dataclass, KW_ONLY
 from binascii import b2a_base64, hexlify
-import html
-import json
 import mimetypes
 import os
-import struct
 import warnings
 from copy import deepcopy
 from os.path import splitext
@@ -639,6 +636,7 @@ class JSON(DisplayObject):
         if isinstance(data, str):
             if self.filename is None and self.url is None:
                 warnings.warn("JSON expects JSONable dict or list, not JSON strings")
+            import json
             data = json.loads(data)
         self._data = data
 
@@ -800,6 +798,7 @@ def _pngxy(data):
     """read the (width, height) from a PNG header"""
     ihdr = data.index(b'IHDR')
     # next 8 bytes are width/height
+    import struct
     return struct.unpack('>ii', data[ihdr+4:ihdr+12])
 
 
@@ -807,6 +806,7 @@ def _jpegxy(data):
     """read the (width, height) from a JPEG header"""
     # adapted from http://www.64lines.com/jpeg-width-height
 
+    import struct
     idx = 4
     while True:
         block_size = struct.unpack('>H', data[idx:idx+2])[0]
@@ -825,11 +825,13 @@ def _jpegxy(data):
 
 def _gifxy(data):
     """read the (width, height) from a GIF header"""
+    import struct
     return struct.unpack('<HH', data[6:10])
 
 
 def _webpxy(data):
     """read the (width, height) from a WEBP header"""
+    import struct
     if data[12:16] == b"VP8 ":
         width, height = struct.unpack("<HH", data[24:30])
         width = width & 0x3FFF
@@ -1055,6 +1057,7 @@ class Image(DisplayObject):
 
     def _repr_html_(self):
         if not self.embed:
+            import html
             width = height = klass = alt = ""
             if self.width:
                 width = ' width="%d"' % self.width
@@ -1225,6 +1228,7 @@ class Video(DisplayObject):
         # External URLs and potentially local files are not embedded into the
         # notebook output.
         if not self.embed:
+            import html
             url = self.url if self.url is not None else self.filename
             output = """<video src="{}" {} {} {}>
       Your browser does not support the <code>video</code> element.

--- a/IPython/core/displayhook.py
+++ b/IPython/core/displayhook.py
@@ -15,7 +15,6 @@ from traitlets.config.configurable import Configurable
 from traitlets import Instance, Float
 from warnings import warn
 
-from .history import HistoryOutput
 
 # TODO: Move the various attributes (cache_size, [others now moved]). Some
 # of these are also attributes of InteractiveShell. They should be on ONE object
@@ -248,6 +247,7 @@ class DisplayHook(Configurable):
 
     def log_output(self, format_dict):
         """Log the output."""
+        from .history import HistoryOutput
         self.shell.history_manager.outputs[self.prompt_count].append(
             HistoryOutput(output_type="execute_result", bundle=format_dict)
         )

--- a/IPython/core/doctb.py
+++ b/IPython/core/doctb.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import linecache
 import sys
 from collections.abc import Sequence
@@ -163,6 +162,7 @@ class DocTB(TBTools):
         indent: str = " " * INDENT_SIZE
 
         assert isinstance(frame_info.lineno, int)
+        import inspect
         args, varargs, varkw, locals_ = inspect.getargvalues(frame_info.frame)
         if frame_info.executing is not None:
             func = frame_info.executing.code_qualname()
@@ -369,6 +369,7 @@ class DocTB(TBTools):
         tbs = []
         while cf is not None:
             try:
+                import inspect
                 mod = inspect.getmodule(cf.tb_frame)
                 if mod is not None:
                     mod_name = mod.__name__

--- a/IPython/core/doctb.py
+++ b/IPython/core/doctb.py
@@ -8,10 +8,8 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
-from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.token import Token
 
-from IPython.utils.PyColorize import Theme, TokenStream, theme_table
 from IPython.utils.terminal import get_terminal_size
 
 from .tbtools import (
@@ -26,6 +24,8 @@ from .tbtools import (
 
 if TYPE_CHECKING:
     import stack_data
+
+    from IPython.utils.PyColorize import Theme, TokenStream
 
 INDENT_SIZE = 8
 
@@ -144,6 +144,8 @@ class DocTB(TBTools):
         """Format a single stack frame"""
         import stack_data
 
+        from IPython.utils.PyColorize import theme_table
+
         assert isinstance(frame_info, FrameInfo)
 
         if isinstance(frame_info._sd, stack_data.RepeatedFrames):
@@ -246,6 +248,7 @@ class DocTB(TBTools):
         return result
 
     def prepare_header(self, etype: str) -> str:
+        from IPython.utils.PyColorize import theme_table
         width = min(75, get_terminal_size()[0])
         head = theme_table[self._theme_name].format(
             [
@@ -260,6 +263,7 @@ class DocTB(TBTools):
         return head
 
     def format_exception(self, etype: Any, evalue: Any) -> Any:
+        from IPython.utils.PyColorize import theme_table
         # Get (safely) a string form of the exception info
         try:
             etype_str, evalue_str = map(str, (etype, evalue))
@@ -297,6 +301,8 @@ class DocTB(TBTools):
         This may be called multiple times by Python 3 exception chaining
         (PEP 3134).
         """
+        from IPython.utils.PyColorize import theme_table
+
         # some locals
         orig_etype = etype
         try:
@@ -333,12 +339,16 @@ class DocTB(TBTools):
     def get_records(self, etb: TracebackType, context: int, tb_offset: int) -> Any:
         import stack_data
 
+        from IPython.utils.PyColorize import theme_table
+
         assert context == 1, context
         assert etb is not None
         context = context - 1
         after = context // 2
         before = context - after
         if self.has_colors:
+            from pygments.formatters.terminal256 import Terminal256Formatter
+
             base_style = theme_table[self._theme_name].as_pygments_style()
             # stack_data ships without type annotations
             style = stack_data.style_with_executing_node(  # type: ignore[no-untyped-call]
@@ -387,6 +397,8 @@ class DocTB(TBTools):
         context: int = 1,
     ) -> list[str]:
         """Return a nice text document describing the traceback."""
+        from IPython.utils.PyColorize import theme_table
+
         assert context > 0
         assert context == 1, context
         formatted_exceptions: list[list[str]] = self.format_exception_as_a_whole(

--- a/IPython/core/doctb.py
+++ b/IPython/core/doctb.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import inspect
 import linecache
 import sys
 from collections.abc import Sequence
 from types import TracebackType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
-import stack_data
 from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.token import Token
 
@@ -22,6 +23,9 @@ from .tbtools import (
     get_line_number_of_frame,
     nullrepr,
 )
+
+if TYPE_CHECKING:
+    import stack_data
 
 INDENT_SIZE = 8
 
@@ -41,6 +45,8 @@ def _format_traceback_lines(
     ----------
     lines : list[Line | LineGap]
     """
+    import stack_data
+
     numbers_width = INDENT_SIZE - 1
     tokens: TokenStream = [(Token, "\n")]
 
@@ -136,6 +142,8 @@ class DocTB(TBTools):
 
     def format_record(self, frame_info: FrameInfo) -> str:
         """Format a single stack frame"""
+        import stack_data
+
         assert isinstance(frame_info, FrameInfo)
 
         if isinstance(frame_info._sd, stack_data.RepeatedFrames):
@@ -323,6 +331,8 @@ class DocTB(TBTools):
         return [[head] + frames + formatted_exception]
 
     def get_records(self, etb: TracebackType, context: int, tb_offset: int) -> Any:
+        import stack_data
+
         assert context == 1, context
         assert etb is not None
         context = context - 1

--- a/IPython/core/formatters.py
+++ b/IPython/core/formatters.py
@@ -66,7 +66,6 @@ Inheritance diagram:
 
 import abc
 import sys
-import traceback
 import warnings
 from io import StringIO
 
@@ -286,6 +285,7 @@ def catch_format_error(method):
             if ip is not None:
                 ip.showtraceback(exc_info)
             else:
+                import traceback
                 traceback.print_exception(*exc_info)
             return self._check_return(None, args[0])
         return self._check_return(r, args[0])

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -45,6 +45,10 @@ from typing import cast
 from warnings import warn
 from weakref import ref, WeakSet
 
+from collections.abc import Callable, Iterator
+from weakref import ReferenceType
+
+
 if TYPE_CHECKING:
     import sqlite3
     from types import TracebackType
@@ -1216,9 +1220,6 @@ class HistoryManager(HistoryAccessor):
 if hasattr(os, "register_at_fork"):
     os.register_at_fork(before=HistoryManager._stop_thread)
 
-
-from collections.abc import Callable, Iterator
-from weakref import ReferenceType
 
 
 @contextmanager

--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -46,28 +46,67 @@ from warnings import warn
 from weakref import ref, WeakSet
 
 if TYPE_CHECKING:
+    import sqlite3
     from types import TracebackType
 
     from IPython.core.interactiveshell import InteractiveShell
     from traitlets.config import Config as Configuration
 
-try:
-    from sqlite3 import DatabaseError, OperationalError
+# sqlite3 is optional: it is a pure-Python package wrapping the `_sqlite3`
+# extension module, and CPython can be built (or packaged) without the latter.
+# Importing it costs ~8 ms and 23 modules, and a session that never touches
+# history never needs it, so everything below resolves it on first use.
+#
+# Note that `importlib.util.find_spec("sqlite3")` is *not* a valid
+# availability check: the pure-Python package is on disk either way, and only
+# the import of `_sqlite3` underneath it fails. Only trying the import tells
+# the truth -- and it must catch `ImportError`, not just `ModuleNotFoundError`,
+# since the extension can also be present but fail to load.
+
+
+@functools.cache
+def _sqlite3() -> t.Any:
+    """Return the `sqlite3` module, with IPython's converter registered.
+
+    Raises `ImportError` if this Python has no working sqlite3.
+    """
     import sqlite3
 
     sqlite3.register_converter(
         "timestamp", lambda val: datetime.datetime.fromisoformat(val.decode())
     )
+    return sqlite3
 
-    sqlite3_found = True
-except ModuleNotFoundError:
-    sqlite3_found = False
 
-    class DatabaseError(Exception):  # type: ignore [no-redef]
-        pass
+@functools.cache
+def _sqlite3_found() -> bool:
+    """Whether this Python can actually import sqlite3."""
+    try:
+        _sqlite3()
+    except ImportError:
+        return False
+    return True
 
-    class OperationalError(Exception):  # type: ignore [no-redef]
-        pass
+
+@functools.cache
+def _db_errors() -> tuple[type[BaseException], ...]:
+    """The sqlite3 errors to catch, or an empty tuple if it is unavailable.
+
+    An empty tuple in an `except` clause simply never matches, which is the
+    right behaviour when there is no database to fail in the first place.
+    """
+    if not _sqlite3_found():
+        return ()
+    sqlite3 = _sqlite3()
+    return (sqlite3.DatabaseError, sqlite3.OperationalError)
+
+
+@functools.cache
+def _operational_error() -> tuple[type[BaseException], ...]:
+    """`sqlite3.OperationalError`, or an empty tuple if unavailable."""
+    if not _sqlite3_found():
+        return ()
+    return (_sqlite3().OperationalError,)
 
 
 InOrInOut = str | tuple[str, str | None]
@@ -141,7 +180,7 @@ def catch_corrupt_db(f: t.Callable[_P, _R]) -> t.Callable[_P, _R]:
         self = cast("HistoryAccessor", a[0])
         try:
             return f(*a, **kw)
-        except (DatabaseError, OperationalError) as e:
+        except _db_errors() as e:
             self._corrupt_db_counter += 1
             self.log.error("Failed to open SQLite history %s (%s).", self.hist_file, e)
             if self.hist_file != ":memory:":
@@ -258,7 +297,6 @@ class HistoryAccessor(HistoryAccessorBase):
     ).tag(config=True)
 
     enabled = Bool(
-        sqlite3_found,
         help="""enable the SQLite history
 
         set enabled=False to disable the SQLite history,
@@ -267,6 +305,13 @@ class HistoryAccessor(HistoryAccessorBase):
         threaded environments where IPython is embedded.
         """,
     ).tag(config=True)
+
+    @default("enabled")
+    def _enabled_default(self) -> bool:
+        # dynamic rather than `Bool(_sqlite3_found())`: a static default is
+        # evaluated when the class is created, which would import sqlite3 on
+        # every `import IPython`
+        return _sqlite3_found()
 
     connection_options = Dict(
         help="""Options for configuring the SQLite connection
@@ -288,7 +333,7 @@ class HistoryAccessor(HistoryAccessorBase):
     def _db_changed(self, change):  # type: ignore [no-untyped-def]
         """validate the db, since it can be an Instance of two different types"""
         new = change["new"]
-        connection_types = (DummyDB, sqlite3.Connection)
+        connection_types = (DummyDB, _sqlite3().Connection)
         if not isinstance(new, connection_types):
             msg = "{}.db must be sqlite3 Connection or DummyDB, not {!r}".format(
                 self.__class__.__name__,
@@ -348,9 +393,10 @@ class HistoryAccessor(HistoryAccessorBase):
             return
 
         # use detect_types so that timestamps return datetime objects
+        sqlite3 = _sqlite3()
         kwargs = dict(detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
         kwargs.update(self.connection_options)
-        self.db = sqlite3.connect(str(self.hist_file), **kwargs)  # type: ignore [call-overload]
+        self.db = sqlite3.connect(str(self.hist_file), **kwargs)
         self._finalizer = weakref.finalize(self, lambda db: db.close(), self.db)
         with self.db:
             self.db.execute(
@@ -739,7 +785,7 @@ class HistoryManager(HistoryAccessor):
 
         try:
             self.new_session()
-        except OperationalError:
+        except _operational_error():
             self.log.error(
                 "Failed to create history session in %s. History will not be saved.",
                 self.hist_file,
@@ -1139,7 +1185,7 @@ class HistoryManager(HistoryAccessor):
         with self.db_input_cache_lock:
             try:
                 self._writeout_input_cache(conn)
-            except sqlite3.IntegrityError:
+            except _sqlite3().IntegrityError:
                 self.new_session(conn)
                 print(
                     "ERROR! Session/line number was not unique in",
@@ -1150,7 +1196,7 @@ class HistoryManager(HistoryAccessor):
                     # Try writing to the new session. If this fails, don't
                     # recurse
                     self._writeout_input_cache(conn)
-                except sqlite3.IntegrityError:
+                except _sqlite3().IntegrityError:
                     pass
             finally:
                 self.db_input_cache = []
@@ -1158,7 +1204,7 @@ class HistoryManager(HistoryAccessor):
         with self.db_output_cache_lock:
             try:
                 self._writeout_output_cache(conn)
-            except sqlite3.IntegrityError:
+            except _sqlite3().IntegrityError:
                 print(
                     "!! Session/line number for output was not unique",
                     "in database. Output will not be stored.",
@@ -1217,7 +1263,7 @@ class HistorySavingThread(threading.Thread):
             hm: ReferenceType[HistoryManager]
             with hold(self.history_manager) as hm:
                 if hm() is not None:
-                    self.db = sqlite3.connect(
+                    self.db = _sqlite3().connect(
                         str(hm().hist_file),  # type: ignore [union-attr]
                         **cast(dict[str, t.Any], hm().connection_options),  # type: ignore [union-attr]
                     )

--- a/IPython/core/hooks.py
+++ b/IPython/core/hooks.py
@@ -41,7 +41,6 @@ from typing import Any
 from collections.abc import Callable
 
 import os
-import subprocess
 import sys
 
 from .error import TryNext
@@ -78,6 +77,7 @@ def editor(self, filename, linenum=None, wait=True):
         editor = '"%s"' % editor
 
     # Call the actual editor
+    import subprocess
     proc = subprocess.Popen('{} {} {}'.format(editor, linemark, filename),
                             shell=True)
     if wait and proc.wait() != 0:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -35,6 +35,7 @@ from logging import error
 from pathlib import Path
 from typing import Any as AnyType
 from typing import Literal
+from typing import TYPE_CHECKING
 from collections.abc import Sequence
 from warnings import warn
 import textwrap
@@ -61,7 +62,7 @@ from traitlets.config.configurable import SingletonConfigurable
 from traitlets.utils.importstring import import_item
 
 import IPython.core.hooks
-from IPython.core import magic, oinspect, page, prefilter, ultratb
+from IPython.core import magic, page, prefilter, ultratb
 from IPython.core.alias import Alias, AliasManager
 from IPython.core.autocall import ExitAutocall
 from IPython.core.builtin_trap import BuiltinTrap
@@ -94,7 +95,10 @@ from IPython.utils.process import get_output_error_code, getoutput, system
 from IPython.utils.strdispatch import StrDispatch
 from IPython.utils.syspathcontext import prepended_to_syspath
 from IPython.utils.text import DollarFormatter, LSString, SList, format_screen
-from IPython.core.oinspect import OInfo
+
+if TYPE_CHECKING:
+    from IPython.core import oinspect
+    from IPython.core.oinspect import OInfo
 
 
 def sphinxify(oinfo):
@@ -356,7 +360,7 @@ class InteractiveShell(SingletonConfigurable):
     _user_ns: dict
     _sys_modules_keys: set[str]
 
-    inspector: oinspect.Inspector
+    inspector: "oinspect.Inspector"
 
     ast_transformers: List[ast.NodeTransformer] = List(
         [],
@@ -456,7 +460,9 @@ class InteractiveShell(SingletonConfigurable):
     display_pub_class = Type(DisplayPublisher)
     compiler_class = Type(CachingCompiler)
     inspector_class = Type(
-        oinspect.Inspector, help="Class to use to instantiate the shell inspector"
+        klass="IPython.core.oinspect.Inspector",
+        default_value="IPython.core.oinspect.Inspector",
+        help="Class to use to instantiate the shell inspector",
     ).tag(config=True)
 
     sphinxify_docstring = Bool(False, help=
@@ -1711,7 +1717,7 @@ class InteractiveShell(SingletonConfigurable):
 
     def _ofind(
         self, oname: str, namespaces: Sequence[tuple[str, AnyType]] | None = None
-    ) -> OInfo:
+    ) -> "OInfo":
         """Find an object in the available namespaces.
 
 
@@ -1727,6 +1733,8 @@ class InteractiveShell(SingletonConfigurable):
 
         Has special code to detect magic functions.
         """
+        from IPython.core.oinspect import OInfo
+
         oname = oname.strip()
         parts_ok, parts = self._find_parts(oname)
 
@@ -1873,7 +1881,7 @@ class InteractiveShell(SingletonConfigurable):
         # Nothing helped, fall back.
         return getattr(obj, attrname)
 
-    def _object_find(self, oname, namespaces=None) -> OInfo:
+    def _object_find(self, oname, namespaces=None) -> "OInfo":
         """Find an object and return a struct with info about it."""
         return self._ofind(oname, namespaces)
 
@@ -1882,7 +1890,9 @@ class InteractiveShell(SingletonConfigurable):
 
         This function is meant to be called by pdef, pdoc & friends.
         """
-        info: OInfo = self._object_find(oname, namespaces)
+        from IPython.core import oinspect
+
+        info = self._object_find(oname, namespaces)
         if self.sphinxify_docstring:
             try:
                 docformat = sphinxify(self.object_inspect(oname))
@@ -1914,6 +1924,8 @@ class InteractiveShell(SingletonConfigurable):
 
     def object_inspect(self, oname, detail_level=0):
         """Get object info about oname"""
+        from IPython.core import oinspect
+
         with self.builtin_trap:
             info = self._object_find(oname)
             if info.found:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -33,7 +33,6 @@ from contextlib import contextmanager
 from io import open as io_open
 from logging import error
 from pathlib import Path
-from collections.abc import Callable
 from typing import Any as AnyType
 from typing import Literal
 from collections.abc import Sequence
@@ -67,7 +66,6 @@ from IPython.core.alias import Alias, AliasManager
 from IPython.core.autocall import ExitAutocall
 from IPython.core.builtin_trap import BuiltinTrap
 from IPython.core.compilerop import CachingCompiler
-from IPython.core.debugger import InterruptiblePdb
 from IPython.core.display_trap import DisplayTrap
 from IPython.core.displayhook import DisplayHook
 from IPython.core.displaypub import DisplayPublisher
@@ -99,24 +97,22 @@ from IPython.utils.text import DollarFormatter, LSString, SList, format_screen
 from IPython.core.oinspect import OInfo
 
 
-sphinxify: Callable | None
-
-try:
+def sphinxify(oinfo):
+    # docrepr (and the sphinx it pulls in) is only needed for the
+    # provisional `sphinxify_docstring` feature, so import it lazily
+    # here instead of paying the cost on every `import IPython`.
     import docrepr.sphinxify as sphx
 
-    def sphinxify(oinfo):
-        wrapped_docstring = sphx.wrap_main_docstring(oinfo)
+    wrapped_docstring = sphx.wrap_main_docstring(oinfo)
 
-        def sphinxify_docstring(docstring):
-            with TemporaryDirectory() as dirname:
-                return {
-                    "text/html": sphx.sphinxify(wrapped_docstring, dirname),
-                    "text/plain": docstring,
-                }
+    def sphinxify_docstring(docstring):
+        with TemporaryDirectory() as dirname:
+            return {
+                "text/html": sphx.sphinxify(wrapped_docstring, dirname),
+                "text/plain": docstring,
+            }
 
-        return sphinxify_docstring
-except ImportError:
-    sphinxify = None
+    return sphinxify_docstring
 
 
 class ProvisionalWarning(DeprecationWarning):
@@ -1888,9 +1884,10 @@ class InteractiveShell(SingletonConfigurable):
         """
         info: OInfo = self._object_find(oname, namespaces)
         if self.sphinxify_docstring:
-            if sphinxify is None:
+            try:
+                docformat = sphinxify(self.object_inspect(oname))
+            except ImportError:
                 raise ImportError("Module ``docrepr`` required but missing")
-            docformat = sphinxify(self.object_inspect(oname))
         else:
             docformat = None
         if info.found or hasattr(info.parent, oinspect.HOOK_NAME):
@@ -1940,9 +1937,10 @@ class InteractiveShell(SingletonConfigurable):
             info = self._object_find(oname)
             if info.found:
                 if self.sphinxify_docstring:
-                    if sphinxify is None:
+                    try:
+                        docformat = sphinxify(self.object_inspect(oname))
+                    except ImportError:
                         raise ImportError("Module ``docrepr`` required but missing")
-                    docformat = sphinxify(self.object_inspect(oname))
                 else:
                     docformat = None
                 return self.inspector._get_info(
@@ -1969,7 +1967,14 @@ class InteractiveShell(SingletonConfigurable):
     # Things related to exception handling and tracebacks (not debugging)
     #-------------------------------------------------------------------------
 
-    debugger_cls = InterruptiblePdb
+    @property
+    def debugger_cls(self):
+        # Deferred so that `pdb` (and everything it drags in) is only
+        # imported the first time a debugger is actually needed, rather
+        # than on every IPython startup.
+        from IPython.core.debugger import InterruptiblePdb
+
+        return InterruptiblePdb
 
     def init_traceback_handlers(self, custom_exceptions) -> None:
         # Syntax error handler.
@@ -1982,7 +1987,6 @@ class InteractiveShell(SingletonConfigurable):
             mode=self.xmode,
             theme_name=self.colors,
             tb_offset=1,
-            debugger_cls=self.debugger_cls,
         )
 
         # The instance will store a pointer to the system-wide exception hook,

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -66,7 +66,6 @@ from IPython.core.extensions import ExtensionManager
 from IPython.core.formatters import DisplayFormatter
 from IPython.core.history import HistoryManager, HistoryOutput
 from IPython.core.inputtransformer2 import ESC_MAGIC, ESC_MAGIC2
-from IPython.core.logger import Logger
 from IPython.core.macro import Macro
 from IPython.core.payload import PayloadManager
 from IPython.core.prefilter import PrefilterManager
@@ -658,7 +657,6 @@ class InteractiveShell(SingletonConfigurable):
         self.init_events()
         self.init_pushd_popd_magic()
         self.init_user_ns()
-        self.init_logger()
         self.init_builtins()
 
         # The following was in post_config_initialization
@@ -858,9 +856,28 @@ class InteractiveShell(SingletonConfigurable):
 
         self.dir_stack = []
 
-    def init_logger(self) -> None:
-        self.logger = Logger(self.home_dir, logfname='ipython_log.py',
-                             logmode='rotate')
+    _logger = None
+
+    @property
+    def logger(self):
+        """The session transcript logger behind `%logstart` and friends.
+
+        This is *not* the traitlets `log` trait (`self.log`), which is an
+        ordinary `logging.Logger` for diagnostics; this one writes the
+        session to a replayable `ipython_log.py`. Sessions that never run
+        `%logstart` never need it, so it is built on first access.
+        """
+        if self._logger is None:
+            from IPython.core.logger import Logger
+
+            self._logger = Logger(
+                self.home_dir, logfname="ipython_log.py", logmode="rotate"
+            )
+        return self._logger
+
+    @logger.setter
+    def logger(self, value):
+        self._logger = value
 
     def init_logstart(self) -> None:
         """Initialize logging in case it was requested at the command line.

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -13,25 +13,17 @@
 import abc
 import ast
 import atexit
-import bdb
 import builtins as builtin_mod
 import functools
-import inspect
 import os
 import re
 import runpy
-import shutil
-import subprocess
-from subprocess import CalledProcessError
 import sys
-import tempfile
-import traceback
 import types
 import warnings
 from ast import stmt
 from contextlib import contextmanager
 from io import open as io_open
-from logging import error
 from pathlib import Path
 from typing import Any as AnyType
 from typing import Literal
@@ -42,7 +34,6 @@ import textwrap
 
 from IPython.external.pickleshare import PickleShareDB
 
-from tempfile import TemporaryDirectory
 from traitlets import (
     Any,
     Bool,
@@ -110,6 +101,8 @@ def sphinxify(oinfo):
     wrapped_docstring = sphx.wrap_main_docstring(oinfo)
 
     def sphinxify_docstring(docstring):
+        from tempfile import TemporaryDirectory
+
         with TemporaryDirectory() as dirname:
             return {
                 "text/html": sphx.sphinxify(wrapped_docstring, dirname),
@@ -1245,6 +1238,7 @@ class InteractiveShell(SingletonConfigurable):
             return
 
         if not hasattr(sys,'last_traceback'):
+            from logging import error
             error('No traceback has been produced, nothing to debug.')
             return
 
@@ -2185,6 +2179,7 @@ class InteractiveShell(SingletonConfigurable):
         Return as a string (ending with a newline) the exception that
         just occurred, without any traceback.
         """
+        import traceback
         etype, value, tb = self._get_exc_info(exc_tuple)
         msg = traceback.format_exception_only(etype, value)
         return ''.join(msg)
@@ -2239,6 +2234,7 @@ class InteractiveShell(SingletonConfigurable):
                     if contains_exceptiongroup(value):
                         # fall back to native exception formatting until ultratb
                         # supports exception groups
+                        import traceback
                         traceback.print_exc()
                     else:
                         try:
@@ -2256,6 +2252,7 @@ class InteractiveShell(SingletonConfigurable):
                             print(
                                 "Unexpected exception formatting exception. Falling back to standard exception"
                             )
+                            import traceback
                             traceback.print_exc()
                             return None
 
@@ -2297,6 +2294,7 @@ class InteractiveShell(SingletonConfigurable):
         If the syntax error occurred when running a compiled code (i.e. running_compile_code=True),
         longer stack trace will be displayed.
         """
+        import traceback
         etype, value, last_traceback = self._get_exc_info()
 
         if filename and issubclass(etype, SyntaxError):
@@ -2702,6 +2700,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # Raise an exception if the command failed and system_raise_on_error is True
         if self.system_raise_on_error and exit_code != 0:
+            from subprocess import CalledProcessError
             raise CalledProcessError(exit_code, cmd)
 
     def system_raw(self, cmd):
@@ -2753,6 +2752,7 @@ class InteractiveShell(SingletonConfigurable):
             executable = os.environ.get('SHELL', None)
             try:
                 # Use env shell instead of default /bin/sh
+                import subprocess
                 ec = subprocess.call(cmd, shell=True, executable=executable)
             except KeyboardInterrupt:
                 # intercept control-C; a long traceback is not useful here
@@ -2770,6 +2770,7 @@ class InteractiveShell(SingletonConfigurable):
 
         # Raise an exception if the command failed and system_raise_on_error is True
         if self.system_raise_on_error and ec != 0:
+            from subprocess import CalledProcessError
             raise CalledProcessError(ec, cmd)
 
     # use piped system by default, because it is better behaved
@@ -2809,6 +2810,7 @@ class InteractiveShell(SingletonConfigurable):
 
             # Raise an exception if the command failed
             if exit_code != 0:
+                from subprocess import CalledProcessError
                 raise CalledProcessError(exit_code, cmd)
         else:
             # Use the original getoutput for backward compatibility
@@ -3517,6 +3519,8 @@ class InteractiveShell(SingletonConfigurable):
         Format an exception's traceback and details for storage, with special handling
         for different types of errors.
         """
+        import traceback
+
         etype = type(exception)
         evalue = exception
         tb = exception.__traceback__
@@ -3705,6 +3709,7 @@ class InteractiveShell(SingletonConfigurable):
         try:
 
             def compare(code):
+                import inspect
                 is_async = inspect.CO_COROUTINE & code.co_flags == inspect.CO_COROUTINE
                 return is_async
 
@@ -3783,6 +3788,7 @@ class InteractiveShell(SingletonConfigurable):
         # code (such as magics) needs access to it.
         self.sys_excepthook = old_excepthook
         outflag = True  # happens in more places, so it's easier as default
+        import bdb
         try:
             try:
                 if async_:
@@ -3989,6 +3995,7 @@ class InteractiveShell(SingletonConfigurable):
           - data(None): if data is given, it gets written out to the temp file
             immediately, and the file is closed again."""
 
+        import tempfile
         dir_path = Path(tempfile.mkdtemp(prefix=prefix))
         self.tempdirs.append(dir_path)
 
@@ -4173,6 +4180,8 @@ class InteractiveShell(SingletonConfigurable):
             except FileNotFoundError:
                 pass
         del self.tempfiles
+        import shutil
+
         for tdir in self.tempdirs:
             try:
                 shutil.rmtree(tdir)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -32,7 +32,6 @@ from collections.abc import Sequence
 from warnings import warn
 import textwrap
 
-from IPython.external.pickleshare import PickleShareDB
 
 from traitlets import (
     Any,
@@ -650,11 +649,6 @@ class InteractiveShell(SingletonConfigurable):
         self.save_sys_module_state()
         self.init_sys_modules()
 
-        # While we're trying to have each part of the code directly access what
-        # it needs without keeping redundant references to objects, we have too
-        # much legacy code that expects ip.db to exist.
-        self.db = PickleShareDB(os.path.join(self.profile_dir.location, 'db'))
-
         self.init_history()
         self.init_encoding()
         self.init_prefilter()
@@ -696,6 +690,27 @@ class InteractiveShell(SingletonConfigurable):
         # `ipykernel.kernelapp`.
         self.trio_runner = None
         self.showing_traceback = False
+
+    _db = None
+
+    @property
+    def db(self):
+        """A key/value store persisted in the profile directory.
+
+        Plenty of legacy code expects ``ip.db`` to exist, but a session that
+        never touches it should not pay for `pickleshare` (and `pickle`
+        underneath it) at startup, nor create the database directory, so it is
+        built on first access.
+        """
+        if self._db is None:
+            from IPython.external.pickleshare import PickleShareDB
+
+            self._db = PickleShareDB(os.path.join(self.profile_dir.location, "db"))
+        return self._db
+
+    @db.setter
+    def db(self, value):
+        self._db = value
 
     @property
     def user_ns(self):

--- a/IPython/core/kitty.py
+++ b/IPython/core/kitty.py
@@ -1,9 +1,40 @@
 # Implements https://sw.kovidgoyal.net/kitty/graphics-protocol/
 
 from base64 import b64encode, b64decode
+import os
 import sys
+import warnings
+
+#: Set ``IPYTHON_KITTY_GRAPHICS`` to ``1``/``true`` or ``0``/``false`` to state
+#: outright whether the terminal speaks the kitty graphics protocol. Unset (or
+#: empty) autodetects. Forcing it also skips the detection itself, which walks
+#: the process tree and is the reason IPython imports psutil at startup.
+_FORCE_ENVVAR = "IPYTHON_KITTY_GRAPHICS"
+
+
+def _forced_kitty_graphics() -> bool | None:
+    """Whether the user has stated support explicitly; None to autodetect."""
+    value = os.environ.get(_FORCE_ENVVAR)
+    if value is None or value == "":
+        return None
+    if value.lower() in {"1", "true"}:
+        return True
+    if value.lower() in {"0", "false"}:
+        return False
+    warnings.warn(
+        f"Ignoring {_FORCE_ENVVAR}={value!r}: expected one of"
+        " '0', '1', 'false', 'true' or '' (autodetect).",
+        UserWarning,
+        stacklevel=2,
+    )
+    return None
+
 
 def _supports_kitty_graphics() -> bool:
+    forced = _forced_kitty_graphics()
+    if forced is not None:
+        return forced
+
     import platform
 
     if platform.system() not in ("Darwin", "Linux"):

--- a/IPython/core/logger.py
+++ b/IPython/core/logger.py
@@ -17,14 +17,9 @@ from __future__ import annotations
 # Python standard modules
 import glob
 import io
-import logging
 import os
 import time
 from typing import IO
-
-
-# prevent jedi/parso's debug messages pipe into interactiveshell
-logging.getLogger("parso").setLevel(logging.WARNING)
 
 #****************************************************************************
 # FIXME: This class isn't a mixin anymore, but it still needs attributes from

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -20,10 +20,8 @@ from traitlets.config.configurable import Configurable
 from .error import UsageError
 from .inputtransformer2 import ESC_MAGIC, ESC_MAGIC2
 from ..utils.ipstruct import Struct
-from ..utils.process import arg_split
 from ..utils.text import dedent
 from traitlets import Bool, Dict, Instance, observe
-from logging import error
 
 import typing as t
 from typing import Any, Literal, TypeVar, overload
@@ -736,6 +734,7 @@ class Magics(Configurable):
         odict: dict[str, t.Any] = {}  # Dictionary with options
         args = arg_str.split()
         if len(args) >= 1:
+            from ..utils.process import arg_split
             # If the list of inputs only has 0 or 1 thing in it, there's no
             # need to look for options
             argv = arg_split(arg_str, posix, strict)

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -17,7 +17,6 @@ import sys
 from getopt import getopt, GetoptError
 
 from traitlets.config.configurable import Configurable
-from . import oinspect
 from .error import UsageError
 from .inputtransformer2 import ESC_MAGIC, ESC_MAGIC2
 from ..utils.ipstruct import Struct
@@ -670,6 +669,8 @@ class Magics(Configurable):
 
     def arg_err(self, func: Callable[..., Any]) -> None:
         """Print docstring if incorrect arguments were passed"""
+        from . import oinspect
+
         print("Error in arguments:")
         print(oinspect.getdoc(func))
 

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -20,7 +20,6 @@ import re
 import sys
 import ast
 from itertools import chain
-from urllib.parse import urlencode
 from pathlib import Path
 
 # Our own packages
@@ -278,6 +277,7 @@ class CodeMagics(Magics):
           -e: Pass number of days for the link to be expired.
               The default will be 7 days.
         """
+        from urllib.parse import urlencode
         from urllib.request import Request
 
         opts, args = self.parse_options(parameter_s, "d:e:")

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -20,7 +20,6 @@ import re
 import sys
 import ast
 from itertools import chain
-from urllib.request import Request, urlopen
 from urllib.parse import urlencode
 from pathlib import Path
 
@@ -36,6 +35,16 @@ from IPython.utils.path import get_py_filename
 from warnings import warn
 from logging import error
 from IPython.utils.text import get_text_list
+
+
+def urlopen(*args, **kwargs):
+    """Lazily import urllib.request (and its costly ``http.client``/``email``
+    dependencies) so that the cost is only paid the first time %pastebin
+    actually performs a network request."""
+    from urllib.request import urlopen as _urlopen
+
+    return _urlopen(*args, **kwargs)
+
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -270,6 +279,8 @@ class CodeMagics(Magics):
           -e: Pass number of days for the link to be expired.
               The default will be 7 days.
         """
+        from urllib.request import Request
+
         opts, args = self.parse_options(parameter_s, "d:e:")
 
         try:

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -27,7 +27,6 @@ from pathlib import Path
 from IPython.core.error import TryNext, StdinNotImplementedError, UsageError
 from IPython.core.macro import Macro
 from IPython.core.magic import Magics, magics_class, line_magic
-from IPython.core.oinspect import find_file, find_source_lines
 from IPython.core.release import version
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.contexts import preserve_keys
@@ -418,6 +417,7 @@ class CodeMagics(Magics):
     @staticmethod
     def _find_edit_target(shell, args, opts, last_call):
         """Utility method used by magic_edit to find what to edit."""
+        from IPython.core.oinspect import find_file, find_source_lines
 
         def make_filename(arg):
             "Make a filename from the given args"

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -9,7 +9,6 @@ import bdb
 import builtins as builtin_mod
 import gc
 import itertools
-import math
 import os
 import re
 import shlex
@@ -89,10 +88,12 @@ class TimeitResult:
 
     @property
     def average(self):
+        import math
         return math.fsum(self.timings) / len(self.timings)
 
     @property
     def stdev(self):
+        import math
         mean = self.average
         return (math.fsum([(x - mean) ** 2 for x in self.timings]) / len(self.timings)) ** 0.5
 
@@ -1706,6 +1707,7 @@ def _format_time(timespan, precision=3):
     scaling = [1, 1e3, 1e6, 1e9]
 
     if timespan > 0.0:
+        import math
         order = min(-int(math.floor(math.log10(timespan)) // 3), 3)
     else:
         order = 3

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -5,7 +5,6 @@
 
 
 import ast
-import bdb
 import builtins as builtin_mod
 import gc
 import itertools
@@ -46,7 +45,6 @@ from IPython.utils.ipstruct import Struct
 from IPython.utils.module_paths import find_mod
 from IPython.utils.path import get_py_filename, shellglob
 from IPython.utils.process import arg_split_with_quotes
-from IPython.utils.timing import clock, clock2
 from IPython.core.magics.ast_mod import ReplaceCodeTransformer
 
 #-----------------------------------------------------------------------------
@@ -938,6 +936,7 @@ class ExecutionMagics(Magics):
 
         # reset Breakpoint state, which is moronically kept
         # in a class
+        import bdb
         bdb.Breakpoint.next = 1
         bdb.Breakpoint.bplist = {}
         bdb.Breakpoint.bpbynumber = [None]
@@ -1022,6 +1021,8 @@ class ExecutionMagics(Magics):
             Number of times to execute `run`.
 
         """
+        from IPython.utils.timing import clock2
+
         twall0 = time.perf_counter()
         if nruns == 1:
             t0 = clock2()
@@ -1138,6 +1139,8 @@ class ExecutionMagics(Magics):
         statement to import function or create variables. Generally, the bias
         does not matter as long as results from timeit.py are not mixed with
         those from ``%timeit``."""
+        from IPython.utils.timing import clock
+
 
         # TODO: port to magic_arguments as currently this is duplicated in IPCompleter._extract_code
         opts, stmt = self.parse_options(
@@ -1344,6 +1347,8 @@ class ExecutionMagics(Magics):
                 Wall time: 0.00 s
                 Compiler : 0.78 s
         """
+        from IPython.utils.timing import clock, clock2
+
         args, extra = magic_arguments.parse_argstring(self.time, line, partial=True)
         line = " ".join(extra)
 

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -7,7 +7,6 @@
 import ast
 import bdb
 import builtins as builtin_mod
-import cProfile as profile
 import gc
 import itertools
 import math
@@ -325,6 +324,7 @@ class ExecutionMagics(Magics):
             A dictionary for Python namespace (e.g., `self.shell.user_ns`).
 
         """
+        import cProfile as profile
         import pstats
 
         # Fill default values for unspecified options:

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -12,7 +12,6 @@ import gc
 import itertools
 import math
 import os
-import pstats
 import re
 import shlex
 import sys
@@ -25,7 +24,6 @@ from ast import (
 from io import StringIO
 from logging import error
 from pathlib import Path
-from pdb import Restart
 from textwrap import indent
 from warnings import warn
 
@@ -327,6 +325,7 @@ class ExecutionMagics(Magics):
             A dictionary for Python namespace (e.g., `self.shell.user_ns`).
 
         """
+        import pstats
 
         # Fill default values for unspecified options:
         opts.merge(Struct(D=[''], l=[], s=['time'], T=['']))
@@ -929,6 +928,8 @@ class ExecutionMagics(Magics):
             If the break point given by `bp_line` is not valid.
 
         """
+        from pdb import Restart
+
         deb = self.shell.InteractiveTB.pdb
         if not deb:
             self.shell.InteractiveTB.pdb = self.shell.InteractiveTB.debugger_cls()

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -14,7 +14,6 @@ import sys
 from pprint import pformat
 
 from IPython.core import magic_arguments
-from IPython.core import oinspect
 from IPython.core import page
 from IPython.core.alias import AliasError, Alias
 from IPython.core.error import UsageError
@@ -171,6 +170,8 @@ class OSMagics(Magics):
         try:
             alias,cmd = par.split(None, 1)
         except TypeError:
+            from IPython.core import oinspect
+
             print(oinspect.getdoc(self.alias))
             return
 

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -11,7 +11,6 @@ import sys
 import time
 import weakref
 from codecs import getincrementaldecoder
-from subprocess import CalledProcessError
 from threading import Thread
 
 from traitlets import Any, Dict, List, default
@@ -229,6 +228,7 @@ class ScriptMagics(Magics):
         """
         import asyncio
         import asyncio.exceptions
+        from subprocess import CalledProcessError
 
         # Create the event loop in which to run script magics
         # this operates on a background thread

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -6,7 +6,6 @@
 import atexit
 import errno
 import os
-import signal
 import sys
 import time
 import weakref
@@ -346,6 +345,7 @@ class ScriptMagics(Magics):
             in_thread(_stream_communicate(p, cell))
         except KeyboardInterrupt:
             try:
+                import signal
                 p.send_signal(signal.SIGINT)
                 in_thread(asyncio.wait_for(p.wait(), timeout=0.1))
                 if p.returncode is not None:
@@ -413,6 +413,7 @@ class ScriptMagics(Magics):
         for p in self.bg_processes:
             if p.returncode is None:
                 try:
+                    import signal
                     p.send_signal(signal.SIGINT)
                 except OSError:
                     pass

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -3,8 +3,6 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
-import asyncio.exceptions
 import atexit
 import errno
 import os
@@ -229,6 +227,8 @@ class ScriptMagics(Magics):
             2
             3
         """
+        import asyncio
+        import asyncio.exceptions
 
         # Create the event loop in which to run script magics
         # this operates on a background thread

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -48,9 +48,6 @@ from IPython.utils.text import indent
 from IPython.utils.wildcard import list_namespace, typestr2type
 from IPython.utils.decorators import undoc
 
-from pygments import highlight
-from pygments.lexers import PythonLexer
-from pygments.formatters import HtmlFormatter
 
 HOOK_NAME = "__custom_documentations__"
 
@@ -69,6 +66,13 @@ class OInfo:
     obj: Any
 
 def pylight(code):
+    # `pygments.lexers` and `pygments.formatters` pull in the pygments plugin
+    # machinery (importlib.metadata, zipfile); only HTML-formatted docstrings
+    # need them, so keep them out of `import IPython.core.oinspect`
+    from pygments import highlight
+    from pygments.formatters import HtmlFormatter
+    from pygments.lexers import PythonLexer
+
     return highlight(code, PythonLexer(), HtmlFormatter(noclasses=True))
 
 # builtin docstrings to ignore

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -22,7 +22,6 @@ from io import UnsupportedOperation
 from pathlib import Path
 
 from IPython.core.getipython import get_ipython
-from IPython.display import display
 from IPython.core.error import TryNext
 from IPython.utils.data import chop
 from IPython.utils.terminal import get_terminal_size
@@ -36,6 +35,7 @@ def display_page(strng, start=0, screen_lines=25):
         if start:
             strng = '\n'.join(strng.splitlines()[start:])
         data = { 'text/plain': strng }
+    from IPython.display import display
     display(data, raw=True)
 
 

--- a/IPython/core/page.py
+++ b/IPython/core/page.py
@@ -17,8 +17,6 @@ import os
 import io
 import re
 import sys
-import tempfile
-import subprocess
 
 from io import UnsupportedOperation
 from pathlib import Path
@@ -27,7 +25,6 @@ from IPython.core.getipython import get_ipython
 from IPython.display import display
 from IPython.core.error import TryNext
 from IPython.utils.data import chop
-from IPython.utils.process import system
 from IPython.utils.terminal import get_terminal_size
 
 
@@ -193,6 +190,7 @@ def pager_page(strng, start=0, screen_lines=0, pager_cmd=None) -> None:
                 # The default WinXP 'type' command is failing on complex strings.
                 retval = 1
             else:
+                import tempfile
                 fd, tmpname = tempfile.mkstemp('.txt')
                 tmppath = Path(tmpname)
                 try:
@@ -211,6 +209,7 @@ def pager_page(strng, start=0, screen_lines=0, pager_cmd=None) -> None:
             try:
                 retval = None
                 # Emulate os.popen, but redirect stderr
+                import subprocess
                 proc = subprocess.Popen(
                     pager_cmd,
                     shell=True,
@@ -272,6 +271,7 @@ def page_file(fname, start=0, pager_cmd=None):
     try:
         if os.environ['TERM'] in ['emacs','dumb']:
             raise OSError
+        from IPython.utils.process import system
         system(pager_cmd + ' ' + fname)
     except Exception:
         try:

--- a/IPython/core/profiledir.py
+++ b/IPython/core/profiledir.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-import shutil
 import errno
 from pathlib import Path
 
@@ -129,6 +128,7 @@ class ProfileDir(LoggingConfigurable):
 
             if os.path.exists(src):
                 if not os.path.exists(readme):
+                    import shutil
                     shutil.copy(src, readme)
             else:
                 self.log.warning(
@@ -157,6 +157,7 @@ class ProfileDir(LoggingConfigurable):
         This function moves these from that location to the working profile
         directory.
         """
+        import shutil
         dst = Path(os.path.join(self.location, config_file))
         if dst.exists() and not overwrite:
             return False

--- a/IPython/core/splitinput.py
+++ b/IPython/core/splitinput.py
@@ -9,8 +9,10 @@ prefilter.
 
 import re
 import warnings
+from typing import TYPE_CHECKING
 
-from IPython.core.oinspect import OInfo
+if TYPE_CHECKING:
+    from IPython.core.oinspect import OInfo
 
 # -----------------------------------------------------------------------------
 # Main function
@@ -123,7 +125,7 @@ class LineInfo:
         else:
             self.pre_whitespace = self.pre
 
-    def ofind(self, ip) -> OInfo:
+    def ofind(self, ip) -> "OInfo":
         """Do a full, attribute-walking lookup of the ifun in the various
         namespaces for the given IPython InteractiveShell instance.
 

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -12,7 +12,6 @@ from collections.abc import Callable
 from pygments.token import Token
 
 from IPython.core.getipython import get_ipython
-from IPython.utils import path as util_path
 from IPython.utils.PyColorize import Theme, TokenStream, theme_table
 
 if TYPE_CHECKING:
@@ -206,6 +205,7 @@ def _tokens_filename(
             ]
     else:
         file_str = file or ""
+        from IPython.utils import path as util_path
         name = util_path.compress_user(file_str)
         if lineno is None:
             return [

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 import sys
 import types
 import warnings
@@ -336,6 +335,7 @@ class FrameInfo:
         if sd is None:
             try:
                 # return a list of source lines and a starting line number
+                import inspect
                 self.raw_lines = inspect.getsourcelines(frame)[0]
             except OSError:
                 self.raw_lines = [

--- a/IPython/core/tbtools.py
+++ b/IPython/core/tbtools.py
@@ -2,21 +2,21 @@ from __future__ import annotations
 
 import functools
 import inspect
-import pydoc
 import sys
 import types
 import warnings
 from types import TracebackType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
-import stack_data
 from pygments.token import Token
 
 from IPython.core.getipython import get_ipython
-from IPython.core import debugger
 from IPython.utils import path as util_path
 from IPython.utils.PyColorize import Theme, TokenStream, theme_table
+
+if TYPE_CHECKING:
+    import stack_data
 
 _sentinel = object()
 INDENT_SIZE = 8
@@ -84,6 +84,8 @@ def _format_traceback_lines(
     ----------
     lines : list[Line | LineGap]
     """
+    import stack_data
+
     numbers_width = INDENT_SIZE - 1
     tokens: TokenStream = []
 
@@ -129,6 +131,8 @@ def text_repr(value: Any) -> str:
     """Hopefully pretty robust repr equivalent."""
     # this is pretty horrible but should always return *something*
     try:
+        import pydoc
+
         return pydoc.text.repr(value)
     except KeyboardInterrupt:
         raise
@@ -386,7 +390,7 @@ class TBTools:
     _old_theme_name: str
     call_pdb: bool
     ostream: Any
-    debugger_cls: Any
+    _debugger_cls: Any
     pdb: Any
 
     def __init__(
@@ -429,7 +433,7 @@ class TBTools:
 
         # Create color table
         self.set_theme_name(theme_name)
-        self.debugger_cls = debugger_cls or debugger.Pdb
+        self._debugger_cls = debugger_cls
 
         if call_pdb:
             self.pdb = self.debugger_cls()
@@ -454,6 +458,26 @@ class TBTools:
         self._ostream = val
 
     ostream = property(_get_ostream, _set_ostream)
+
+    def _get_debugger_cls(self) -> Any:
+        if self._debugger_cls is None:
+            # Deferred: pdb (and everything it drags in) is only imported
+            # the first time a debugger class is actually needed, rather
+            # than on every IPython startup. Prefer the running shell's
+            # own choice (e.g. the terminal's TerminalPdb) if there is one.
+            ip = get_ipython()
+            if ip is not None:
+                self._debugger_cls = ip.debugger_cls
+            else:
+                from IPython.core import debugger
+
+                self._debugger_cls = debugger.Pdb
+        return self._debugger_cls
+
+    def _set_debugger_cls(self, val) -> None:  # type:ignore[no-untyped-def]
+        self._debugger_cls = val
+
+    debugger_cls = property(_get_debugger_cls, _set_debugger_cls)
 
     @staticmethod
     def _get_chained_exception(exception_value: Any) -> Any:

--- a/IPython/core/tips.py
+++ b/IPython/core/tips.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from datetime import datetime
+import importlib.util
 import os
 import sys
-from random import choice
 from typing import Any
 
 _tips: Any = {
@@ -114,15 +114,14 @@ if sys.version_info < (3, 12):
         "IPython support for Python versions outside of SPEC-0 is funded by the D. E. Shaw group: https://deshaw.com"
     )
 
-# Check if argcomplete is installed and add tip
-try:
-    import argcomplete
-
+# Check if argcomplete is installed and add tip.
+# `find_spec` only looks the module up on sys.path; actually importing
+# argcomplete costs ~3 ms and 8 modules on every IPython startup, just to
+# decide whether one tip out of many is eligible to be shown.
+if importlib.util.find_spec("argcomplete") is not None:
     _tips["random"].append(
         "Run `activate-global-python-argcomplete` from your shell to enable CLI completion for IPython"
     )
-except ModuleNotFoundError:
-    pass
 
 
 def pick_tip() -> str:
@@ -132,4 +131,5 @@ def pick_tip() -> str:
     if (month, day) in _tips["every_year"]:
         return _tips["every_year"][(month, day)]
 
+    from random import choice
     return choice(_tips["random"])

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -77,8 +77,8 @@ from collections.abc import Sequence
 from types import TracebackType
 from typing import Any
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
-import stack_data
 from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.token import Token
 
@@ -99,6 +99,9 @@ from .tbtools import (
     get_line_number_of_frame,
     nullrepr,
 )
+
+if TYPE_CHECKING:
+    import stack_data
 
 # Globals
 # amount of space to put line numbers before verbose tracebacks
@@ -560,6 +563,8 @@ class VerboseTB(TBTools):
 
     def format_record(self, frame_info: FrameInfo) -> str:
         """Format a single stack frame"""
+        import stack_data
+
         assert isinstance(frame_info, FrameInfo)
 
         if isinstance(frame_info._sd, stack_data.RepeatedFrames):
@@ -790,6 +795,8 @@ class VerboseTB(TBTools):
         This may be called multiple times by Python 3 exception chaining
         (PEP 3134).
         """
+        import stack_data
+
         # some locals
         orig_etype = etype
         try:
@@ -851,6 +858,8 @@ class VerboseTB(TBTools):
         return [[head] + frames + formatted_exception]
 
     def get_records(self, etb: TracebackType, context: int, tb_offset: int) -> Any:
+        import stack_data
+
         assert etb is not None
         context = context - 1
         after = context // 2

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -79,11 +79,9 @@ from typing import Any
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.token import Token
 
 from IPython.core.getipython import get_ipython
-from IPython.utils.PyColorize import Parser, TokenStream, theme_table
 from IPython.utils.terminal import get_terminal_size
 
 from .display_trap import DisplayTrap
@@ -102,6 +100,7 @@ from .tbtools import (
 
 if TYPE_CHECKING:
     import stack_data
+    from IPython.utils.PyColorize import TokenStream
 
 # Globals
 # amount of space to put line numbers before verbose tracebacks
@@ -181,6 +180,7 @@ class ListTB(TBTools):
         # (see the recursive self.structured_traceback() call below), and can
         # also be a pre-built list of frames per the docstring above; neither
         # is expressible in the public `TracebackType | None` signature.
+        from IPython.utils.PyColorize import theme_table
         if isinstance(etb, tuple):
             etb, chained_exc_ids = etb  # type: ignore[unreachable]
         else:
@@ -254,6 +254,7 @@ class ListTB(TBTools):
 
         Lifted almost verbatim from traceback.py
         """
+        from IPython.utils.PyColorize import theme_table
 
         output_list = []
         for ind, (filename, lineno, name, line) in enumerate(extracted_list):
@@ -304,6 +305,8 @@ class ListTB(TBTools):
 
         Also lifted nearly verbatim from traceback.py
         """
+        from IPython.utils.PyColorize import theme_table
+
         have_filedata = False
         output_list = []
         stype_tokens = [(Token.ExcName, etype.__name__)]
@@ -564,6 +567,7 @@ class VerboseTB(TBTools):
     def format_record(self, frame_info: FrameInfo) -> str:
         """Format a single stack frame"""
         import stack_data
+        from IPython.utils.PyColorize import theme_table
 
         assert isinstance(frame_info, FrameInfo)
 
@@ -667,6 +671,7 @@ class VerboseTB(TBTools):
                 ]
             )
 
+            from IPython.utils.PyColorize import Parser
             _line_format = Parser(theme_name=self._theme_name).format2
             assert isinstance(frame_info.code, types.CodeType)
             first_line: int = frame_info.code.co_firstlineno
@@ -718,6 +723,7 @@ class VerboseTB(TBTools):
 
     def prepare_header(self, etype: str, long_version: bool = False) -> str:
         width = min(75, get_terminal_size()[0])
+        from IPython.utils.PyColorize import theme_table
         if long_version:
             # Header with the exception type, python version, and date
             pyver = "Python " + sys.version.split()[0] + ": " + sys.executable
@@ -753,6 +759,8 @@ class VerboseTB(TBTools):
         return head
 
     def format_exception(self, etype, evalue):
+        from IPython.utils.PyColorize import theme_table
+
         # Get (safely) a string form of the exception info
         try:
             etype_str, evalue_str = map(str, (etype, evalue))
@@ -796,6 +804,8 @@ class VerboseTB(TBTools):
         (PEP 3134).
         """
         import stack_data
+
+        from IPython.utils.PyColorize import theme_table
 
         # some locals
         orig_etype = etype
@@ -860,6 +870,8 @@ class VerboseTB(TBTools):
     def get_records(self, etb: TracebackType, context: int, tb_offset: int) -> Any:
         import stack_data
 
+        from IPython.utils.PyColorize import theme_table
+
         assert etb is not None
         context = context - 1
         after = context // 2
@@ -869,6 +881,7 @@ class VerboseTB(TBTools):
             base_style = theme.as_pygments_style()
             tb_highlight = theme.extra_style.get(Token.TbHighlight, self.tb_highlight)
             style = stack_data.style_with_executing_node(base_style, tb_highlight)
+            from pygments.formatters.terminal256 import Terminal256Formatter
             formatter = Terminal256Formatter(style=style)
         else:
             formatter = None
@@ -952,6 +965,8 @@ class VerboseTB(TBTools):
         context: int = 5,
     ) -> list[str]:
         """Return a nice text document describing the traceback."""
+        from IPython.utils.PyColorize import theme_table
+
         formatted_exceptions: list[list[str]] = self.format_exception_as_a_whole(
             etype, evalue, etb, context, tb_offset
         )

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -58,6 +58,8 @@ Inheritance diagram:
    :parts: 3
 """
 
+from __future__ import annotations
+
 # *****************************************************************************
 # Copyright (C) 2001 Nathaniel Gray <n8gray@caltech.edu>
 # Copyright (C) 2001-2004 Fernando Perez <fperez@colorado.edu>
@@ -66,11 +68,9 @@ Inheritance diagram:
 # the file COPYING, distributed as part of this software.
 # *****************************************************************************
 
-import inspect
 import linecache
 import sys
 import time
-import traceback
 import types
 import warnings
 from collections.abc import Sequence
@@ -101,6 +101,7 @@ from .tbtools import (
 if TYPE_CHECKING:
     import stack_data
     from IPython.utils.PyColorize import TokenStream
+    import traceback
 
 # Globals
 # amount of space to put line numbers before verbose tracebacks
@@ -141,6 +142,7 @@ class ListTB(TBTools):
         self.ostream.write("\n")
 
     def _extract_tb(self, tb: TracebackType | None) -> traceback.StackSummary | None:
+        import traceback
         if tb:
             return traceback.extract_tb(tb)
         else:
@@ -566,6 +568,7 @@ class VerboseTB(TBTools):
 
     def format_record(self, frame_info: FrameInfo) -> str:
         """Format a single stack frame"""
+        import inspect
         import stack_data
         from IPython.utils.PyColorize import theme_table
 
@@ -868,6 +871,7 @@ class VerboseTB(TBTools):
         return [[head] + frames + formatted_exception]
 
     def get_records(self, etb: TracebackType, context: int, tb_offset: int) -> Any:
+        import inspect
         import stack_data
 
         from IPython.utils.PyColorize import theme_table

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -2,7 +2,6 @@
 
 Authors : MinRK, gregcaporaso, dannystaple
 """
-from html import escape as html_escape
 from os.path import exists, isfile, splitext, abspath, join, isdir
 from os import walk, sep, fsdecode
 
@@ -240,6 +239,8 @@ class Audio(DisplayObject):
             return """data:{type};base64,{base64}""".format(type=self.mimetype,
                                                             base64=data)
         elif self.url is not None:
+            from html import escape as html_escape
+
             return html_escape(self.url)
         else:
             return ""
@@ -252,6 +253,8 @@ class Audio(DisplayObject):
 
     def element_id_attr(self):
         if (self.element_id):
+            from html import escape as html_escape
+
             return f'id="{html_escape(self.element_id)}"'
         else:
             return ''
@@ -286,6 +289,8 @@ class IFrame:
 
     def _repr_html_(self):
         """return the embed iframe"""
+        from html import escape as html_escape
+
         if self.params:
             from urllib.parse import urlencode
             params = "?" + urlencode(self.params)
@@ -412,6 +417,8 @@ class FileLink:
         self.result_html_suffix = result_html_suffix
 
     def _format_path(self):
+        from html import escape as html_escape
+
         fp = ''.join([self.url_prefix, html_escape(self.path)])
         return ''.join([self.result_html_prefix,
                         self.html_link_str % \
@@ -539,7 +546,12 @@ class FileLinks(FileLink):
         escape_names: whether directory and file names must be HTML-escaped
          before being substituted, as they are for the notebook formatter
         """
-        escape = html_escape if escape_names else str
+        if escape_names:
+            from html import escape as html_escape
+
+            escape = html_escape
+        else:
+            escape = str
 
         def f(dirname, fnames, included_suffixes=None):
             result = []

--- a/IPython/paths.py
+++ b/IPython/paths.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os.path
-import tempfile
 from warnings import warn
 
 from IPython.utils.importstring import import_item
@@ -23,6 +22,7 @@ def get_ipython_dir() -> str:
     This uses the logic in `get_home_dir` to find the home directory
     and then adds .ipython to the end of the path.
     """
+    import tempfile
 
     env = os.environ
     pjoin = os.path.join

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -48,7 +48,6 @@ from prompt_toolkit.styles.pygments import style_from_pygments_cls, style_from_p
 from pygments.styles import get_style_by_name
 from pygments.style import Style
 
-from .debugger import TerminalPdb, Pdb
 from .magics import TerminalMagics
 from .pt_inputhooks import get_inputhook_name_and_func
 from .prompts import Prompts, ClassicPrompts, RichPromptDisplayHook
@@ -247,6 +246,11 @@ class TerminalInteractiveShell(InteractiveShell):
 
     @property
     def debugger_cls(self):
+        # Deferred: `.debugger` (and everything it drags in, including
+        # pdb and prompt_toolkit-based pieces) is only imported the first
+        # time a debugger class is actually needed.
+        from .debugger import TerminalPdb, Pdb
+
         return Pdb if self.simple_prompt else TerminalPdb
 
     confirm_exit = Bool(True,

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -45,7 +45,6 @@ from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle, print_formatted_text
 from prompt_toolkit.styles import DynamicStyle, merge_styles
 from prompt_toolkit.styles.pygments import style_from_pygments_cls, style_from_pygments_dict
-from pygments.styles import get_style_by_name
 from pygments.style import Style
 
 from .magics import TerminalMagics
@@ -841,6 +840,11 @@ class TerminalInteractiveShell(InteractiveShell):
 
         theme = theme_table.get(legacy, None)
         assert theme is not None, legacy
+
+        # `pygments.styles` drags in the pygments plugin machinery
+        # (importlib.metadata -> zipfile -> shutil); it is only needed to
+        # resolve a theme's base style, which happens once, here.
+        from pygments.styles import get_style_by_name
 
         if legacy == "nocolor":
             style_overrides = {}

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -20,7 +20,6 @@ from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.patch_stdout import patch_stdout
 
 
-import pygments.lexers as pygments_lexers
 import os
 import sys
 import traceback
@@ -215,6 +214,10 @@ class _LazyPygmentsLexer:
 
     def lex_document(self, document):
         if self._lexer is None:
+            # `pygments.lexers` is the expensive part: it pulls in the pygments
+            # plugin machinery, and with it importlib.metadata and zipfile
+            import pygments.lexers as pygments_lexers
+
             cls = getattr(pygments_lexers, self._pygments_cls_name)
             self._lexer = PygmentsLexer(cls)
         return self._lexer.lex_document(document)

--- a/IPython/terminal/ptutils.py
+++ b/IPython/terminal/ptutils.py
@@ -198,23 +198,50 @@ class IPythonPTCompleter(Completer):
                 )
 
 
+class _LazyPygmentsLexer:
+    """A ``PygmentsLexer``-like object that only builds the real lexer
+    (and imports the pygments submodule backing it) the first time it's
+    actually asked to highlight something.
+
+    Most sessions only ever use the Python lexer; building all the
+    per-``%%magic`` lexers (bash, html, javascript, perl, ruby, latex...)
+    up front measurably slows down every terminal startup for languages
+    that may never come up in that session.
+    """
+
+    def __init__(self, pygments_cls_name: str):
+        self._pygments_cls_name = pygments_cls_name
+        self._lexer: PygmentsLexer | None = None
+
+    def lex_document(self, document):
+        if self._lexer is None:
+            cls = getattr(pygments_lexers, self._pygments_cls_name)
+            self._lexer = PygmentsLexer(cls)
+        return self._lexer.lex_document(document)
+
+
+_MAGIC_LEXER_CLASSES = {
+    "HTML": "HtmlLexer",
+    "html": "HtmlLexer",
+    "javascript": "JavascriptLexer",
+    "js": "JavascriptLexer",
+    "perl": "PerlLexer",
+    "ruby": "RubyLexer",
+    "latex": "TexLexer",
+}
+
+
 class IPythonPTLexer(Lexer):
     """
     Wrapper around PythonLexer and BashLexer.
     """
     def __init__(self):
-        l = pygments_lexers
-        self.python_lexer = PygmentsLexer(l.Python3Lexer)
-        self.shell_lexer = PygmentsLexer(l.BashLexer)
+        self.python_lexer = _LazyPygmentsLexer("Python3Lexer")
+        self.shell_lexer = _LazyPygmentsLexer("BashLexer")
 
         self.magic_lexers = {
-            'HTML': PygmentsLexer(l.HtmlLexer),
-            'html': PygmentsLexer(l.HtmlLexer),
-            'javascript': PygmentsLexer(l.JavascriptLexer),
-            'js': PygmentsLexer(l.JavascriptLexer),
-            'perl': PygmentsLexer(l.PerlLexer),
-            'ruby': PygmentsLexer(l.RubyLexer),
-            'latex': PygmentsLexer(l.TexLexer),
+            name: _LazyPygmentsLexer(cls_name)
+            for name, cls_name in _MAGIC_LEXER_CLASSES.items()
         }
 
     def lex_document(self, document):

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -5,16 +5,20 @@ import token
 import tokenize
 import warnings
 from io import StringIO
-from typing import Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import pygments
-from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.style import Style
-from pygments.styles import get_style_by_name
 from pygments.token import Token, _TokenType
 from functools import cache
 
 from typing import TypedDict
+
+if TYPE_CHECKING:
+    # importing this drags in the whole `pygments.formatters` package, which
+    # is only needed once something is actually formatted -- see
+    # Theme._get_formatter below.
+    from pygments.formatters.terminal256 import Terminal256Formatter
 
 
 TokenStream: TypeAlias = list[tuple[_TokenType, str]]
@@ -55,11 +59,15 @@ class Theme:
         self.extra_style = extra_style
         s: Symbols = symbols if symbols is not None else _default_symbols
         self.symbols = {**_default_symbols, **s}
-        self._formatter = Terminal256Formatter(style=self.as_pygments_style())
 
     @cache
     def as_pygments_style(self) -> type[Style]:
         if self.base is not None:
+            # `pygments.styles` pulls in the pygments plugin machinery, and
+            # with it `importlib.metadata`, `zipfile` and `shutil`; keep that
+            # off the import path of everything that merely wants a Theme.
+            from pygments.styles import get_style_by_name
+
             base_styles = get_style_by_name(self.base).styles
         else:
             base_styles = {}
@@ -69,8 +77,14 @@ class Theme:
 
         return MyStyle
 
+    @cache
+    def _get_formatter(self) -> "Terminal256Formatter":
+        from pygments.formatters.terminal256 import Terminal256Formatter
+
+        return Terminal256Formatter(style=self.as_pygments_style())
+
     def format(self, stream: TokenStream) -> str:
-        return pygments.format(stream, self._formatter)
+        return pygments.format(stream, self._get_formatter())
 
     def make_arrow(self, width: int) -> str:
         """generate the leading arrow in front of traceback or debugger"""

--- a/IPython/utils/_process_common.py
+++ b/IPython/utils/_process_common.py
@@ -14,12 +14,16 @@ of subprocess utilities, and it contains tools that are common to all of them.
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
 import os
 import shlex
-import subprocess
 import sys
-from typing import IO, TypeVar
+from typing import IO, TYPE_CHECKING, TypeVar
 from collections.abc import Callable
+
+if TYPE_CHECKING:
+    import subprocess
 
 _T = TypeVar("_T")
 
@@ -48,7 +52,7 @@ def read_no_interrupt(stream: IO[bytes]) -> bytes | None:
 def process_handler(
     cmd: str | list[str],
     callback: Callable[[subprocess.Popen[bytes]], _T],
-    stderr: int = subprocess.PIPE,
+    stderr: int | None = None,
 ) -> _T | None:
     """Open a command in a shell subprocess and execute a callback.
 
@@ -73,6 +77,11 @@ def process_handler(
     -------
     The return value of the provided callback is returned.
     """
+    import subprocess
+
+    if stderr is None:
+        stderr = subprocess.PIPE
+
     sys.stdout.flush()
     sys.stderr.flush()
     # On win32, close_fds can't be true when using pipes for stdin/out/err
@@ -137,6 +146,8 @@ def getoutput(cmd: str | list[str]) -> str:
     file descriptors (so the order of the information in this string is the
     correct order as would be seen if running the command in a terminal).
     """
+    import subprocess
+
     out = process_handler(cmd, lambda p: p.communicate()[0], subprocess.STDOUT)
     if out is None:
         return ''

--- a/IPython/utils/io.py
+++ b/IPython/utils/io.py
@@ -8,7 +8,6 @@ IO related utilities.
 
 
 import sys
-import tempfile
 from pathlib import Path
 
 from .capture import CapturedIO, capture_output
@@ -125,6 +124,7 @@ def temp_pyfile(src: str, ext: str='.py') -> str:
     (filename, open filehandle)
         It is the caller's responsibility to close the open file and unlink it.
     """
+    import tempfile
     fname = tempfile.mkstemp(ext)[1]
     with open(Path(fname), "w", encoding="utf-8") as f:
         f.write(src)

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -8,12 +8,8 @@ Utilities for path handling.
 import os
 import sys
 import errno
-import shutil
-import random
 import glob
 import warnings
-
-from IPython.utils.process import system
 
 #-----------------------------------------------------------------------------
 # Code
@@ -328,6 +324,7 @@ def link_or_copy(src, dst):
             # anyway, we get duplicate files - see http://bugs.python.org/issue21876
             return
 
+        import random
         new_dst = dst + "-temp-%04X" %(random.randint(1, 16**4), )
         try:
             link_or_copy(src, new_dst)
@@ -341,6 +338,7 @@ def link_or_copy(src, dst):
     elif link_errno != 0:
         # Either link isn't supported, or the filesystem doesn't support
         # linking, or 'src' and 'dst' are on different filesystems.
+        import shutil
         shutil.copy(src, dst)
 
 def ensure_dir_exists(path: str, mode: int=0o755):

--- a/IPython/utils/process.py
+++ b/IPython/utils/process.py
@@ -7,7 +7,6 @@ Utilities for working with external processes.
 
 
 import os
-import shutil
 import sys
 
 if sys.platform == 'win32':
@@ -48,6 +47,7 @@ def find_cmd(cmd):
     cmd : str
         The command line program to look for.
     """
+    import shutil
     path = shutil.which(cmd)
     if path is None:
         raise FindCmdError('command could not be found: %s' % cmd)

--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -18,7 +18,6 @@ import os
 import platform
 import pprint
 import sys
-import subprocess
 
 from pathlib import Path
 
@@ -57,6 +56,7 @@ def pkg_commit_hash(pkg_path: str) -> tuple[str, str]:
         return "installation", _sysinfo.commit
 
     # maybe we are in a repository
+    import subprocess
     proc = subprocess.Popen('git rev-parse --short HEAD'.split(' '),
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,

--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import os
 import sys
 import warnings
-from shutil import get_terminal_size as _get_terminal_size
 
 # This variable is part of the expected API of the module:
 ignore_termtitle = True
@@ -122,4 +121,5 @@ def restore_term_title():
 
 
 def get_terminal_size(defaultx: int = 80, defaulty: int = 25) -> tuple[int, int]:
+    from shutil import get_terminal_size as _get_terminal_size
     return _get_terminal_size((defaultx, defaulty))

--- a/docs/source/whatsnew/pr/kitty-graphics-force.rst
+++ b/docs/source/whatsnew/pr/kitty-graphics-force.rst
@@ -1,0 +1,20 @@
+Forcing kitty graphics support on or off
+----------------------------------------
+
+IPython decides whether the terminal understands the `kitty graphics protocol
+<https://sw.kovidgoyal.net/kitty/graphics-protocol/>`__ by walking up the
+process tree looking for a known terminal emulator. That guess can be wrong --
+for instance inside ``tmux``, a container, or an emulator not on the list -- and
+it is not free: it imports ``psutil`` and inspects the process tree on every
+startup that has a tty.
+
+The ``IPYTHON_KITTY_GRAPHICS`` environment variable now states the answer
+outright and skips the detection entirely::
+
+    IPYTHON_KITTY_GRAPHICS=1 ipython     # my terminal does support it
+    IPYTHON_KITTY_GRAPHICS=0 ipython     # it does not; do not even look
+
+Accepted values are ``1``/``true`` and ``0``/``false``, case-insensitive.
+Leaving it unset, or setting it to the empty string, keeps the existing
+autodetection. Any other value is ignored with a warning, so a typo cannot
+silently turn graphics off.

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -11,9 +11,28 @@ import pytest
 from traitlets import Unicode
 from traitlets.config import Config
 
-from IPython.core.application import BaseIPythonApplication
+from IPython.core.application import (
+    LOGGING_CRITICAL,
+    LOGGING_DEBUG,
+    BaseIPythonApplication,
+    base_flags,
+)
 from IPython.core.profiledir import ProfileDir
 from IPython.testing import decorators as dec
+
+
+def test_logging_level_constants():
+    """The inlined logging levels must not drift from the `logging` ones.
+
+    `IPython.core.application` spells these out rather than importing
+    `logging` at startup; this is the check that keeps the copies honest.
+    """
+    import logging
+
+    assert LOGGING_DEBUG == logging.DEBUG
+    assert LOGGING_CRITICAL == logging.CRITICAL
+    assert base_flags["debug"][0]["Application"]["log_level"] == logging.DEBUG
+    assert base_flags["quiet"][0]["Application"]["log_level"] == logging.CRITICAL
 
 
 @pytest.fixture

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -1,5 +1,7 @@
 import subprocess
 import sys
+
+import pytest
 from pathlib import Path
 
 
@@ -82,3 +84,73 @@ def test_supports_kitty_graphics_handles_psutil_access_denied(monkeypatch):
     monkeypatch.setattr(psutil, "Process", lambda *args, **kwargs: DeniedProcess())
 
     assert kitty._supports_kitty_graphics() is False
+
+
+def test_kitty_graphics_forced_on(monkeypatch):
+    """IPYTHON_KITTY_GRAPHICS=1 states support without probing anything."""
+    import psutil
+
+    from IPython.core import kitty
+
+    monkeypatch.setenv("IPYTHON_KITTY_GRAPHICS", "1")
+
+    def fail(*args, **kwargs):
+        raise AssertionError("detection must be skipped when forced")
+
+    monkeypatch.setattr(psutil, "Process", fail)
+    monkeypatch.setattr(sys, "stdout", DummyStdout())  # not even a tty
+
+    assert kitty._supports_kitty_graphics() is True
+
+
+def test_kitty_graphics_forced_off(monkeypatch):
+    """IPYTHON_KITTY_GRAPHICS=0 wins over a terminal that does support it."""
+    import psutil
+
+    from IPython.core import kitty
+
+    monkeypatch.setenv("IPYTHON_KITTY_GRAPHICS", "0")
+
+    def fail(*args, **kwargs):
+        raise AssertionError("detection must be skipped when forced")
+
+    monkeypatch.setattr(psutil, "Process", fail)
+    monkeypatch.setattr(sys, "stdout", StdoutTTY())
+
+    assert kitty._supports_kitty_graphics() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE"])
+def test_kitty_graphics_force_true_spellings(monkeypatch, value):
+    from IPython.core import kitty
+
+    monkeypatch.setenv("IPYTHON_KITTY_GRAPHICS", value)
+    assert kitty._forced_kitty_graphics() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE"])
+def test_kitty_graphics_force_false_spellings(monkeypatch, value):
+    from IPython.core import kitty
+
+    monkeypatch.setenv("IPYTHON_KITTY_GRAPHICS", value)
+    assert kitty._forced_kitty_graphics() is False
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_kitty_graphics_unset_autodetects(monkeypatch, value):
+    from IPython.core import kitty
+
+    if value is None:
+        monkeypatch.delenv("IPYTHON_KITTY_GRAPHICS", raising=False)
+    else:
+        monkeypatch.setenv("IPYTHON_KITTY_GRAPHICS", value)
+    assert kitty._forced_kitty_graphics() is None
+
+
+def test_kitty_graphics_bad_value_warns_and_autodetects(monkeypatch):
+    """A typo must not silently disable (or enable) graphics."""
+    from IPython.core import kitty
+
+    monkeypatch.setenv("IPYTHON_KITTY_GRAPHICS", "yes-please")
+    with pytest.warns(UserWarning, match="IPYTHON_KITTY_GRAPHICS"):
+        assert kitty._forced_kitty_graphics() is None

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -35,6 +35,15 @@ from IPython.core.magic import (
     register_line_magic,
 )
 from IPython.core.magics import code, execution, logging, osm, script
+
+try:
+    # cProfile is stdlib but wraps the optional `_lsprof` extension, so an
+    # interpreter can be built without a working profiler
+    import cProfile  # noqa: F401
+
+    HAS_PROFILER = True
+except ImportError:
+    HAS_PROFILER = False
 from IPython.core.history import HistoryOutput
 from IPython.testing import decorators as dec
 from IPython.testing import tools as tt
@@ -945,7 +954,7 @@ def test_timeit_raise_on_interrupt():
         thread.join()
 
 
-@dec.skipif(execution.profile is None)
+@dec.skipif(not HAS_PROFILER)
 def test_prun_special_syntax():
     "Test %%prun with IPython special syntax"
 
@@ -962,7 +971,7 @@ def test_prun_special_syntax():
     assert _ip.user_ns["lmagic_out"] == "my line2"
 
 
-@dec.skipif(execution.profile is None)
+@dec.skipif(not HAS_PROFILER)
 def test_prun_quotes():
     "Test that prun does not clobber string escapes (GH #1302)"
     _ip.run_line_magic("prun", r"-q x = '\t'")

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -60,21 +60,30 @@ def test_detect_screen_size():
 
 def test_display_page_string(monkeypatch):
     calls = []
-    monkeypatch.setattr(page, "display", lambda data, raw: calls.append((data, raw)))
+    # display_page imports display when it runs, so patch it at the source
+    monkeypatch.setattr(
+        "IPython.display.display", lambda data, raw: calls.append((data, raw))
+    )
     page.display_page("a\nb\nc", start=1)
     assert calls == [({"text/plain": "b\nc"}, True)]
 
 
 def test_display_page_string_no_start(monkeypatch):
     calls = []
-    monkeypatch.setattr(page, "display", lambda data, raw: calls.append((data, raw)))
+    # display_page imports display when it runs, so patch it at the source
+    monkeypatch.setattr(
+        "IPython.display.display", lambda data, raw: calls.append((data, raw))
+    )
     page.display_page("hello")
     assert calls == [({"text/plain": "hello"}, True)]
 
 
 def test_display_page_dict(monkeypatch):
     calls = []
-    monkeypatch.setattr(page, "display", lambda data, raw: calls.append((data, raw)))
+    # display_page imports display when it runs, so patch it at the source
+    monkeypatch.setattr(
+        "IPython.display.display", lambda data, raw: calls.append((data, raw))
+    )
     bundle = {"text/plain": "hi", "text/html": "<b>hi</b>"}
     page.display_page(bundle, start=3)
     # mime-bundles are passed through untouched; start is ignored

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -285,7 +285,8 @@ def test_pager_page_broken_pipe(page_mod, monkeypatch):
     def raise_broken_pipe(*args, **kwargs):
         raise OSError(32, "Broken pipe")
 
-    monkeypatch.setattr(page_mod.subprocess, "Popen", raise_broken_pipe)
+    # pager_page imports subprocess when it runs, so patch it at the source
+    monkeypatch.setattr("subprocess.Popen", raise_broken_pipe)
     text = "\n".join("line %d" % i for i in range(50))
     page_mod.pager_page(text, screen_lines=10, pager_cmd="cat > /dev/null")
     assert dumb_calls == []
@@ -302,7 +303,8 @@ def test_pager_page_oserror_falls_back(page_mod, monkeypatch):
     def raise_oserror(*args, **kwargs):
         raise OSError("no such pager")
 
-    monkeypatch.setattr(page_mod.subprocess, "Popen", raise_oserror)
+    # pager_page imports subprocess when it runs, so patch it at the source
+    monkeypatch.setattr("subprocess.Popen", raise_oserror)
     text = "\n".join("line %d" % i for i in range(50))
     page_mod.pager_page(text, screen_lines=10, pager_cmd="cat > /dev/null")
     assert dumb_calls == [text]
@@ -370,7 +372,10 @@ def test_page_file_uses_system_pager(page_mod, monkeypatch, tmp_path):
     # keep 'less' unmodified by get_pager_cmd so get_pager_start matches it
     monkeypatch.setenv("LESS", "-r")
     commands = []
-    monkeypatch.setattr(page_mod, "system", lambda cmd: commands.append(cmd))
+    # page_file imports `system` when it runs, so patch it where it is defined
+    monkeypatch.setattr(
+        "IPython.utils.process.system", lambda cmd: commands.append(cmd)
+    )
     fname = tmp_path / "some_file.txt"
     fname.write_text("contents", encoding="utf-8")
     page_mod.page_file(str(fname), start=2, pager_cmd="less")

--- a/tests/test_terminal_utils.py
+++ b/tests/test_terminal_utils.py
@@ -23,7 +23,8 @@ def test_get_terminal_size_returns_tuple():
     (40, 10),
 ])
 def test_get_terminal_size_defaults_used_when_no_tty(defaultx, defaulty):
-    with mock.patch("IPython.utils.terminal._get_terminal_size") as m:
+    # get_terminal_size imports it when it runs, so patch it in shutil
+    with mock.patch("shutil.get_terminal_size") as m:
         m.return_value = (defaultx, defaulty)
         w, h = get_terminal_size(defaultx, defaulty)
     assert w == defaultx

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -1,6 +1,7 @@
 from IPython.core.tips import _tips
 
 import importlib
+import importlib.util
 import os
 import sys
 import types
@@ -32,7 +33,8 @@ def test_pick_tip_random_day(monkeypatch):
     monkeypatch.setattr(
         tips_mod, "datetime", types.SimpleNamespace(now=lambda: datetime(2025, 6, 15))
     )
-    monkeypatch.setattr(tips_mod, "choice", lambda seq: seq[0])
+    # pick_tip imports `choice` when it runs, so patch it in random
+    monkeypatch.setattr("random.choice", lambda seq: seq[0])
     assert tips_mod.pick_tip() == tips_mod._tips["random"][0]
 
 
@@ -61,10 +63,36 @@ def test_unicode_tips_on_non_windows():
 
 
 def test_argcomplete_tip_added_when_available(monkeypatch):
+    # tips looks argcomplete up with find_spec rather than importing it, so
+    # pretend the module is on sys.path without providing one
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "argcomplete":
+            return types.SimpleNamespace(name=name)
+        return real_find_spec(name, *args, **kwargs)
+
     try:
         with monkeypatch.context() as m:
-            m.setitem(sys.modules, "argcomplete", types.ModuleType("argcomplete"))
+            m.setattr(importlib.util, "find_spec", fake_find_spec)
             mod = importlib.reload(tips_mod)
             assert any("argcomplete" in tip for tip in mod._tips["random"])
+    finally:
+        importlib.reload(tips_mod)
+
+
+def test_argcomplete_tip_absent_when_unavailable(monkeypatch):
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "argcomplete":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    try:
+        with monkeypatch.context() as m:
+            m.setattr(importlib.util, "find_spec", fake_find_spec)
+            mod = importlib.reload(tips_mod)
+            assert not any("argcomplete" in tip for tip in mod._tips["random"])
     finally:
         importlib.reload(tips_mod)

--- a/tests/test_utils_terminal.py
+++ b/tests/test_utils_terminal.py
@@ -123,7 +123,8 @@ def test_get_terminal_size_from_environment(monkeypatch):
 
 
 def test_get_terminal_size_defaults(monkeypatch):
-    # shutil.get_terminal_size falls back to the passed default values
-    monkeypatch.setattr(terminal, "_get_terminal_size", lambda fallback: fallback)
+    # shutil.get_terminal_size falls back to the passed default values.
+    # get_terminal_size imports it when it runs, so patch it in shutil.
+    monkeypatch.setattr("shutil.get_terminal_size", lambda fallback: fallback)
     assert terminal.get_terminal_size() == (80, 25)
     assert terminal.get_terminal_size(100, 50) == (100, 50)

--- a/tools/importtime_average.py
+++ b/tools/importtime_average.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Average several ``python -X importtime`` runs into a single report.
+
+``python -X importtime`` prints, to *stderr*, one line per imported module::
+
+    import time: self [us] | cumulative | imported package
+    import time:       146 |        146 |   _io
+    import time:       846 |       1223 | _frozen_importlib_external
+
+The ``self``/``cumulative`` columns are microseconds and the indentation of the
+module name encodes the import tree. A single run is noisy; this script reads
+several runs and emits one report with the per-module timings averaged, in the
+same format so downstream tooling (e.g. ``tuna``) can still read it.
+
+Usage
+-----
+Average existing logs (each file may itself contain several runs, split on the
+``self [us]`` header line -- so ``2>>log`` appended repeatedly works too)::
+
+    python tools/importtime_average.py run1.log run2.log run3.log
+
+Run a command N times and average (everything after ``--`` is the command; it
+must emit importtime output, i.e. include ``-X importtime``)::
+
+    python tools/importtime_average.py -n 10 -- python -X importtime -c "import IPython"
+
+Read a single run from stdin::
+
+    python -X importtime -c "import IPython" 2>&1 | python tools/importtime_average.py -
+
+Options let you sort by ``self`` or ``cumulative`` time instead of preserving
+the import tree, and annotate each line with how many runs it appeared in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+
+
+def progress(msg: str, *, done: bool = False) -> None:
+    """Write a progress line to stderr (in-place when stderr is a TTY)."""
+    if _QUIET:
+        return
+    if sys.stderr.isatty():
+        # \r + clear-to-end-of-line keeps updates on a single line.
+        end = "\n" if done else ""
+        print(f"\r\033[K{msg}", end=end, file=sys.stderr, flush=True)
+    else:
+        print(msg, file=sys.stderr, flush=True)
+
+
+_QUIET = False
+
+# A data line: "import time:  <self> | <cumulative> | <indented module>"
+# The header line has "self [us]" instead of a number and is used as a run
+# boundary. We keep the raw module column (with indentation) to reproduce the
+# tree, and strip it for the per-module key.
+_LINE = re.compile(r"^import time:\s*(\d+)\s*\|\s*(\d+)\s*\|(.*)$")
+_HEADER = re.compile(r"^import time:\s*self \[us\]")
+
+
+@dataclass
+class Module:
+    """Accumulated samples for one module across runs."""
+
+    display: str  # raw module column incl. indentation, from first sighting
+    self_us: list[int] = field(default_factory=list)
+    cumulative_us: list[int] = field(default_factory=list)
+
+    @property
+    def mean_self(self) -> float:
+        return statistics.fmean(self.self_us)
+
+    @property
+    def mean_cumulative(self) -> float:
+        return statistics.fmean(self.cumulative_us)
+
+
+def parse_runs(text: str) -> list[dict[str, tuple[int, int, str]]]:
+    """Split ``text`` into runs and parse each into {key: (self, cum, display)}.
+
+    A new run starts at every importtime header line; text before the first
+    header (or with no header at all) is treated as a single run.
+    """
+    runs: list[dict[str, tuple[int, int, str]]] = []
+    current: dict[str, tuple[int, int, str]] | None = None
+
+    def start() -> dict[str, tuple[int, int, str]]:
+        d: dict[str, tuple[int, int, str]] = {}
+        runs.append(d)
+        return d
+
+    for line in text.splitlines():
+        if _HEADER.match(line):
+            current = start()
+            continue
+        m = _LINE.match(line)
+        if not m:
+            continue
+        if current is None:
+            current = start()
+        self_us, cum_us, display = int(m.group(1)), int(m.group(2)), m.group(3)
+        key = display.strip()
+        # A module is normally reported once per run; if a run somehow repeats a
+        # name, keep the first (importtime prints in post-order of first import).
+        current.setdefault(key, (self_us, cum_us, display))
+
+    return [r for r in runs if r]
+
+
+def collect(texts: list[str]) -> tuple[list[Module], int, int]:
+    """Merge run texts into averaged modules.
+
+    Returns (modules, n_runs, reference_index) where reference_index points at
+    the run with the most modules -- used to order/indent the tree output.
+    """
+    runs: list[dict[str, tuple[int, int, str]]] = []
+    for text in texts:
+        runs.extend(parse_runs(text))
+    if not runs:
+        raise SystemExit("no importtime data found in input")
+
+    modules: dict[str, Module] = {}
+    for run in runs:
+        for key, (self_us, cum_us, display) in run.items():
+            mod = modules.get(key)
+            if mod is None:
+                mod = modules[key] = Module(display=display)
+            mod.self_us.append(self_us)
+            mod.cumulative_us.append(cum_us)
+
+    reference_index = max(range(len(runs)), key=lambda i: len(runs[i]))
+    return list(modules.values()), len(runs), reference_index, runs
+
+
+def order_modules(
+    modules: list[Module],
+    runs: list[dict[str, tuple[int, int, str]]],
+    reference_index: int,
+    sort: str,
+) -> list[Module]:
+    by_key = {m.display.strip(): m for m in modules}
+    if sort == "tree":
+        ordered: list[Module] = []
+        seen: set[str] = set()
+        # Follow the most complete run to preserve tree order and indentation.
+        for key in runs[reference_index]:
+            ordered.append(by_key[key])
+            seen.add(key)
+        # Append modules that never appeared in the reference run.
+        leftover = [m for k, m in by_key.items() if k not in seen]
+        leftover.sort(key=lambda m: m.mean_self, reverse=True)
+        ordered.extend(leftover)
+        return ordered
+    key_fn = {
+        "self": lambda m: m.mean_self,
+        "cumulative": lambda m: m.mean_cumulative,
+    }[sort]
+    return sorted(modules, key=key_fn, reverse=True)
+
+
+def format_report(modules: list[Module], n_runs: int, sort: str, annotate: bool) -> str:
+    lines = ["import time: self [us] | cumulative | imported package"]
+    for mod in modules:
+        # For flat sorts the tree indentation is meaningless, so strip it and
+        # print the bare name; for "tree" keep the original indented column.
+        name = mod.display if sort == "tree" else " " + mod.display.strip()
+        line = "import time: %9d | %10d |%s" % (
+            round(mod.mean_self),
+            round(mod.mean_cumulative),
+            name,
+        )
+        if annotate and len(mod.self_us) != n_runs:
+            line += f"    # {len(mod.self_us)}/{n_runs} runs"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def run_command(cmd: list[str], repeat: int) -> list[str]:
+    texts: list[str] = []
+    durations: list[float] = []
+    for i in range(repeat):
+        progress(f"running {i + 1}/{repeat} ...")
+        started = time.perf_counter()
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        elapsed = time.perf_counter() - started
+        durations.append(elapsed)
+        # importtime writes to stderr; some programs also print there, but the
+        # parser ignores non-matching lines.
+        combined = proc.stderr + "\n" + proc.stdout
+        if "import time:" not in combined:
+            progress("", done=True)
+            raise SystemExit(
+                f"run {i + 1}: no importtime output from {cmd!r}; "
+                "did you include '-X importtime'?"
+            )
+        texts.append(combined)
+        progress(
+            f"ran {i + 1}/{repeat} "
+            f"(last {elapsed:.2f}s, mean {statistics.fmean(durations):.2f}s)",
+            done=(i + 1 == repeat),
+        )
+    return texts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Average several `python -X importtime` runs.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="importtime log files ('-' for stdin). Each file may contain "
+        "several runs separated by the importtime header line.",
+    )
+    parser.add_argument(
+        "-n",
+        "--repeat",
+        type=int,
+        metavar="N",
+        help="run the command after '--' N times and average those runs.",
+    )
+    parser.add_argument(
+        "--sort",
+        choices=("tree", "self", "cumulative"),
+        default="tree",
+        help="output order: preserve the import tree (default), or sort "
+        "descending by mean self/cumulative time (flat list).",
+    )
+    parser.add_argument(
+        "--annotate",
+        action="store_true",
+        help="append '# k/N runs' to modules that did not appear in every run.",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="print a short summary (run count, module count, total time) to stderr.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="suppress progress reporting on stderr.",
+    )
+    # Everything after '--' is the command to run.
+    if argv is None:
+        argv = sys.argv[1:]
+    cmd: list[str] = []
+    if "--" in argv:
+        split = argv.index("--")
+        argv, cmd = argv[:split], argv[split + 1 :]
+    args = parser.parse_args(argv)
+
+    global _QUIET
+    _QUIET = args.quiet
+
+    texts: list[str] = []
+    if cmd:
+        repeat = args.repeat if args.repeat is not None else 1
+        if repeat < 1:
+            parser.error("--repeat must be >= 1")
+        texts.extend(run_command(cmd, repeat))
+    elif args.repeat is not None:
+        parser.error("--repeat requires a command after '--'")
+
+    for i, path in enumerate(args.files):
+        if path == "-":
+            texts.append(sys.stdin.read())
+        else:
+            progress(f"reading {i + 1}/{len(args.files)}: {path}")
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                texts.append(fh.read())
+    if args.files and args.files != ["-"]:
+        progress(f"read {len(args.files)} file(s)", done=True)
+
+    if not texts:
+        parser.error("provide log file(s), '-' for stdin, or '-n N -- <command>'")
+
+    progress("averaging ...")
+    modules, n_runs, reference_index, runs = collect(texts)
+    progress(f"averaged {len(modules)} modules across {n_runs} run(s)", done=True)
+    modules = order_modules(modules, runs, reference_index, args.sort)
+    report = format_report(modules, n_runs, args.sort, args.annotate)
+    print(report)
+
+    if args.stats:
+        # Sum of self time is the real cost of the import graph (cumulative
+        # double-counts children). Average it across runs by summing per run.
+        per_run_totals = [sum(v[0] for v in run.values()) for run in runs]
+        print(
+            f"\n# runs: {n_runs} | modules: {len(modules)} | "
+            f"mean total self time: {statistics.fmean(per_run_totals):.0f} us "
+            f"(min {min(per_run_totals)} / max {max(per_run_totals)})",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This is a global effort to speedup both import time and startup of IPython (and ipykernel). 

```
IPYKERNEL_BENCHMARK_STARTUP_SHUTDOWN=1 python tools/importtime_average.py -n 20 -- python -X importtime -m ipykernel  > totlog.log && tuna totlog.log
```

With `tuna` installed to view the report. 

Beyond making things lazy, it also add an option to avoid autodetection of kitty support at startup that can take some time. This can be controled with `IPYTHON_KITTY_GRAPHICS`, which is an env variable as it need to be detected before traitlets configuration options.


This did use Opus to split the work into multiple commits in case of regression to partially revert and write some of the commit messages



