### PR TITLE
Make %lsmagic return plain text by default

### DIFF
--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -181,10 +181,21 @@ class BasicMagics(Magics):
                 magic_escapes['cell'], name,
                 magic_escapes['cell'], target, params_str))
 
+    @magic_arguments.magic_arguments()
+    @magic_arguments.argument(
+        "-j", "--json", action="store_true", help="Return the magic list as JSON."
+    )
     @line_magic
     def lsmagic(self, parameter_s=''):
-        """List currently available magic functions."""
-        return MagicsDisplay(self.shell.magics_manager, ignore=[])
+        """List currently available magic functions.
+
+        Use ``--json`` to return a JSON-compatible dictionary instead of text.
+        """
+        args = magic_arguments.parse_argstring(self.lsmagic, parameter_s)
+        display = MagicsDisplay(self.shell.magics_manager, ignore=[])
+        if args.json:
+            return display._jsonable()
+        return str(display)
 
     def _magic_docs(self, brief=False, rest=False):
         """Return docstrings from magic functions."""

--- a/docs/source/whatsnew/pr/incompat-lsmagic-plain-text.rst
+++ b/docs/source/whatsnew/pr/incompat-lsmagic-plain-text.rst
@@ -1,0 +1,3 @@
+``%lsmagic`` now returns plain text by default so that frontends render its
+human-readable output consistently. Use ``%lsmagic --json`` to retrieve the
+machine-readable mapping of registered magics.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1818,13 +1818,16 @@ def test_bookmark():
 
 def test_ls_magic():
     ip = get_ipython()
-    json_formatter = ip.display_formatter.formatters["application/json"]
-    json_formatter.enabled = True
     lsmagic = ip.run_line_magic("lsmagic", "")
-    with warnings.catch_warnings(record=True) as w:
-        j = json_formatter(lsmagic)
-    assert sorted(j) == ["cell", "line"]
-    assert w == []  # no warnings
+    assert isinstance(lsmagic, str)
+    assert "Available line magics:" in lsmagic
+    assert "Available cell magics:" in lsmagic
+
+
+def test_ls_magic_json():
+    ip = get_ipython()
+    lsmagic = ip.run_line_magic("lsmagic", "--json")
+    assert sorted(lsmagic) == ["cell", "line"]
 
 
 def test_strip_initial_indent():


### PR DESCRIPTION
Closes #11793.

`%lsmagic` now returns its human-readable text by default so frontends such as JupyterLab do not prefer the JSON MIME representation. Users that need the machine-readable mapping can request it explicitly with `%lsmagic --json`.

This adds coverage for both output modes and an incompatibility news fragment. It follows up on the approach in the now-closed #14331, with the default path returning text instead of the original rich-display object.
