### PR TITLE
Resolve attribute annotations under the policy in eval_node

### DIFF
--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -1,5 +1,5 @@
 from copy import copy
-from inspect import isclass, signature, Signature, getmodule
+from inspect import get_annotations, isclass, signature, Signature, getmodule
 from typing import (
     Annotated,
     AnyStr,
@@ -29,7 +29,7 @@ from types import MethodDescriptorType, ModuleType, MethodType
 from IPython.utils.decorators import undoc
 
 import types
-from typing import Self, LiteralString, get_type_hints
+from typing import Self, LiteralString
 
 if sys.version_info < (3, 12):
     from typing_extensions import TypeAliasType
@@ -1125,14 +1125,9 @@ def eval_node(node: ast.AST | None, context: EvaluationContext):
                 value if isinstance(value, type) else getattr(value, "__class__", None)
             )
             if cls is not None:
-                resolved_hints = get_type_hints(
-                    cls,
-                    globalns=(context.globals or {}),
-                    localns=(context.locals or {}),
-                )
-                if node.attr in resolved_hints:
-                    annotated = resolved_hints[node.attr]
-                    return _resolve_annotation(annotated, context)
+                hints = _collect_annotations(cls)
+                if node.attr in hints:
+                    return _resolve_annotation(hints[node.attr], context)
         except Exception:
             # Fall through to the guard rejection
             pass
@@ -1319,15 +1314,27 @@ def _eval_return_type(func: Callable, node: ast.Call, context: EvaluationContext
     return NOT_EVALUATED
 
 
+def _collect_annotations(cls: type) -> dict:
+    """Collect annotations of a class and its bases without resolving them.
+
+    `typing.get_type_hints()` is not usable here because it resolves stringized
+    annotations with `eval()`; under PEP 563 every annotation of a module is a
+    string, so that would run arbitrary code from `__annotations__`. Strings are
+    left as-is and later resolved by `_eval_annotation` under the policy.
+    """
+    annotations: dict = {}
+    for base in reversed(cls.__mro__):
+        annotations.update(get_annotations(base, eval_str=False))
+    return annotations
+
+
 def _eval_annotation(
     annotation: str,
     context: EvaluationContext,
 ):
-    return (
-        _eval_node_name(annotation, context)
-        if isinstance(annotation, str)
-        else annotation
-    )
+    if not isinstance(annotation, str):
+        return annotation
+    return eval_node(ast.parse(annotation, mode="eval").body, context)
 
 
 class _GetItemDuck(dict):

--- a/tests/test_guarded_eval.py
+++ b/tests/test_guarded_eval.py
@@ -122,6 +122,31 @@ def test_rejects_custom_properties():
         guarded_eval("data.iloc[0]", context)
 
 
+def test_rejects_stringized_annotations():
+    """Annotations are arbitrary expressions and must be resolved under the policy.
+
+    Every annotation of a module using PEP 563 is a string, so resolving them
+    eagerly would run whatever the string spells out.
+    """
+    called = []
+
+    def side_effect():
+        called.append(1)
+        return int
+
+    class Custom:
+        attr: "side_effect()"
+
+        def __getattr__(self, key):
+            raise AssertionError("should not be called")
+
+    context = limited(data=Custom(), side_effect=side_effect)
+
+    with pytest.raises(GuardRejection):
+        guarded_eval("data.attr", context)
+    assert called == []
+
+
 @dec.skip_without("pandas")
 def test_accepts_non_overriden_properties():
     import pandas as pd


### PR DESCRIPTION
**Arbitrary code execution from class annotations in eval_node**

The attribute branch falls back to `typing.get_type_hints()` after the policy has already refused the attribute, and that call resolves stringized annotations with `eval()`, so completing `obj.attr` runs whatever the annotation contains under the default `limited` policy. Collecting the raw annotations with `inspect.get_annotations(eval_str=False)` and resolving them through `eval_node` keeps annotation completion working while routing the expression through the same policy checks as the rest of the input.
