### PR TITLE
escape urls and file names interpolated into display html attributes

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1065,7 +1065,7 @@ class Image(DisplayObject):
             if self.alt:
                 alt = ' alt="%s"' % html.escape(self.alt)
             return '<img src="{url}"{width}{height}{klass}{alt}/>'.format(
-                url=self.url,
+                url=html.escape(self.url or ""),
                 width=width,
                 height=height,
                 klass=klass,
@@ -1228,7 +1228,7 @@ class Video(DisplayObject):
             url = self.url if self.url is not None else self.filename
             output = """<video src="{}" {} {} {}>
       Your browser does not support the <code>video</code> element.
-    </video>""".format(url, self.html_attributes, width, height)
+    </video>""".format(html.escape(url or ""), self.html_attributes, width, height)
             return output
 
         # Embedded videos are base64-encoded.

--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -240,7 +240,7 @@ class Audio(DisplayObject):
             return """data:{type};base64,{base64}""".format(type=self.mimetype,
                                                             base64=data)
         elif self.url is not None:
-            return self.url
+            return html_escape(self.url)
         else:
             return ""
 
@@ -252,7 +252,7 @@ class Audio(DisplayObject):
 
     def element_id_attr(self):
         if (self.element_id):
-            return f'id="{self.element_id}"'
+            return f'id="{html_escape(self.element_id)}"'
         else:
             return ''
 
@@ -292,9 +292,9 @@ class IFrame:
         else:
             params = ""
         return self.iframe.format(
-            src=self.src,
-            width=self.width,
-            height=self.height,
+            src=html_escape(self.src),
+            width=html_escape(str(self.width)),
+            height=html_escape(str(self.height)),
             params=params,
             extras=" ".join(self.extras),
         )
@@ -513,7 +513,12 @@ class FileLinks(FileLink):
         self.recursive = recursive
 
     def _get_display_formatter(
-        self, dirname_output_format, fname_output_format, fp_format, fp_cleaner=None
+        self,
+        dirname_output_format,
+        fname_output_format,
+        fp_format,
+        fp_cleaner=None,
+        escape_names=False,
     ):
         """generate built-in formatter function
 
@@ -531,7 +536,11 @@ class FileLinks(FileLink):
         fp_format: string to use for formatting filepaths, must contain
          exactly two "%s" and the dirname will be substituted for the first
          and fname will be substituted for the second
+        escape_names: whether directory and file names must be HTML-escaped
+         before being substituted, as they are for the notebook formatter
         """
+        escape = html_escape if escape_names else str
+
         def f(dirname, fnames, included_suffixes=None):
             result = []
             # begin by figuring out which filenames, if any,
@@ -550,18 +559,18 @@ class FileLinks(FileLink):
             else:
                 # otherwise print the formatted directory name followed by
                 # the formatted filenames
-                dirname_output_line = dirname_output_format % dirname
+                dirname_output_line = dirname_output_format % escape(dirname)
                 result.append(dirname_output_line)
                 for fname in display_fnames:
-                    fp = fp_format % (dirname,fname)
+                    fp = fp_format % (escape(dirname), escape(fname))
                     if fp_cleaner is not None:
                         fp = fp_cleaner(fp)
                     try:
                         # output can include both a filepath and a filename...
-                        fname_output_line = fname_output_format % (fp, fname)
+                        fname_output_line = fname_output_format % (fp, escape(fname))
                     except TypeError:
                         # ... or just a single filepath
-                        fname_output_line = fname_output_format % fname
+                        fname_output_line = fname_output_format % escape(fname)
                     result.append(fname_output_line)
             return result
         return f
@@ -586,10 +595,13 @@ class FileLinks(FileLink):
         else:
             fp_cleaner = None
 
-        return self._get_display_formatter(dirname_output_format,
-                                           fname_output_format,
-                                           fp_format,
-                                           fp_cleaner)
+        return self._get_display_formatter(
+            dirname_output_format,
+            fname_output_format,
+            fp_format,
+            fp_cleaner,
+            escape_names=True,
+        )
 
     def _get_terminal_display_formatter(self,
                                         spacer="  "):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -188,9 +188,33 @@ def test_recursive_FileLinks():
         assert len(actual) == 2, actual
 
 
+def test_escaped_names_FileLinks():
+    """FileLinks: html metacharacters in file names are escaped"""
+    td = mkdtemp()
+    with open(pjoin(td, "a'><script>.txt"), "w"):
+        pass
+    actual = display.FileLinks(td)._repr_html_()
+    assert "a&#x27;&gt;&lt;script&gt;.txt" in actual
+    assert "a'><script>.txt" not in actual
+
+
 def test_audio_from_file():
     path = pjoin(dirname(__file__), "test.wav")
     display.Audio(filename=path)
+
+
+def test_escaped_url_Audio():
+    """Audio: quotes in url and element_id do not break out of the attribute"""
+    audio = display.Audio(url='http://example.com/a.wav" onerror="alert(1)')
+    assert (
+        'src="http://example.com/a.wav&quot; onerror=&quot;alert(1)"'
+        in audio._repr_html_()
+    )
+
+    audio = display.Audio(
+        url="http://example.com/a.wav", element_id='x" onload="alert(1)'
+    )
+    assert 'id="x&quot; onload=&quot;alert(1)"' in audio._repr_html_()
 
 
 @skipif_not_numpy

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -191,11 +191,14 @@ def test_recursive_FileLinks():
 def test_escaped_names_FileLinks():
     """FileLinks: html metacharacters in file names are escaped"""
     td = mkdtemp()
-    with open(pjoin(td, "a'><script>.txt"), "w"):
+    # links are emitted as href='...', so the apostrophe is what breaks out of
+    # the attribute; "<" and ">" are not usable as they are invalid on windows
+    name = "a' onmouseover='alert(1)&.txt"
+    with open(pjoin(td, name), "w"):
         pass
     actual = display.FileLinks(td)._repr_html_()
-    assert "a&#x27;&gt;&lt;script&gt;.txt" in actual
-    assert "a'><script>.txt" not in actual
+    assert "a&#x27; onmouseover=&#x27;alert(1)&amp;.txt" in actual
+    assert name not in actual
 
 
 def test_audio_from_file():

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -565,6 +565,36 @@ def test_image_alt_tag():
     assert md["alt"] == "an image"
 
 
+def test_image_url_escaping():
+    """Image: a quote in the url does not break out of the src attribute"""
+    img = display.Image(url='http://example.com/i.png" onerror="alert(1)')
+    assert (
+        '<img src="http://example.com/i.png&quot; onerror=&quot;alert(1)"/>'
+        == img._repr_html_()
+    )
+
+
+def test_video_url_escaping():
+    """Video: a quote in the url does not break out of the src attribute"""
+    v = display.Video('http://example.com/v.mp4" onerror="alert(1)')
+    assert (
+        'src="http://example.com/v.mp4&quot; onerror=&quot;alert(1)"'
+        in v._repr_html_()
+    )
+
+
+def test_iframe_escaping():
+    """IFrame: quotes in src, width and height stay inside their attributes"""
+    html = display.IFrame('http://example.com/?a=1"><script>', 400, 300)._repr_html_()
+    assert 'src="http://example.com/?a=1&quot;&gt;&lt;script&gt;"' in html
+
+    html = display.YouTubeVideo('abc"><script>')._repr_html_()
+    assert '"><script>' not in html
+
+    html = display.IFrame("http://example.com", '400" onload="alert(1)', 300)
+    assert 'width="400&quot; onload=&quot;alert(1)"' in html._repr_html_()
+
+
 def test_image_bad_filename_raises_proper_exception():
     with pytest.raises(FileNotFoundError):
         display.Image("/this/file/does/not/exist/")._repr_png_()


### PR DESCRIPTION
Values callers pass to the display objects land unescaped inside quoted HTML attributes, so a quote in one closes the attribute and the rest is parsed as markup:

- `Image` and `Video` interpolate url/filename into `src="..."`; `Image._repr_html_` already escapes `alt` but not the url beside it
- `IFrame` does the same for `src`, `width` and `height`, reachable through the `YouTubeVideo`/`VimeoVideo`/`ScribdDocument` id argument
- `Audio` for its url and `element_id`, and the `FileLinks` notebook formatter for names read off disk
- `YouTubeVideo('abc"><script>')` closes the iframe and injects a tag into the notebook output

Left raw: `Video.html_attributes`, `IFrame.extras` and the `FileLink` html prefix/suffix, which are documented as HTML; `IFrame` params are already percent-encoded by urlencode. For a valid url the only change is `&` rendering as `&amp;`.
