### PR TITLE
Use guarded_eval for the callable in python_func_kw_matches

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2975,8 +2975,18 @@ class IPCompleter(Completer):
         argMatches = []
         try:
             callableObj = '.'.join(ids[::-1])
-            namedArgs = self._default_arguments(eval(callableObj,
-                                                    self.namespace))
+            namedArgs = self._default_arguments(
+                guarded_eval(
+                    callableObj,
+                    EvaluationContext(
+                        globals=self.global_namespace,
+                        locals=self.namespace,
+                        evaluation=self.evaluation,
+                        auto_import=self._auto_import,
+                        policy_overrides=self.policy_overrides,
+                    ),
+                )
+            )
 
             # Remove used named arguments from the list, no need to show twice
             for namedArg in set(namedArgs) - usedNamedArgs:

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -1481,6 +1481,39 @@ def test_dict_key_completion_contexts():
         assert_completion(line_buffer="get()['ab")
         assert_completion(line_buffer="get()['abc")
 
+def test_func_kw_matches_respects_evaluation_policy():
+    ip = get_ipython()
+    complete = ip.Completer.complete
+    evaluated = []
+
+    class Proxy:
+        @property
+        def handler(self):
+            evaluated.append("handler")
+            return lambda timeout=1: None
+
+    def plain(alpha=1):
+        pass
+
+    ip.user_ns["proxy"] = Proxy()
+    ip.user_ns["plain"] = plain
+
+    with jedi_status(False):
+        with evaluation_policy("limited"):
+            _, matches = complete(line_buffer="proxy.handler(")
+            assert "timeout=" not in matches
+            assert evaluated == []
+
+            # plain callables are unaffected
+            _, matches = complete(line_buffer="plain(")
+            assert "alpha=" in matches
+
+        with evaluation_policy("unsafe"):
+            _, matches = complete(line_buffer="proxy.handler(")
+            assert "timeout=" in matches
+            assert evaluated == ["handler"]
+
+
 def test_completion_autoimport():
     ip = get_ipython()
     complete = ip.Completer.complete


### PR DESCRIPTION
Keyword completion is the one evaluation site left in the completer that never consulted the policy:

- `python_func_kw_matches` resolves the callable with a bare `eval()`, while `global_matches`, `_evaluate_expr` and the dict key matcher all go through `guarded_eval`
- `python_func_kw_matcher` is in the default matcher list, so `obj.attr(` plus Tab runs a property getter or a custom `__getattr__` with no cell executed
- `guarded_eval` refuses that same attribute access under the default `limited` policy, so the two currently disagree about the same expression

Routed it through the `EvaluationContext` the sibling matchers already build. Plain functions and ordinary methods still complete their keywords, and the eager behaviour stays available under `evaluation="unsafe"`.