### PR TITLE
Register IPython's built-in magics lazily

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2432,6 +2432,8 @@ class IPCompleter(Completer):
         texts = text.strip().split()
 
         if len(texts) > 0 and (texts[0] == 'config' or texts[0] == '%config'):
+            # Only instantiated magics are configurable; load the lazy ones.
+            self.shell.magics_manager.load_all_lazy_magics()
             # get all configuration classes
             classes = sorted({ c for c in self.shell.configurables
                                    if c.__class__.class_traits(config=True)

--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2432,6 +2432,9 @@ class IPCompleter(Completer):
         texts = text.strip().split()
 
         if len(texts) > 0 and (texts[0] == 'config' or texts[0] == '%config'):
+            # Magics classes are registered lazily and are only configurable
+            # once instantiated; load them so %config completes all of them.
+            self.shell.magics_manager.load_all_lazy_magics()
             # get all configuration classes
             classes = sorted({ c for c in self.shell.configurables
                                    if c.__class__.class_traits(config=True)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2440,16 +2440,20 @@ class InteractiveShell(SingletonConfigurable):
         # Expose as public API from the magics manager
         self.register_magics = self.magics_manager.register
 
-        self.register_magics(m.AutoMagics, m.BasicMagics, m.CodeMagics,
-            m.ConfigMagics, m.DisplayMagics, m.ExecutionMagics,
-            m.ExtensionMagics, m.HistoryMagics, m.LoggingMagics,
-            m.NamespaceMagics, m.OSMagics, m.PackagingMagics,
-            m.PylabMagics, m.ScriptMagics,
-        )
-        self.register_magics(m.AsyncMagics)
+        mman = self.magics_manager
+
+        # IPython's own magics are declared rather than registered: the module
+        # implementing one is imported the first time it is looked up.  The
+        # table is hand maintained; tests/test_magic_table.py checks it.
+        for magic_kind, table in m.BUILTIN_LAZY_MAGICS.items():
+            for magic_name, spec in table.items():
+                mman.register_lazy(magic_name, spec, magic_kind)
+        # ScriptMagics generates a cell magic per configured interpreter.
+        script_magics = m.MAGICS_CLASSES["ScriptMagics"] + ":ScriptMagics"
+        for magic_name in m.configured_script_magics(self.config):
+            mman.register_lazy(magic_name, script_magics, "cell")
 
         # Register Magic Aliases
-        mman = self.magics_manager
         # FIXME: magic aliases should be defined by the Magics classes
         # or in MagicsManager, not here
         mman.register_alias('ed', 'edit')
@@ -2462,7 +2466,9 @@ class InteractiveShell(SingletonConfigurable):
         # FIXME: Move the color initialization to the DisplayHook, which
         # should be split into a prompt manager and displayhook. We probably
         # even need a centralize colors management object.
-        self.run_line_magic('colors', self.colors)
+        # This used to go through `%colors`, which would import the basic
+        # magics on every startup just to assign `shell.colors`.
+        self.init_syntax_highlighting()
 
     # Defined here so that it's included in the documentation
     @functools.wraps(magic.MagicsManager.register_function)
@@ -2486,17 +2492,8 @@ class InteractiveShell(SingletonConfigurable):
 
         Note that this may have any side effects
         """
-        finder = {"line": self.find_line_magic, "cell": self.find_cell_magic}[type_]
-        fn = finder(magic_name)
-        if fn is not None:
-            return fn
-        lazy = self.magics_manager.lazy_magics.get(magic_name)
-        if lazy is None:
-            return None
-
-        self.run_line_magic("load_ext", lazy)
-        res = finder(magic_name)
-        return res
+        # find_line_magic/find_cell_magic lazy-load by themselves now.
+        return self.magics_manager.find(type_, magic_name)
 
     def run_line_magic(self, magic_name: str, line: str, _stack_depth=1):
         """Execute the given line magic.
@@ -2512,11 +2509,6 @@ class InteractiveShell(SingletonConfigurable):
             This is added to ensure backward compatibility for use of 'get_ipython().magic()'
         """
         fn = self._find_with_lazy_load("line", magic_name)
-        if fn is None:
-            lazy = self.magics_manager.lazy_magics.get(magic_name)
-            if lazy:
-                self.run_line_magic("load_ext", lazy)
-                fn = self.find_line_magic(magic_name)
         if fn is None:
             cm = self.find_cell_magic(magic_name)
             etpl = "Line magic function `%%%s` not found%s."
@@ -2618,19 +2610,19 @@ class InteractiveShell(SingletonConfigurable):
         """Find and return a line magic by name.
 
         Returns None if the magic isn't found."""
-        return self.magics_manager.magics['line'].get(magic_name)
+        return self.magics_manager.find("line", magic_name)
 
     def find_cell_magic(self, magic_name):
         """Find and return a cell magic by name.
 
         Returns None if the magic isn't found."""
-        return self.magics_manager.magics['cell'].get(magic_name)
+        return self.magics_manager.find("cell", magic_name)
 
     def find_magic(self, magic_name, magic_kind='line'):
         """Find and return a magic of the given type by name.
 
         Returns None if the magic isn't found."""
-        return self.magics_manager.magics[magic_kind].get(magic_name)
+        return self.magics_manager.find(magic_kind, magic_name)
 
     #-------------------------------------------------------------------------
     # Things related to macros
@@ -3881,6 +3873,7 @@ class InteractiveShell(SingletonConfigurable):
         # Now we must activate the gui pylab wants to use, and fix %run to take
         # plot updates into account
         self.enable_gui(gui)
+        # registry imports ExecutionMagics on the miss if %run is not loaded.
         self.magics_manager.registry['ExecutionMagics'].default_runner = \
             pt.mpl_runner(self.safe_execfile)
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2440,29 +2440,39 @@ class InteractiveShell(SingletonConfigurable):
         # Expose as public API from the magics manager
         self.register_magics = self.magics_manager.register
 
-        self.register_magics(m.AutoMagics, m.BasicMagics, m.CodeMagics,
-            m.ConfigMagics, m.DisplayMagics, m.ExecutionMagics,
-            m.ExtensionMagics, m.HistoryMagics, m.LoggingMagics,
-            m.NamespaceMagics, m.OSMagics, m.PackagingMagics,
-            m.PylabMagics, m.ScriptMagics,
-        )
-        self.register_magics(m.AsyncMagics)
+        mman = self.magics_manager
+
+        # The built-in magics are registered lazily: only their *names* are
+        # known at startup, and the module implementing a magic is imported the
+        # first time that magic is used.  The name -> class table is hand
+        # maintained in IPython.core.magics._table; tests/test_magic_table.py
+        # fails if it drifts out of sync.
+        for class_name, names in m.BUILTIN_MAGICS.items():
+            spec = "{}:{}".format(m.MAGICS_CLASSES[class_name], class_name)
+            line_magics = names["line"]
+            cell_magics = names["cell"]
+            if class_name == "ScriptMagics":
+                # ScriptMagics generates one `%%<interpreter>` cell magic per
+                # entry of its (configurable) `script_magics` trait.
+                cell_magics = (
+                    *cell_magics,
+                    *m.configured_script_magics(self.config),
+                )
+            mman.register_lazy_class(spec, line_magics, cell_magics)
 
         # Register Magic Aliases
-        mman = self.magics_manager
         # FIXME: magic aliases should be defined by the Magics classes
         # or in MagicsManager, not here
-        mman.register_alias('ed', 'edit')
-        mman.register_alias('hist', 'history')
-        mman.register_alias('rep', 'recall')
-        mman.register_alias('SVG', 'svg', 'cell')
-        mman.register_alias('HTML', 'html', 'cell')
-        mman.register_alias('file', 'writefile', 'cell')
+        for alias, target, magic_kind in m.BUILTIN_MAGIC_ALIASES:
+            mman.register_alias(alias, target, magic_kind)
 
         # FIXME: Move the color initialization to the DisplayHook, which
         # should be split into a prompt manager and displayhook. We probably
         # even need a centralize colors management object.
-        self.run_line_magic('colors', self.colors)
+        # This used to go through `%colors`, but that would defeat the lazy
+        # registration above by importing the basic magics on every startup;
+        # all the magic does is assign `shell.colors`, whose observer this is.
+        self.init_syntax_highlighting()
 
     # Defined here so that it's included in the documentation
     @functools.wraps(magic.MagicsManager.register_function)
@@ -2618,19 +2628,19 @@ class InteractiveShell(SingletonConfigurable):
         """Find and return a line magic by name.
 
         Returns None if the magic isn't found."""
-        return self.magics_manager.magics['line'].get(magic_name)
+        return self.magics_manager.find("line", magic_name)
 
     def find_cell_magic(self, magic_name):
         """Find and return a cell magic by name.
 
         Returns None if the magic isn't found."""
-        return self.magics_manager.magics['cell'].get(magic_name)
+        return self.magics_manager.find("cell", magic_name)
 
     def find_magic(self, magic_name, magic_kind='line'):
         """Find and return a magic of the given type by name.
 
         Returns None if the magic isn't found."""
-        return self.magics_manager.magics[magic_kind].get(magic_name)
+        return self.magics_manager.find(magic_kind, magic_name)
 
     #-------------------------------------------------------------------------
     # Things related to macros

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -349,6 +349,67 @@ register_line_cell_magic = _function_magic_marker("line_cell")
 # -----------------------------------------------------------------------------
 
 
+class LazyMagic:
+    """Stands in the magics table for a magic that is not imported yet.
+
+    Listing and completing magics only look at names, so they stay cheap;
+    using one -- calling it, or reading any attribute of it, as pyflyby does
+    with ``magics["line"]["prun"].__self__`` -- resolves through
+    :meth:`MagicsManager.find`, which imports and registers the real thing.
+    """
+
+    def __init__(
+        self,
+        manager: MagicsManager,
+        spec: str,
+        magic_kind: _MagicKind,
+        magic_name: str,
+    ) -> None:
+        self.spec = spec
+        self._manager = manager
+        self._kind = magic_kind
+        self._name = magic_name
+
+    def _resolve(self) -> Callable[..., Any]:
+        fn = self._manager.find(self._kind, self._name)
+        if fn is None:
+            raise UsageError(
+                f"Magic `{magic_escapes[self._kind]}{self._name}` not found."
+            )
+        return fn
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._resolve()(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resolve(), name)
+
+    def __repr__(self) -> str:
+        return f"<unloaded magic {self._name} from {self.spec}>"
+
+
+class _MagicsRegistry(dict[str, Any]):
+    """``MagicsManager.registry``, which loads a lazy class on a miss.
+
+    ``registry["ExecutionMagics"]`` is a legitimate way to reach a magics
+    instance, and may now be the first thing that needs the class.
+    """
+
+    def __init__(self, manager: MagicsManager) -> None:
+        super().__init__()
+        self._manager = manager
+
+    def __missing__(self, key: str) -> Any:
+        for magic_name, spec in list(self._manager.lazy_magics.items()):
+            if spec.endswith(":" + key):
+                self._manager.load_lazy(magic_name)
+                break
+        if key not in self:
+            # A second miss must not loop back here.
+            raise KeyError(key)
+        return self[key]
+
+
 class MagicsManager(Configurable):
     """Object that handles all magic-related functionality for IPython."""
 
@@ -375,6 +436,11 @@ class MagicsManager(Configurable):
     On first invocation of `%my_magic`, `%%my_magic`, `%%my_other_magic` or
     `%%my_other_magic`, the corresponding module will be loaded as an ipython
     extensions as if you had previously done `%load_ext ipython`.
+
+    A value of the form ``"package.module:MagicsClass"`` is instead imported
+    and registered directly, without going through the extension machinery.
+    This is how IPython declares its own magics, see
+    :mod:`IPython.core.magics._table`.
 
     Magics names should be without percent(s) as magics can be both cell
     and line magics.
@@ -421,6 +487,9 @@ class MagicsManager(Configurable):
             shell=shell, config=config, user_magics=user_magics, **traits
         )
         self.magics = dict(line={}, cell={})
+        # Specs already loaded, so a class is never registered twice.
+        self._loaded_lazy: set[str] = set()
+        self.registry = _MagicsRegistry(self)
         # Let's add the user_magics to the registry for uniformity, so *all*
         # registered magic containers can be found there.
         if user_magics is not None:
@@ -450,11 +519,16 @@ class MagicsManager(Configurable):
 
         If brief is True, only the first line of each docstring will be returned.
         """
+        # Everything is documented here, so everything has to be imported.
+        self.load_all_lazy_magics()
         docs: dict[str, dict[str, str]] = {}
         for m_type in self.magics:
             m_docs: dict[str, str] = {}
-            for m_name, m_func in self.magics[m_type].items():
-                if m_func.__doc__:
+            for m_name, m_func in list(self.magics[m_type].items()):
+                if isinstance(m_func, LazyMagic):
+                    # An extension we decline to load just for a docstring.
+                    m_docs[m_name] = missing
+                elif m_func.__doc__:
                     if brief:
                         m_docs[m_name] = m_func.__doc__.split("\n", 1)[0]
                     else:
@@ -464,23 +538,95 @@ class MagicsManager(Configurable):
             docs[m_type] = m_docs
         return docs
 
-    def register_lazy(self, name: str, fully_qualified_name: str) -> None:
+    def register_lazy(
+        self,
+        name: str,
+        fully_qualified_name: str,
+        magic_kind: _MagicSpec = "line_cell",
+    ) -> None:
         """
-        Lazily register a magic via an extension.
+        Lazily register a magic, without importing what implements it.
 
+        The magic shows up in ``%lsmagic`` and in completion straight away; the
+        module is only imported the first time it is looked up.
 
         Parameters
         ----------
         name : str
             Name of the magic you wish to register.
-        fully_qualified_name :
-            Fully qualified name of the module/submodule that should be loaded
-            as an extensions when the magic is first called.
-            It is assumed that loading this extensions will register the given
-            magic.
+        fully_qualified_name : str
+            Either ``"package.module"``, which is loaded as an IPython
+            extension (and trusted to register the magic itself), or
+            ``"package.module:MagicsClass"``, which is imported and registered
+            directly -- how IPython declares its own magics.
+        magic_kind : str
+            One of 'line', 'cell' or 'line_cell' (the default, since a lazily
+            declared magic may well be both).
         """
-
+        validate_type(magic_kind)
         self.lazy_magics[name] = fully_qualified_name
+        kinds = magic_kinds if magic_kind == "line_cell" else (magic_kind,)
+        for kind in kinds:
+            self.magics[kind][name] = LazyMagic(self, fully_qualified_name, kind, name)
+
+    def load_lazy(self, magic_name: str) -> None:
+        """Import and register whatever provides `magic_name`.
+
+        Does nothing if `magic_name` was not declared through
+        :meth:`register_lazy` or :attr:`lazy_magics`, or if what provides it
+        has already been loaded.
+        """
+        # `lazy_magics` is user-configurable and may have been replaced
+        # wholesale, so prefer the spec the placeholder carries.
+        fn = self.magics["line"].get(magic_name) or self.magics["cell"].get(magic_name)
+        spec = (
+            fn.spec if isinstance(fn, LazyMagic) else self.lazy_magics.get(magic_name)
+        )
+        if spec is None or spec in self._loaded_lazy:
+            return
+        module_name, sep, class_name = spec.partition(":")
+        # Marked before loading: what we run may look a magic up itself, and
+        # must not come back round and register twice.  Unwound on failure so
+        # a broken spec keeps raising rather than going quiet.
+        self._loaded_lazy.add(spec)
+        try:
+            if sep:
+                from importlib import import_module
+
+                self.register(getattr(import_module(module_name), class_name))
+            else:
+                assert self.shell is not None
+                self.shell.run_line_magic("load_ext", spec)
+        except Exception:
+            self._loaded_lazy.discard(spec)
+            raise
+
+    def load_all_lazy_magics(self) -> None:
+        """Import and register every magic still declared lazily.
+
+        Only the ``module:MagicsClass`` ones: loading an extension can run
+        arbitrary code, so that waits for the magic to actually be used.
+        """
+        for magic_name, spec in list(self.lazy_magics.items()):
+            if ":" in spec:
+                self.load_lazy(magic_name)
+
+    def find(
+        self, magic_kind: _MagicKind, magic_name: str
+    ) -> Callable[..., Any] | None:
+        """Return a registered magic, importing its implementation if needed.
+
+        Returns None if there is no such magic.
+        """
+        fn = self.magics[magic_kind].get(magic_name)
+        if isinstance(fn, LazyMagic) or (fn is None and magic_name in self.lazy_magics):
+            self.load_lazy(magic_name)
+            fn = self.magics[magic_kind].get(magic_name)
+            if isinstance(fn, LazyMagic):
+                # Declared but not delivered; drop the stale placeholder.
+                del self.magics[magic_kind][magic_name]
+                fn = None
+        return t.cast("Callable[..., Any] | None", fn)
 
     def register(self, *magic_objects: type[Magics] | Magics) -> None:
         """Register one or more instances of Magics.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -304,6 +304,60 @@ MAGIC_NO_VAR_EXPAND_ATTR = "_ipython_magic_no_var_expand"
 MAGIC_OUTPUT_CAN_BE_SILENCED = "_ipython_magic_output_can_be_silenced"
 
 
+# Note: this class deliberately has no docstring of its own -- `__doc__` is a
+# property so that anything asking a registered magic for its documentation
+# gets the real magic's docstring instead of this placeholder's.
+#
+# A `LazyMagic` stands in the magics table for a magic whose implementing
+# module has not been imported yet; see `MagicsManager.register_lazy_class`.
+# Listing magics, completing them, or testing membership only ever looks at the
+# *names* in that table, so they stay cheap.  Anything that actually uses the
+# magic -- calling it, reading its docstring, inspecting it -- goes through
+# `_lazy_resolve` below, which imports the module, registers the real `Magics`
+# instance (replacing this object in the table) and delegates to it.
+class LazyMagic:
+    __slots__ = ("_lazy_kind", "_lazy_manager", "_lazy_name", "_lazy_spec")
+
+    def __init__(
+        self,
+        manager: MagicsManager,
+        spec: str,
+        magic_kind: _MagicKind,
+        magic_name: str,
+    ) -> None:
+        self._lazy_manager = manager
+        self._lazy_spec = spec
+        self._lazy_kind = magic_kind
+        self._lazy_name = magic_name
+
+    @property
+    def _lazy_class_name(self) -> str:
+        """Name of the ``Magics`` subclass that will provide this magic."""
+        return self._lazy_spec.rpartition(":")[2]
+
+    def _lazy_resolve(self) -> Callable[..., Any]:
+        """Import the implementing module and return the real magic."""
+        return self._lazy_manager._resolve_lazy(self)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._lazy_resolve()(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_lazy_"):
+            # Never resolve to answer for our own internals; a missing one is a
+            # genuine AttributeError, not a reason to import anything.
+            raise AttributeError(name)
+        return getattr(self._lazy_resolve(), name)
+
+    @property
+    def __doc__(self) -> str | None:  # type: ignore[override]
+        return self._lazy_resolve().__doc__
+
+    def __repr__(self) -> str:
+        escape = magic_escapes[self._lazy_kind]
+        return f"<unloaded magic {escape}{self._lazy_name} from {self._lazy_spec}>"
+
+
 def no_var_expand(magic_func: _F) -> _F:
     """Mark a magic function as not needing variable expansion
 
@@ -347,6 +401,29 @@ register_line_cell_magic = _function_magic_marker("line_cell")
 # -----------------------------------------------------------------------------
 # Core Magic classes
 # -----------------------------------------------------------------------------
+
+
+class _MagicsRegistry(dict[str, Any]):
+    """The ``MagicsManager.registry`` mapping, aware of unloaded magics.
+
+    Looking a class up by name is a legitimate way to reach a magics instance
+    (``shell.magics_manager.registry["ExecutionMagics"]``), and with lazy
+    registration that lookup may well be the first thing that needs the class.
+    So a miss on a name we know how to load imports it rather than raising.
+    """
+
+    def __init__(self, manager: MagicsManager) -> None:
+        super().__init__()
+        self._manager = manager
+
+    def __missing__(self, key: str) -> Any:
+        manager = self._manager
+        spec = manager._lazy_class_specs.get(key)
+        if spec is None or spec in manager._loaded_lazy_classes:
+            # Nothing left to try; a second miss must not loop back here.
+            raise KeyError(key)
+        manager.load_lazy_class(spec)
+        return self[key]
 
 
 class MagicsManager(Configurable):
@@ -421,6 +498,12 @@ class MagicsManager(Configurable):
             shell=shell, config=config, user_magics=user_magics, **traits
         )
         self.magics = dict(line={}, cell={})
+        # Class name -> ``module:ClassName`` spec, for the Magics classes
+        # registered through `register_lazy_class`...
+        self._lazy_class_specs: dict[str, str] = {}
+        # ... and the specs among those that have already been loaded.
+        self._loaded_lazy_classes: set[str] = set()
+        self.registry = _MagicsRegistry(self)
         # Let's add the user_magics to the registry for uniformity, so *all*
         # registered magic containers can be found there.
         if user_magics is not None:
@@ -453,7 +536,7 @@ class MagicsManager(Configurable):
         docs: dict[str, dict[str, str]] = {}
         for m_type in self.magics:
             m_docs: dict[str, str] = {}
-            for m_name, m_func in self.magics[m_type].items():
+            for m_name, m_func in list(self.magics[m_type].items()):
                 if m_func.__doc__:
                     if brief:
                         m_docs[m_name] = m_func.__doc__.split("\n", 1)[0]
@@ -481,6 +564,116 @@ class MagicsManager(Configurable):
         """
 
         self.lazy_magics[name] = fully_qualified_name
+
+    def register_lazy_class(
+        self,
+        spec: str,
+        line_magics: t.Iterable[str] = (),
+        cell_magics: t.Iterable[str] = (),
+    ) -> None:
+        """Register magics whose module is only imported on first use.
+
+        The named magics become visible to ``%lsmagic``, to completion and to
+        :meth:`find` right away, but nothing is imported until one of them is
+        actually used -- at which point the class is instantiated and
+        registered as if :meth:`register` had been called with it.
+
+        This is how IPython registers its own magics; the name tables live in
+        :mod:`IPython.core.magics._table`.  Unlike :attr:`lazy_magics`, which
+        loads an *extension* and trusts it to register something, this knows
+        exactly which class provides which name, and raises if loading the
+        module does not deliver it.
+
+        Parameters
+        ----------
+        spec : str
+            Import path of the class providing the magics, as
+            ``"package.module:ClassName"``.
+        line_magics : iterable of str
+            Names of the line magics the class provides.
+        cell_magics : iterable of str
+            Names of the cell magics the class provides.
+        """
+        module_name, sep, class_name = spec.partition(":")
+        if not (sep and module_name and class_name):
+            raise ValueError(
+                f"spec must be of the form 'package.module:ClassName', got {spec!r}"
+            )
+        if spec in self._loaded_lazy_classes:
+            # Already imported and registered; the real magics are in place and
+            # must not be shadowed by placeholders.
+            return
+        self._lazy_class_specs[class_name] = spec
+        by_kind: tuple[tuple[_MagicKind, t.Iterable[str]], ...] = (
+            ("line", line_magics),
+            ("cell", cell_magics),
+        )
+        for magic_kind, names in by_kind:
+            table = self.magics[magic_kind]
+            for magic_name in names:
+                table[magic_name] = LazyMagic(self, spec, magic_kind, magic_name)
+
+    def load_lazy_class(self, spec: str) -> None:
+        """Import and register a class registered by :meth:`register_lazy_class`.
+
+        Does nothing if it has already been loaded.
+        """
+        if spec in self._loaded_lazy_classes:
+            return
+        module_name, _, class_name = spec.partition(":")
+        # Mark it loaded first: instantiating the class may itself look a magic
+        # up, and we must not recurse back into here.
+        self._loaded_lazy_classes.add(spec)
+        from importlib import import_module
+
+        self.register(getattr(import_module(module_name), class_name))
+
+    def load_all_lazy_magics(self) -> None:
+        """Import and register every magic still waiting to be loaded.
+
+        Only useful for the handful of things that need a complete picture of
+        the magics -- listing every configurable, for instance.  Everything
+        else should go through :meth:`find` and pay for what it uses.
+        """
+        specs = {
+            fn._lazy_spec
+            for table in self.magics.values()
+            for fn in table.values()
+            if isinstance(fn, LazyMagic)
+        }
+        for spec in sorted(specs):
+            self.load_lazy_class(spec)
+
+    def _resolve_lazy(self, proxy: LazyMagic) -> Callable[..., Any]:
+        """Load `proxy`'s class and return the real magic it stands for."""
+        magic_kind, magic_name = proxy._lazy_kind, proxy._lazy_name
+        self.load_lazy_class(proxy._lazy_spec)
+        fn = self.magics[magic_kind].get(magic_name)
+        if fn is None or fn is proxy:
+            # The name table is out of sync with the code it describes.  Drop
+            # the stale entry so the magic reads as missing from now on.
+            if self.magics[magic_kind].get(magic_name) is proxy:
+                del self.magics[magic_kind][magic_name]
+            raise UsageError(
+                f"Magic `{magic_escapes[magic_kind]}{magic_name}` was declared to"
+                f" be provided by {proxy._lazy_spec}, but loading it did not"
+                " define that magic."
+            )
+        if isinstance(fn, LazyMagic):
+            return fn._lazy_resolve()
+        return t.cast("Callable[..., Any]", fn)
+
+    def find(
+        self, magic_kind: _MagicKind, magic_name: str
+    ) -> Callable[..., Any] | None:
+        """Return a registered magic, importing its implementation if needed.
+
+        Returns None if there is no such magic.
+        """
+        fn: Any = self.magics[magic_kind].get(magic_name)
+        if isinstance(fn, LazyMagic):
+            return fn._lazy_resolve()
+        return t.cast("Callable[..., Any] | None", fn)
 
     def register(self, *magic_objects: type[Magics] | Magics) -> None:
         """Register one or more instances of Magics.

--- a/IPython/core/magics/__init__.py
+++ b/IPython/core/magics/__init__.py
@@ -11,22 +11,36 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
+import typing as t
 
 from ..magic import Magics, magics_class
-from .auto import AutoMagics
-from .basic import BasicMagics, AsyncMagics
-from .code import CodeMagics, MacroToEdit
-from .config import ConfigMagics
-from .display import DisplayMagics
-from .execution import ExecutionMagics
-from .extension import ExtensionMagics
-from .history import HistoryMagics
-from .logging import LoggingMagics
-from .namespace import NamespaceMagics
-from .osm import OSMagics
-from .packaging import PackagingMagics
-from .pylab import PylabMagics
-from .script import ScriptMagics
+from ._table import (
+    BUILTIN_LAZY_MAGICS,
+    MAGICS_CLASSES,
+    configured_script_magics,
+    default_script_magics,
+)
+
+# The submodules are *not* imported here: they are loaded the first time one of
+# their magics is used.  The names below stay importable from this package
+# through the module `__getattr__` below.
+if t.TYPE_CHECKING:
+    from .auto import AutoMagics
+    from .basic import AsyncMagics, BasicMagics
+    from .code import CodeMagics, MacroToEdit
+    from .config import ConfigMagics
+    from .display import DisplayMagics
+    from .execution import ExecutionMagics
+    from .extension import ExtensionMagics
+    from .history import HistoryMagics
+    from .logging import LoggingMagics
+    from .namespace import NamespaceMagics
+    from .osm import OSMagics
+    from .packaging import PackagingMagics
+    from .pylab import PylabMagics
+    from .script import ScriptMagics
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -40,3 +54,18 @@ class UserMagics(Magics):
     use this class to isolate the magics defined dynamically by the user into
     their own class.
     """
+
+
+def __getattr__(name: str) -> t.Any:
+    """Import the magics classes on first access (:pep:`562`)."""
+    module_name = MAGICS_CLASSES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    obj = globals()[name] = getattr(import_module(module_name), name)
+    return obj
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(MAGICS_CLASSES))

--- a/IPython/core/magics/__init__.py
+++ b/IPython/core/magics/__init__.py
@@ -11,22 +11,66 @@
 #-----------------------------------------------------------------------------
 # Imports
 #-----------------------------------------------------------------------------
+from __future__ import annotations
+
+import typing as t
 
 from ..magic import Magics, magics_class
-from .auto import AutoMagics
-from .basic import BasicMagics, AsyncMagics
-from .code import CodeMagics, MacroToEdit
-from .config import ConfigMagics
-from .display import DisplayMagics
-from .execution import ExecutionMagics
-from .extension import ExtensionMagics
-from .history import HistoryMagics
-from .logging import LoggingMagics
-from .namespace import NamespaceMagics
-from .osm import OSMagics
-from .packaging import PackagingMagics
-from .pylab import PylabMagics
-from .script import ScriptMagics
+from ._table import (
+    BUILTIN_MAGIC_ALIASES,
+    BUILTIN_MAGICS,
+    MAGICS_CLASSES,
+    configured_script_magics,
+    default_script_magics,
+)
+
+# The submodules implementing the magics are *not* imported here: they, and the
+# `Magics` subclasses they define, are only loaded the first time one of their
+# magics is used.  See `._table` and `IPython.core.magic.MagicsManager` for how
+# the lazy registration works.  The names below stay importable from this
+# package through the module `__getattr__` further down.
+if t.TYPE_CHECKING:
+    from .auto import AutoMagics
+    from .basic import AsyncMagics, BasicMagics
+    from .code import CodeMagics, MacroToEdit
+    from .config import ConfigMagics
+    from .display import DisplayMagics
+    from .execution import ExecutionMagics
+    from .extension import ExtensionMagics
+    from .history import HistoryMagics
+    from .logging import LoggingMagics
+    from .namespace import NamespaceMagics
+    from .osm import OSMagics
+    from .packaging import PackagingMagics
+    from .pylab import PylabMagics
+    from .script import ScriptMagics
+
+# Kept literal so that static analysers can see it; `tests/test_magic_table.py`
+# checks it against MAGICS_CLASSES.
+__all__ = [
+    "BUILTIN_MAGICS",
+    "BUILTIN_MAGIC_ALIASES",
+    "MAGICS_CLASSES",
+    "AsyncMagics",
+    "AutoMagics",
+    "BasicMagics",
+    "CodeMagics",
+    "ConfigMagics",
+    "DisplayMagics",
+    "ExecutionMagics",
+    "ExtensionMagics",
+    "HistoryMagics",
+    "LoggingMagics",
+    "MacroToEdit",
+    "NamespaceMagics",
+    "OSMagics",
+    "PackagingMagics",
+    "PylabMagics",
+    "ScriptMagics",
+    "UserMagics",
+    "configured_script_magics",
+    "default_script_magics",
+]
 
 #-----------------------------------------------------------------------------
 # Magic implementation classes
@@ -40,3 +84,20 @@ class UserMagics(Magics):
     use this class to isolate the magics defined dynamically by the user into
     their own class.
     """
+
+
+def __getattr__(name: str) -> t.Any:
+    """Import the magics classes on first access (:pep:`562`)."""
+    module_name = MAGICS_CLASSES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    obj = getattr(import_module(module_name), name)
+    # Cache it so subsequent lookups skip this function entirely.
+    globals()[name] = obj
+    return obj
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/IPython/core/magics/_table.py
+++ b/IPython/core/magics/_table.py
@@ -1,0 +1,205 @@
+"""Static description of the magics IPython ships with.
+
+Importing a magics module and instantiating the ``Magics`` classes it defines
+is expensive, and most magics are never used in a given session, so IPython
+declares its own to ``MagicsManager.lazy_magics`` instead of registering them.
+
+These tables are therefore hand maintained. ``tests/test_magic_table.py``
+imports every magics module, instantiates every ``Magics`` subclass, and fails
+-- printing the corrected table -- if anything here has drifted.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+if t.TYPE_CHECKING:
+    from traitlets.config import Config
+
+
+#: Public name re-exported by :mod:`IPython.core.magics` -> module defining it,
+#: for that package's ``__getattr__``.
+MAGICS_CLASSES: dict[str, str] = {
+    "AsyncMagics": "IPython.core.magics.basic",
+    "AutoMagics": "IPython.core.magics.auto",
+    "BasicMagics": "IPython.core.magics.basic",
+    "CodeMagics": "IPython.core.magics.code",
+    "ConfigMagics": "IPython.core.magics.config",
+    "DisplayMagics": "IPython.core.magics.display",
+    "ExecutionMagics": "IPython.core.magics.execution",
+    "ExtensionMagics": "IPython.core.magics.extension",
+    "HistoryMagics": "IPython.core.magics.history",
+    "LoggingMagics": "IPython.core.magics.logging",
+    "MacroToEdit": "IPython.core.magics.code",
+    "NamespaceMagics": "IPython.core.magics.namespace",
+    "OSMagics": "IPython.core.magics.osm",
+    "PackagingMagics": "IPython.core.magics.packaging",
+    "PylabMagics": "IPython.core.magics.pylab",
+    "ScriptMagics": "IPython.core.magics.script",
+}
+
+#: The magics IPython ships with, as ``kind -> {name -> "module:Class"}``, fed
+#: to ``MagicsManager.register_lazy`` by ``InteractiveShell.init_magics``.
+#: ``ScriptMagics`` also generates a cell magic per configured interpreter,
+#: see :func:`configured_script_magics`.
+BUILTIN_LAZY_MAGICS: dict[str, dict[str, str]] = {
+    "line": {
+        # AutoMagics
+        "autocall": "IPython.core.magics.auto:AutoMagics",
+        "automagic": "IPython.core.magics.auto:AutoMagics",
+        # BasicMagics
+        "alias_magic": "IPython.core.magics.basic:BasicMagics",
+        "colors": "IPython.core.magics.basic:BasicMagics",
+        "doctest_mode": "IPython.core.magics.basic:BasicMagics",
+        "gui": "IPython.core.magics.basic:BasicMagics",
+        "lsmagic": "IPython.core.magics.basic:BasicMagics",
+        "magic": "IPython.core.magics.basic:BasicMagics",
+        "notebook": "IPython.core.magics.basic:BasicMagics",
+        "page": "IPython.core.magics.basic:BasicMagics",
+        "pprint": "IPython.core.magics.basic:BasicMagics",
+        "precision": "IPython.core.magics.basic:BasicMagics",
+        "quickref": "IPython.core.magics.basic:BasicMagics",
+        "xmode": "IPython.core.magics.basic:BasicMagics",
+        # CodeMagics
+        "edit": "IPython.core.magics.code:CodeMagics",
+        "load": "IPython.core.magics.code:CodeMagics",
+        "loadpy": "IPython.core.magics.code:CodeMagics",
+        "pastebin": "IPython.core.magics.code:CodeMagics",
+        "save": "IPython.core.magics.code:CodeMagics",
+        # ConfigMagics
+        "config": "IPython.core.magics.config:ConfigMagics",
+        # ExecutionMagics
+        "code_wrap": "IPython.core.magics.execution:ExecutionMagics",
+        "debug": "IPython.core.magics.execution:ExecutionMagics",
+        "macro": "IPython.core.magics.execution:ExecutionMagics",
+        "pdb": "IPython.core.magics.execution:ExecutionMagics",
+        "prun": "IPython.core.magics.execution:ExecutionMagics",
+        "run": "IPython.core.magics.execution:ExecutionMagics",
+        "tb": "IPython.core.magics.execution:ExecutionMagics",
+        "time": "IPython.core.magics.execution:ExecutionMagics",
+        "timeit": "IPython.core.magics.execution:ExecutionMagics",
+        # ExtensionMagics
+        "load_ext": "IPython.core.magics.extension:ExtensionMagics",
+        "reload_ext": "IPython.core.magics.extension:ExtensionMagics",
+        "unload_ext": "IPython.core.magics.extension:ExtensionMagics",
+        # HistoryMagics
+        "history": "IPython.core.magics.history:HistoryMagics",
+        "recall": "IPython.core.magics.history:HistoryMagics",
+        "rerun": "IPython.core.magics.history:HistoryMagics",
+        # LoggingMagics
+        "logoff": "IPython.core.magics.logging:LoggingMagics",
+        "logon": "IPython.core.magics.logging:LoggingMagics",
+        "logstart": "IPython.core.magics.logging:LoggingMagics",
+        "logstate": "IPython.core.magics.logging:LoggingMagics",
+        "logstop": "IPython.core.magics.logging:LoggingMagics",
+        # NamespaceMagics
+        "pdef": "IPython.core.magics.namespace:NamespaceMagics",
+        "pdoc": "IPython.core.magics.namespace:NamespaceMagics",
+        "pfile": "IPython.core.magics.namespace:NamespaceMagics",
+        "pinfo": "IPython.core.magics.namespace:NamespaceMagics",
+        "pinfo2": "IPython.core.magics.namespace:NamespaceMagics",
+        "psearch": "IPython.core.magics.namespace:NamespaceMagics",
+        "psource": "IPython.core.magics.namespace:NamespaceMagics",
+        "reset": "IPython.core.magics.namespace:NamespaceMagics",
+        "reset_selective": "IPython.core.magics.namespace:NamespaceMagics",
+        "who": "IPython.core.magics.namespace:NamespaceMagics",
+        "who_ls": "IPython.core.magics.namespace:NamespaceMagics",
+        "whos": "IPython.core.magics.namespace:NamespaceMagics",
+        "xdel": "IPython.core.magics.namespace:NamespaceMagics",
+        # OSMagics
+        "alias": "IPython.core.magics.osm:OSMagics",
+        "bookmark": "IPython.core.magics.osm:OSMagics",
+        "cd": "IPython.core.magics.osm:OSMagics",
+        "dhist": "IPython.core.magics.osm:OSMagics",
+        "dirs": "IPython.core.magics.osm:OSMagics",
+        "env": "IPython.core.magics.osm:OSMagics",
+        "popd": "IPython.core.magics.osm:OSMagics",
+        "pushd": "IPython.core.magics.osm:OSMagics",
+        "pwd": "IPython.core.magics.osm:OSMagics",
+        "pycat": "IPython.core.magics.osm:OSMagics",
+        "rehashx": "IPython.core.magics.osm:OSMagics",
+        "sc": "IPython.core.magics.osm:OSMagics",
+        "set_env": "IPython.core.magics.osm:OSMagics",
+        "sx": "IPython.core.magics.osm:OSMagics",
+        "system": "IPython.core.magics.osm:OSMagics",
+        "unalias": "IPython.core.magics.osm:OSMagics",
+        # PackagingMagics
+        "conda": "IPython.core.magics.packaging:PackagingMagics",
+        "mamba": "IPython.core.magics.packaging:PackagingMagics",
+        "micromamba": "IPython.core.magics.packaging:PackagingMagics",
+        "pip": "IPython.core.magics.packaging:PackagingMagics",
+        "uv": "IPython.core.magics.packaging:PackagingMagics",
+        # PylabMagics
+        "matplotlib": "IPython.core.magics.pylab:PylabMagics",
+        "pylab": "IPython.core.magics.pylab:PylabMagics",
+        # ScriptMagics
+        "killbgscripts": "IPython.core.magics.script:ScriptMagics",
+        # AsyncMagics
+        "autoawait": "IPython.core.magics.basic:AsyncMagics",
+    },
+    "cell": {
+        # DisplayMagics
+        "html": "IPython.core.magics.display:DisplayMagics",
+        "javascript": "IPython.core.magics.display:DisplayMagics",
+        "js": "IPython.core.magics.display:DisplayMagics",
+        "latex": "IPython.core.magics.display:DisplayMagics",
+        "markdown": "IPython.core.magics.display:DisplayMagics",
+        "svg": "IPython.core.magics.display:DisplayMagics",
+        # ExecutionMagics
+        "capture": "IPython.core.magics.execution:ExecutionMagics",
+        "code_wrap": "IPython.core.magics.execution:ExecutionMagics",
+        "debug": "IPython.core.magics.execution:ExecutionMagics",
+        "prun": "IPython.core.magics.execution:ExecutionMagics",
+        "time": "IPython.core.magics.execution:ExecutionMagics",
+        "timeit": "IPython.core.magics.execution:ExecutionMagics",
+        # OSMagics
+        "!": "IPython.core.magics.osm:OSMagics",
+        "sx": "IPython.core.magics.osm:OSMagics",
+        "system": "IPython.core.magics.osm:OSMagics",
+        "writefile": "IPython.core.magics.osm:OSMagics",
+        # ScriptMagics
+        "script": "IPython.core.magics.script:ScriptMagics",
+    },
+}
+
+
+def default_script_magics() -> list[str]:
+    """Default value of the ``ScriptMagics.script_magics`` trait.
+
+    Here so the lazy declaration knows the generated ``%%<interpreter>`` names
+    without importing :mod:`IPython.core.magics.script`.
+    """
+    defaults = [
+        "sh",
+        "bash",
+        "perl",
+        "ruby",
+        "python",
+        "python2",
+        "python3",
+        "pypy",
+    ]
+    if os.name == "nt":
+        defaults.extend(
+            [
+                "cmd",
+            ]
+        )
+
+    return defaults
+
+
+def configured_script_magics(config: Config | None) -> list[str]:
+    """Cell magic names ``ScriptMagics`` will provide for the given config.
+
+    Peeks at the config rather than instantiating the class, which is what we
+    are trying to avoid.
+    """
+    section = getattr(config, "ScriptMagics", None) if config is not None else None
+    if section is not None and "script_magics" in section:
+        return list(section["script_magics"])
+    return default_script_magics()

--- a/IPython/core/magics/_table.py
+++ b/IPython/core/magics/_table.py
@@ -1,0 +1,224 @@
+"""Static description of the magics IPython ships with.
+
+Importing a module and instantiating the ``Magics`` subclasses it defines is
+expensive, and most of the magics in a given session are never used.  To keep
+``import IPython`` and shell startup fast, IPython registers its own magics
+lazily: only the tables below are consulted at startup, and the module
+implementing a magic is imported the first time that magic is looked up.
+
+That means these tables are hand maintained and *must* be kept in sync with the
+code.  ``tests/test_magic_table.py`` imports every magics module, instantiates every
+``Magics`` subclass, and fails if anything here is missing, stale, or pointing
+at the wrong class -- and prints the corrected table.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+if t.TYPE_CHECKING:
+    from traitlets.config import Config
+
+
+#: Every public name re-exported by :mod:`IPython.core.magics`, mapped to the
+#: module that defines it.  Used by that package's module ``__getattr__`` so
+#: that ``from IPython.core.magics import ExecutionMagics`` keeps working
+#: without importing all the sibling modules.
+MAGICS_CLASSES: dict[str, str] = {
+    "AsyncMagics": "IPython.core.magics.basic",
+    "AutoMagics": "IPython.core.magics.auto",
+    "BasicMagics": "IPython.core.magics.basic",
+    "CodeMagics": "IPython.core.magics.code",
+    "ConfigMagics": "IPython.core.magics.config",
+    "DisplayMagics": "IPython.core.magics.display",
+    "ExecutionMagics": "IPython.core.magics.execution",
+    "ExtensionMagics": "IPython.core.magics.extension",
+    "HistoryMagics": "IPython.core.magics.history",
+    "LoggingMagics": "IPython.core.magics.logging",
+    "MacroToEdit": "IPython.core.magics.code",
+    "NamespaceMagics": "IPython.core.magics.namespace",
+    "OSMagics": "IPython.core.magics.osm",
+    "PackagingMagics": "IPython.core.magics.packaging",
+    "PylabMagics": "IPython.core.magics.pylab",
+    "ScriptMagics": "IPython.core.magics.script",
+}
+
+#: The magics each built-in ``Magics`` subclass provides, in the order the
+#: classes are registered by ``InteractiveShell.init_magics``.  Order matters:
+#: a name defined by two classes resolves to the one registered last.
+#:
+#: ``ScriptMagics`` is a special case -- on top of the names listed here it
+#: generates one cell magic per configured interpreter, see
+#: :func:`configured_script_magics`.
+BUILTIN_MAGICS: dict[str, dict[str, tuple[str, ...]]] = {
+    "AutoMagics": {
+        "line": ("autocall", "automagic"),
+        "cell": (),
+    },
+    "BasicMagics": {
+        "line": (
+            "alias_magic",
+            "colors",
+            "doctest_mode",
+            "gui",
+            "lsmagic",
+            "magic",
+            "notebook",
+            "page",
+            "pprint",
+            "precision",
+            "quickref",
+            "xmode",
+        ),
+        "cell": (),
+    },
+    "CodeMagics": {
+        "line": ("edit", "load", "loadpy", "pastebin", "save"),
+        "cell": (),
+    },
+    "ConfigMagics": {
+        "line": ("config",),
+        "cell": (),
+    },
+    "DisplayMagics": {
+        "line": (),
+        "cell": ("html", "javascript", "js", "latex", "markdown", "svg"),
+    },
+    "ExecutionMagics": {
+        "line": (
+            "code_wrap",
+            "debug",
+            "macro",
+            "pdb",
+            "prun",
+            "run",
+            "tb",
+            "time",
+            "timeit",
+        ),
+        "cell": ("capture", "code_wrap", "debug", "prun", "time", "timeit"),
+    },
+    "ExtensionMagics": {
+        "line": ("load_ext", "reload_ext", "unload_ext"),
+        "cell": (),
+    },
+    "HistoryMagics": {
+        "line": ("history", "recall", "rerun"),
+        "cell": (),
+    },
+    "LoggingMagics": {
+        "line": ("logoff", "logon", "logstart", "logstate", "logstop"),
+        "cell": (),
+    },
+    "NamespaceMagics": {
+        "line": (
+            "pdef",
+            "pdoc",
+            "pfile",
+            "pinfo",
+            "pinfo2",
+            "psearch",
+            "psource",
+            "reset",
+            "reset_selective",
+            "who",
+            "who_ls",
+            "whos",
+            "xdel",
+        ),
+        "cell": (),
+    },
+    "OSMagics": {
+        "line": (
+            "alias",
+            "bookmark",
+            "cd",
+            "dhist",
+            "dirs",
+            "env",
+            "popd",
+            "pushd",
+            "pwd",
+            "pycat",
+            "rehashx",
+            "sc",
+            "set_env",
+            "sx",
+            "system",
+            "unalias",
+        ),
+        "cell": ("!", "sx", "system", "writefile"),
+    },
+    "PackagingMagics": {
+        "line": ("conda", "mamba", "micromamba", "pip", "uv"),
+        "cell": (),
+    },
+    "PylabMagics": {
+        "line": ("matplotlib", "pylab"),
+        "cell": (),
+    },
+    "ScriptMagics": {
+        "line": ("killbgscripts",),
+        "cell": ("script",),
+    },
+    "AsyncMagics": {
+        "line": ("autoawait",),
+        "cell": (),
+    },
+}
+
+#: Aliases ``InteractiveShell.init_magics`` registers, as
+#: ``(alias, target, kind)``.  Aliases resolve their target when called, so
+#: registering them does not force any magics module to be imported.
+BUILTIN_MAGIC_ALIASES: tuple[tuple[str, str, str], ...] = (
+    ("ed", "edit", "line"),
+    ("hist", "history", "line"),
+    ("rep", "recall", "line"),
+    ("SVG", "svg", "cell"),
+    ("HTML", "html", "cell"),
+    ("file", "writefile", "cell"),
+)
+
+
+def default_script_magics() -> list[str]:
+    """Interpreters ``%%script`` shortcuts are generated for by default.
+
+    This is the default value of the ``ScriptMagics.script_magics`` trait; it
+    lives here so that the lazy registration can know the generated names
+    without importing :mod:`IPython.core.magics.script`.
+    """
+    defaults = [
+        "sh",
+        "bash",
+        "perl",
+        "ruby",
+        "python",
+        "python2",
+        "python3",
+        "pypy",
+    ]
+    if os.name == "nt":
+        defaults.extend(
+            [
+                "cmd",
+            ]
+        )
+
+    return defaults
+
+
+def configured_script_magics(config: Config | None) -> list[str]:
+    """Cell magic names ``ScriptMagics`` will provide for the given config.
+
+    ``ScriptMagics.script_magics`` is configurable, so the generated names are
+    not known statically; peek at the config rather than instantiating the
+    class, which is what we are trying to avoid in the first place.
+    """
+    section = getattr(config, "ScriptMagics", None) if config is not None else None
+    if section is not None and "script_magics" in section:
+        return list(section["script_magics"])
+    return default_script_magics()

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -13,7 +13,13 @@ from warnings import warn
 from traitlets.utils.importstring import import_item
 from IPython.core import magic_arguments, page
 from IPython.core.error import UsageError
-from IPython.core.magic import Magics, magics_class, line_magic, magic_escapes
+from IPython.core.magic import (
+    LazyMagic,
+    Magics,
+    magics_class,
+    line_magic,
+    magic_escapes,
+)
 from IPython.utils.text import format_screen, dedent, indent
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.ipstruct import Struct
@@ -60,10 +66,14 @@ class MagicsDisplay:
             d = {}
             magic_dict[key] = d
             for name, obj in subdict.items():
-                try:
-                    classname = obj.__self__.__class__.__name__
-                except AttributeError:
-                    classname = 'Other'
+                if isinstance(obj, LazyMagic):
+                    # Not imported yet; the spec already names the class.
+                    classname = obj.spec.rpartition(":")[2] or "Other"
+                else:
+                    try:
+                        classname = obj.__self__.__class__.__name__
+                    except AttributeError:
+                        classname = "Other"
 
                 d[name] = classname
         return magic_dict

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -13,7 +13,13 @@ from warnings import warn
 from traitlets.utils.importstring import import_item
 from IPython.core import magic_arguments, page
 from IPython.core.error import UsageError
-from IPython.core.magic import Magics, magics_class, line_magic, magic_escapes
+from IPython.core.magic import (
+    LazyMagic,
+    Magics,
+    magic_escapes,
+    magics_class,
+    line_magic,
+)
 from IPython.utils.text import format_screen, dedent, indent
 from IPython.testing.skipdoctest import skip_doctest
 from IPython.utils.ipstruct import Struct
@@ -60,10 +66,15 @@ class MagicsDisplay:
             d = {}
             magic_dict[key] = d
             for name, obj in subdict.items():
-                try:
-                    classname = obj.__self__.__class__.__name__
-                except AttributeError:
-                    classname = 'Other'
+                if isinstance(obj, LazyMagic):
+                    # Not imported yet, and asking for the class name is no
+                    # reason to import it; the table already knows.
+                    classname = obj._lazy_class_name
+                else:
+                    try:
+                        classname = obj.__self__.__class__.__name__
+                    except AttributeError:
+                        classname = "Other"
 
                 d[name] = classname
         return magic_dict

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -87,6 +87,9 @@ class ConfigMagics(Magics):
 
         """
         from traitlets.config.loader import Config
+
+        # Only instantiated magics are configurable; load the lazy ones.
+        self.shell.magics_manager.load_all_lazy_magics()
         # some IPython objects are Configurable, but do not yet have
         # any configurable traits.  Exclude them from the effects of
         # this magic, as their presence is just noise:

--- a/IPython/core/magics/config.py
+++ b/IPython/core/magics/config.py
@@ -87,6 +87,11 @@ class ConfigMagics(Magics):
 
         """
         from traitlets.config.loader import Config
+
+        # Magics classes only become configurable once they are instantiated,
+        # and most of them are registered lazily; load them all so that every
+        # built-in magic shows up here whether or not it has been used yet.
+        self.shell.magics_manager.load_all_lazy_magics()
         # some IPython objects are Configurable, but do not yet have
         # any configurable traits.  Exclude them from the effects of
         # this magic, as their presence is just noise:

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -23,6 +23,8 @@ from IPython.core.async_helpers import _AsyncIOProxy
 from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
 from IPython.utils.process import arg_split
 
+from ._table import default_script_magics
+
 #-----------------------------------------------------------------------------
 # Magic implementation classes
 #-----------------------------------------------------------------------------
@@ -105,23 +107,9 @@ class ScriptMagics(Magics):
     @default('script_magics')
     def _script_magics_default(self):
         """default to a common list of programs"""
-
-        defaults = [
-            'sh',
-            'bash',
-            'perl',
-            'ruby',
-            'python',
-            'python2',
-            'python3',
-            'pypy',
-        ]
-        if os.name == 'nt':
-            defaults.extend([
-                'cmd',
-            ])
-
-        return defaults
+        # In `_table` so the lazy declaration can name these without
+        # importing this module.
+        return default_script_magics()
 
     script_paths = Dict(
         help="""Dict mapping short 'ruby' names to full paths, such as '/opt/secret/bin/ruby'

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -23,6 +23,8 @@ from IPython.core.async_helpers import _AsyncIOProxy
 from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
 from IPython.utils.process import arg_split
 
+from ._table import default_script_magics
+
 #-----------------------------------------------------------------------------
 # Magic implementation classes
 #-----------------------------------------------------------------------------
@@ -105,23 +107,9 @@ class ScriptMagics(Magics):
     @default('script_magics')
     def _script_magics_default(self):
         """default to a common list of programs"""
-
-        defaults = [
-            'sh',
-            'bash',
-            'perl',
-            'ruby',
-            'python',
-            'python2',
-            'python3',
-            'pypy',
-        ]
-        if os.name == 'nt':
-            defaults.extend([
-                'cmd',
-            ])
-
-        return defaults
+        # Kept in `_table` so that the lazy registration knows which
+        # `%%<interpreter>` magics this class provides without importing it.
+        return default_script_magics()
 
     script_paths = Dict(
         help="""Dict mapping short 'ruby' names to full paths, such as '/opt/secret/bin/ruby'

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -24,13 +24,9 @@ from IPython.core.application import (
     ProfileDir, BaseIPythonApplication, base_flags, base_aliases
 )
 from IPython.core.magic import MagicsManager
-from IPython.core.magics import (
-    ScriptMagics, LoggingMagics
-)
 from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
-from IPython.extensions.storemagic import StoreMagics
 from .interactiveshell import TerminalInteractiveShell
 from IPython.paths import get_ipython_dir
 from traitlets import (
@@ -202,6 +198,11 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
     @default('classes')
     def _classes_default(self):
         """This has to be in a method, for TerminalIPythonApp to be available."""
+        # Imported here: only needed for config help, and importing them at
+        # module level would undo the lazy declaration of the magics.
+        from IPython.core.magics import LoggingMagics, ScriptMagics
+        from IPython.extensions.storemagic import StoreMagics
+
         return [
             InteractiveShellApp,  # ShellApp comes before TerminalApp, because
             self.__class__,      # it will also affect subclasses (e.g. QtConsole)

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -24,13 +24,9 @@ from IPython.core.application import (
     ProfileDir, BaseIPythonApplication, base_flags, base_aliases
 )
 from IPython.core.magic import MagicsManager
-from IPython.core.magics import (
-    ScriptMagics, LoggingMagics
-)
 from IPython.core.shellapp import (
     InteractiveShellApp, shell_flags, shell_aliases
 )
-from IPython.extensions.storemagic import StoreMagics
 from .interactiveshell import TerminalInteractiveShell
 from IPython.paths import get_ipython_dir
 from traitlets import (
@@ -202,6 +198,12 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
     @default('classes')
     def _classes_default(self):
         """This has to be in a method, for TerminalIPythonApp to be available."""
+        # Imported here rather than at module level: these are only needed to
+        # generate config help, and importing them eagerly would defeat the
+        # lazy registration of the built-in magics.
+        from IPython.core.magics import LoggingMagics, ScriptMagics
+        from IPython.extensions.storemagic import StoreMagics
+
         return [
             InteractiveShellApp,  # ShellApp comes before TerminalApp, because
             self.__class__,      # it will also affect subclasses (e.g. QtConsole)

--- a/docs/autogen_magics.py
+++ b/docs/autogen_magics.py
@@ -26,6 +26,9 @@ def sortkey(s): return s[0].lower()
 
 def main():
     shell = InteractiveShell.instance()
+    # Built-in magics are declared lazily; documenting them all means
+    # importing them all.
+    shell.magics_manager.load_all_lazy_magics()
     magics = shell.magics_manager.magics
 
     output = [

--- a/docs/source/whatsnew/pr/lazy-builtin-magics.rst
+++ b/docs/source/whatsnew/pr/lazy-builtin-magics.rst
@@ -1,0 +1,25 @@
+IPython's own magics are now declared lazily. Starting a shell used to import
+all fifteen modules under :mod:`IPython.core.magics` and instantiate every
+:class:`~IPython.core.magic.Magics` class in them, even though a session
+typically uses a handful of magics at most. Only the magic *names* are now known
+up front, from a hand-maintained table in ``IPython.core.magics._table``, and the
+module implementing a magic is imported the first time it is looked up. This
+takes roughly 25 ms off ``import IPython`` and shell startup.
+
+This reuses :attr:`~IPython.core.magic.MagicsManager.lazy_magics`, which already
+existed for extensions, so third-party code can declare its magics the same way::
+
+    shell.magics_manager.register_lazy("my_magic", "my_package.magics:MyMagics")
+
+Its values may now be either ``"package.module"``, loaded as an IPython extension
+as before, or ``"package.module:MagicsClass"``, imported and registered directly.
+Unlike before, a magic declared through
+:meth:`~IPython.core.magic.MagicsManager.register_lazy` shows up in ``%lsmagic``
+and in completion right away rather than only after its first use.
+
+Until a magic is loaded, ``shell.magics_manager.magics[kind][name]`` holds a
+:class:`~IPython.core.magic.LazyMagic` placeholder. Calling it, or reading any
+attribute of it, loads and delegates to the real magic, so existing code that
+reaches into that table keeps working. A magics class only appears in
+``shell.configurables`` once loaded; ``%config`` loads everything first, so the
+list of configurable classes it shows is unchanged.

--- a/docs/source/whatsnew/pr/lazy-builtin-magics.rst
+++ b/docs/source/whatsnew/pr/lazy-builtin-magics.rst
@@ -1,0 +1,32 @@
+IPython's own magics are now registered lazily. Starting a shell used to import
+all fifteen modules under :mod:`IPython.core.magics` and instantiate every
+:class:`~IPython.core.magic.Magics` class in them, even though a given session
+typically uses a handful of magics at most. Now only the magic *names* are known
+up front -- from the hand-maintained tables in ``IPython.core.magics._table`` --
+and the module implementing a magic is imported the first time that magic is
+looked up. This shaves roughly 35 ms off ``import IPython`` and shell startup.
+
+This is invisible in normal use: ``%lsmagic``, completion, ``%foo?`` and calling
+a magic all behave as before. Two details are worth knowing if you poke at the
+internals:
+
+* ``shell.magics_manager.magics['line']`` (and ``['cell']``) may hold
+  :class:`~IPython.core.magic.LazyMagic` placeholders rather than bound methods.
+  Calling one, or reading any attribute of one, transparently loads the real
+  magic. Use :meth:`~IPython.core.magic.MagicsManager.find` --- or
+  ``shell.find_line_magic`` / ``find_cell_magic`` / ``find_magic``, which go
+  through it --- to get the real callable.
+* A magics class only appears in ``shell.configurables`` once it has been
+  loaded. ``%config`` (and its completions) load everything first, so the list
+  of configurable classes it shows is unchanged.
+
+Third-party code can use the same mechanism for its own magics::
+
+    shell.magics_manager.register_lazy_class(
+        "my_package.magics:MyMagics",
+        line_magics=["my_magic"],
+        cell_magics=["my_magic"],
+    )
+
+which, unlike the existing ``MagicsManager.lazy_magics`` configuration, does not
+require the magics to be packaged as an IPython extension.

--- a/tests/test_magic_table.py
+++ b/tests/test_magic_table.py
@@ -1,0 +1,296 @@
+"""Check the hand-maintained table of built-in magics against the code.
+
+IPython declares its own magics to ``MagicsManager.lazy_magics`` from the
+static table in :mod:`IPython.core.magics._table`, which is only correct as
+long as somebody keeps it correct -- that is what this module is for.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import inspect
+import pkgutil
+import subprocess
+import sys
+import textwrap
+from importlib import import_module
+
+import pytest
+from traitlets.config import Config, Configurable
+
+import IPython.core.magics
+from IPython import get_ipython
+from IPython.core.interactiveshell import InteractiveShellABC
+from IPython.core.magic import LazyMagic, Magics, MagicsManager
+from IPython.core.magics import _table
+
+EXECUTION_SPEC = "IPython.core.magics.execution:ExecutionMagics"
+
+
+def _shipped_magics_classes():
+    """Every ``Magics`` subclass defined under ``IPython/core/magics``."""
+    found = {}
+    for info in pkgutil.iter_modules(IPython.core.magics.__path__):
+        module_name = f"{IPython.core.magics.__name__}.{info.name}"
+        module = import_module(module_name)
+        for name, obj in vars(module).items():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, Magics)
+                and obj is not Magics
+                # Only where it is defined, not where it is imported.
+                and obj.__module__ == module_name
+            ):
+                found[name] = obj
+    return found
+
+
+class _UnconfiguredShell(Configurable):
+    """Just enough of a shell for a ``Magics`` class to be instantiated.
+
+    With the *default* configuration, not whatever the session-wide test shell
+    has picked up along the way (``test_magic.py`` adds script magics to it).
+    """
+
+    def __init__(self):
+        super().__init__(config=Config())
+        self.configurables = []
+
+
+# So that `MagicsManager.shell` accepts one of these.
+InteractiveShellABC.register(_UnconfiguredShell)
+
+
+def _expected_table():
+    """The table `_table.BUILTIN_LAZY_MAGICS` should hold, plus any name found
+    on more than one class, which a flat name -> class mapping cannot express.
+    """
+    expected = {"line": {}, "cell": {}}
+    duplicated = {}
+    # ScriptMagics generates one cell magic per configured interpreter; the
+    # table only carries the fixed ones, `init_magics` adds the rest.
+    generated = set(_table.default_script_magics())
+    for class_name, cls in sorted(_shipped_magics_classes().items()):
+        spec = f"{cls.__module__}:{class_name}"
+        instance = cls(shell=_UnconfiguredShell())
+        for kind in ("line", "cell"):
+            for name in sorted(instance.magics[kind]):
+                if name in generated and class_name == "ScriptMagics":
+                    continue
+                if name in expected[kind]:
+                    duplicated[name] = (expected[kind][name], spec)
+                expected[kind][name] = spec
+    return expected, duplicated
+
+
+def _render(table):
+    """Render a name table as the source that should live in ``_table.py``."""
+    lines = ["BUILTIN_LAZY_MAGICS = {"]
+    for kind, names in table.items():
+        lines.append(f'    "{kind}": {{')
+        for name, spec in sorted(names.items()):
+            lines.append(f'        "{name}": "{spec}",')
+        lines.append("    },")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def test_builtin_lazy_magics_table_is_accurate():
+    """``BUILTIN_LAZY_MAGICS`` maps every built-in magic to its class."""
+    expected, _ = _expected_table()
+    declared = {
+        kind: dict(sorted(names.items()))
+        for kind, names in _table.BUILTIN_LAZY_MAGICS.items()
+    }
+    assert declared == {k: dict(sorted(v.items())) for k, v in expected.items()}, (
+        "IPython.core.magics._table.BUILTIN_LAZY_MAGICS is out of sync with the "
+        "magics classes. It should read:\n\n" + _render(expected)
+    )
+
+
+def test_no_magic_is_claimed_by_two_classes():
+    """Eagerly, a duplicate resolved to whichever class registered last;
+    declared lazily there is one entry per name, so one would be lost.
+    """
+    _, duplicated = _expected_table()
+    assert not duplicated
+
+
+def test_every_shipped_class_is_in_the_table():
+    """A new Magics class must be added to ``BUILTIN_LAZY_MAGICS``."""
+    declared = {
+        spec.rpartition(":")[2]
+        for names in _table.BUILTIN_LAZY_MAGICS.values()
+        for spec in names.values()
+    }
+    missing = set(_shipped_magics_classes()) - declared
+    assert not missing, (
+        f"{sorted(missing)} are not listed in IPython.core.magics._table."
+        "BUILTIN_LAZY_MAGICS, so their magics would not be known at startup."
+    )
+
+
+def test_every_shipped_class_is_importable_from_the_package():
+    """``MAGICS_CLASSES`` drives ``IPython.core.magics.__getattr__``."""
+    for class_name, cls in _shipped_magics_classes().items():
+        assert _table.MAGICS_CLASSES.get(class_name) == cls.__module__, (
+            f"IPython.core.magics._table.MAGICS_CLASSES[{class_name!r}] should"
+            f" be {cls.__module__!r}"
+        )
+        assert getattr(IPython.core.magics, class_name) is cls
+
+
+def test_magics_classes_entries_resolve():
+    """Every entry of ``MAGICS_CLASSES`` points at something that exists."""
+    for name, module_name in _table.MAGICS_CLASSES.items():
+        module = import_module(module_name)
+        assert hasattr(module, name), f"{module_name} does not define {name}"
+        assert getattr(IPython.core.magics, name) is getattr(module, name)
+    assert set(_table.MAGICS_CLASSES) <= set(dir(IPython.core.magics))
+
+
+def test_registered_names_match_the_table():
+    """A live shell knows every magic the table declares."""
+    ip = get_ipython()
+    for kind in ("line", "cell"):
+        declared = set(_table.BUILTIN_LAZY_MAGICS[kind])
+        if kind == "cell":
+            declared |= set(_table.default_script_magics())
+        assert not declared - set(ip.magics_manager.magics[kind])
+
+
+def test_configured_script_magics():
+    assert _table.configured_script_magics(None) == _table.default_script_magics()
+    assert _table.configured_script_magics(Config()) == _table.default_script_magics()
+
+    config = Config()
+    config.ScriptMagics.script_magics = ["nodejs"]
+    assert _table.configured_script_magics(config) == ["nodejs"]
+
+
+@pytest.fixture
+def manager():
+    """A standalone MagicsManager, so tests don't disturb the shared shell."""
+    return MagicsManager(shell=_UnconfiguredShell())
+
+
+def test_register_lazy_declares_without_importing(manager):
+    manager.register_lazy("timeit", EXECUTION_SPEC, "line_cell")
+    assert isinstance(manager.magics["line"]["timeit"], LazyMagic)
+    assert isinstance(manager.magics["cell"]["timeit"], LazyMagic)
+    assert manager.lazy_magics["timeit"] == EXECUTION_SPEC
+
+    fn = manager.find("line", "timeit")
+    assert callable(fn) and not isinstance(fn, LazyMagic)
+    assert manager.magics["line"]["timeit"] is fn
+    # Loading it registered the whole class, including its cell magics.
+    assert not isinstance(manager.magics["cell"]["timeit"], LazyMagic)
+    assert manager.registry["ExecutionMagics"].__class__.__name__ == "ExecutionMagics"
+
+
+def test_placeholder_resolves_on_attribute_access(manager):
+    """pyflyby reaches the Magics instance through `magics["line"][name]`."""
+    manager.register_lazy("prun", EXECUTION_SPEC, "line")
+    placeholder = manager.magics["line"]["prun"]
+    assert placeholder.__self__ is manager.registry["ExecutionMagics"]
+
+
+def test_register_lazy_validates_the_kind(manager):
+    with pytest.raises(ValueError):
+        manager.register_lazy("timeit", EXECUTION_SPEC, "both")
+
+
+def test_find_drops_a_placeholder_the_class_does_not_deliver(manager):
+    manager.register_lazy("dummy_lazy", EXECUTION_SPEC, "line")
+    # ExecutionMagics provides no `%dummy_lazy`, so the declaration was wrong.
+    assert manager.find("line", "dummy_lazy") is None
+    assert "dummy_lazy" not in manager.magics["line"]
+    # And asking again does not resurrect it or re-register the class.
+    assert manager.find("line", "dummy_lazy") is None
+
+
+def test_a_class_is_only_loaded_once(manager):
+    manager.register_lazy("timeit", EXECUTION_SPEC, "line")
+    manager.register_lazy("prun", EXECUTION_SPEC, "line")
+    manager.find("line", "timeit")
+    first = manager.registry["ExecutionMagics"]
+    manager.find("line", "prun")
+    manager.load_lazy("prun")
+    assert manager.registry["ExecutionMagics"] is first
+
+
+def test_load_all_lazy_magics_skips_extensions(manager):
+    manager.register_lazy("timeit", EXECUTION_SPEC, "line")
+    manager.register_lazy("an_extension_magic", "some.extension.module", "line")
+    manager.load_all_lazy_magics()
+    assert not isinstance(manager.magics["line"]["timeit"], LazyMagic)
+    # Untouched: loading an extension runs arbitrary code, so it waits for the
+    # magic to actually be used.
+    assert isinstance(manager.magics["line"]["an_extension_magic"], LazyMagic)
+
+
+def test_load_lazy_trusts_the_placeholder_over_the_trait(manager):
+    """`lazy_magics` is user-configurable and may be replaced wholesale."""
+    manager.register_lazy("timeit", EXECUTION_SPEC, "line")
+    manager.lazy_magics = {"something": "else"}
+    assert callable(manager.find("line", "timeit"))
+
+
+def test_a_failing_lazy_load_is_retried(manager):
+    manager.register_lazy("nope", "no.such.module:NoMagics", "line")
+    for _ in range(2):
+        # Raising the import error again beats reporting the magic as missing.
+        with pytest.raises(ModuleNotFoundError):
+            manager.find("line", "nope")
+
+
+def test_registry_loads_a_declared_class_on_a_miss(manager):
+    manager.register_lazy("timeit", EXECUTION_SPEC, "line")
+    assert "ExecutionMagics" not in dict(manager.registry)
+    assert manager.registry["ExecutionMagics"].__class__.__name__ == "ExecutionMagics"
+    with pytest.raises(KeyError):
+        manager.registry["NoSuchMagics"]
+
+
+def test_lsmagic_docs_does_not_document_the_placeholder(manager):
+    """%magic must not import an extension just to print a docstring."""
+    manager.register_lazy("an_extension_magic", "some.extension.module", "line")
+    docs = manager.lsmagic_docs(missing="No documentation")
+    assert docs["line"]["an_extension_magic"] == "No documentation"
+
+
+def test_completing_a_declared_magic_does_not_crash():
+    """`%timeit x.<TAB>` reaches into the table for the magic's parser."""
+    ip = get_ipython()
+    ip.Completer.use_jedi = False
+    assert ip.Completer._extract_code("%timeit -n 2 -r 1 foo") == "foo"
+
+
+STARTUP_CHECK = textwrap.dedent(
+    """
+    import sys
+    from IPython.core.interactiveshell import InteractiveShell
+
+    shell = InteractiveShell.instance()
+    loaded = sorted(
+        name
+        for name in sys.modules
+        if name.startswith("IPython.core.magics.")
+        and not name.rsplit(".", 1)[1].startswith("_")
+    )
+    print(",".join(loaded))
+    """
+)
+
+
+def test_startup_does_not_import_the_magics_modules():
+    """The whole point: starting a shell imports no magics implementation."""
+    result = subprocess.run(
+        [sys.executable, "-c", STARTUP_CHECK],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "", (
+        "starting a shell imported magics modules eagerly: " + result.stdout
+    )

--- a/tests/test_magic_table.py
+++ b/tests/test_magic_table.py
@@ -1,0 +1,313 @@
+"""Check the hand-maintained table of built-in magics against the code.
+
+IPython registers its own magics lazily, from the static tables in
+:mod:`IPython.core.magics._table`, so that starting a shell does not import
+every magics module.  Those tables are only correct as long as somebody keeps
+them correct -- that is what this module is for.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import inspect
+import pkgutil
+import subprocess
+import sys
+import textwrap
+from importlib import import_module
+
+import pytest
+from traitlets.config import Config, Configurable
+
+import IPython.core.magics
+from IPython.core.interactiveshell import InteractiveShellABC
+from IPython.core.magic import Magics
+from IPython.core.magics import _table
+from IPython import get_ipython
+
+
+def _shipped_magics_classes():
+    """Every ``Magics`` subclass defined under ``IPython/core/magics``."""
+    found = {}
+    for info in pkgutil.iter_modules(IPython.core.magics.__path__):
+        module_name = f"{IPython.core.magics.__name__}.{info.name}"
+        module = import_module(module_name)
+        for name, obj in vars(module).items():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, Magics)
+                and obj is not Magics
+                # Only where it is defined, not where it is imported.
+                and obj.__module__ == module_name
+            ):
+                found[name] = obj
+    return found
+
+
+class _UnconfiguredShell(Configurable):
+    """Just enough of a shell for a ``Magics`` class to be instantiated.
+
+    The magics a class provides has to be compared against the *default*
+    configuration, not against whatever the session-wide test shell has been
+    configured with along the way (``tests/test_magic.py`` adds script magics
+    to it, for one).
+    """
+
+    def __init__(self):
+        super().__init__(config=Config())
+        self.configurables = []
+
+
+# So that `MagicsManager.shell` accepts one of these.
+InteractiveShellABC.register(_UnconfiguredShell)
+
+
+def _actual_magics(cls):
+    """The line and cell magics an instance of `cls` registers."""
+    instance = cls(shell=_UnconfiguredShell())
+    return {
+        kind: tuple(sorted(instance.magics[kind])) for kind in ("line", "cell")
+    }
+
+
+def _render(table):
+    """Render a name table as the source that should live in ``_table.py``."""
+    lines = ["BUILTIN_MAGICS = {"]
+    for class_name, kinds in table.items():
+        lines.append(f'    "{class_name}": {{')
+        for kind in ("line", "cell"):
+            lines.append(f'        "{kind}": {kinds[kind]!r},')
+        lines.append("    },")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def test_every_shipped_class_is_in_the_table():
+    """A new Magics class must be added to ``BUILTIN_MAGICS``."""
+    shipped = set(_shipped_magics_classes())
+    # UserMagics is a placeholder for magics defined at runtime; it never
+    # provides any magic of its own and is instantiated eagerly.
+    shipped.discard("UserMagics")
+    missing = shipped - set(_table.BUILTIN_MAGICS)
+    assert not missing, (
+        f"{sorted(missing)} are not listed in IPython.core.magics._table."
+        "BUILTIN_MAGICS, so their magics would not be registered at startup."
+    )
+
+
+def test_every_shipped_class_is_importable_from_the_package():
+    """``MAGICS_CLASSES`` drives ``IPython.core.magics.__getattr__``."""
+    for class_name, cls in _shipped_magics_classes().items():
+        if class_name == "UserMagics":
+            continue
+        assert _table.MAGICS_CLASSES.get(class_name) == cls.__module__, (
+            f"IPython.core.magics._table.MAGICS_CLASSES[{class_name!r}] should"
+            f" be {cls.__module__!r}"
+        )
+        assert getattr(IPython.core.magics, class_name) is cls
+
+
+def test_all_covers_the_lazily_exported_names():
+    """``__all__`` is written out by hand so tools can read it statically."""
+    assert set(_table.MAGICS_CLASSES) <= set(IPython.core.magics.__all__)
+    for name in IPython.core.magics.__all__:
+        assert getattr(IPython.core.magics, name) is not None
+    assert set(IPython.core.magics.__all__) <= set(dir(IPython.core.magics))
+
+
+def test_magics_classes_entries_resolve():
+    """Every entry of ``MAGICS_CLASSES`` points at something that exists."""
+    for name, module_name in _table.MAGICS_CLASSES.items():
+        assert hasattr(import_module(module_name), name), (
+            f"{module_name} does not define {name}"
+        )
+        assert getattr(IPython.core.magics, name) is getattr(
+            import_module(module_name), name
+        )
+
+
+def test_builtin_magics_table_is_accurate():
+    """``BUILTIN_MAGICS`` lists exactly the magics each class provides."""
+    expected = {}
+    for class_name in _table.BUILTIN_MAGICS:
+        cls = getattr(IPython.core.magics, class_name)
+        expected[class_name] = _actual_magics(cls)
+
+    # ScriptMagics generates one cell magic per configured interpreter; the
+    # table only carries the fixed ones, `init_magics` adds the rest.
+    generated = set(_table.default_script_magics())
+    expected["ScriptMagics"]["cell"] = tuple(
+        name for name in expected["ScriptMagics"]["cell"] if name not in generated
+    )
+
+    declared = {
+        class_name: {
+            kind: tuple(sorted(kinds[kind])) for kind in ("line", "cell")
+        }
+        for class_name, kinds in _table.BUILTIN_MAGICS.items()
+    }
+
+    assert declared == expected, (
+        "IPython.core.magics._table.BUILTIN_MAGICS is out of sync with the "
+        "magics classes. It should read:\n\n" + _render(expected)
+    )
+
+
+def test_no_magic_is_claimed_by_two_classes():
+    """Lazy registration assumes one class per name.
+
+    With eager registration a duplicated name resolved to whichever class was
+    registered last.  Lazily, whichever class happens to be imported first
+    would win instead, so duplicates must not happen.
+    """
+    for kind in ("line", "cell"):
+        owners = {}
+        for class_name, kinds in _table.BUILTIN_MAGICS.items():
+            for magic_name in kinds[kind]:
+                owners.setdefault(magic_name, []).append(class_name)
+        duplicated = {name: cls for name, cls in owners.items() if len(cls) > 1}
+        assert not duplicated, f"duplicated {kind} magics: {duplicated}"
+
+
+def test_registered_names_match_the_table():
+    """A live shell knows every magic the table declares."""
+    ip = get_ipython()
+    for kind in ("line", "cell"):
+        declared = {
+            name
+            for kinds in _table.BUILTIN_MAGICS.values()
+            for name in kinds[kind]
+        }
+        if kind == "cell":
+            declared |= set(_table.default_script_magics())
+        missing = declared - set(ip.magics_manager.magics[kind])
+        assert not missing
+
+
+def test_aliases_point_at_known_magics():
+    for alias, target, kind in _table.BUILTIN_MAGIC_ALIASES:
+        assert any(
+            target in kinds[kind] for kinds in _table.BUILTIN_MAGICS.values()
+        ), f"%{alias} aliases {target}, which no built-in class provides"
+
+
+def test_configured_script_magics():
+    from traitlets.config import Config
+
+    assert _table.configured_script_magics(None) == _table.default_script_magics()
+    assert _table.configured_script_magics(Config()) == _table.default_script_magics()
+
+    config = Config()
+    config.ScriptMagics.script_magics = ["nodejs"]
+    assert _table.configured_script_magics(config) == ["nodejs"]
+
+
+EXECUTION_SPEC = "IPython.core.magics.execution:ExecutionMagics"
+
+
+@pytest.fixture
+def manager():
+    """A standalone MagicsManager, so tests don't disturb the shared shell."""
+    from IPython.core.magic import MagicsManager
+
+    return MagicsManager(shell=_UnconfiguredShell())
+
+
+def test_register_lazy_class_validates_spec(manager):
+    with pytest.raises(ValueError):
+        manager.register_lazy_class("IPython.core.magics.execution")
+
+
+def test_lazy_magic_resolves_and_replaces_itself(manager):
+    from IPython.core.magic import LazyMagic
+
+    manager.register_lazy_class(EXECUTION_SPEC, line_magics=["timeit"])
+    placeholder = manager.magics["line"]["timeit"]
+    assert isinstance(placeholder, LazyMagic)
+    assert placeholder._lazy_class_name == "ExecutionMagics"
+    assert "timeit" in repr(placeholder)
+
+    # Resolving loads the class and puts the real magic in the table.
+    assert manager.find("line", "timeit") is not None
+    assert not isinstance(manager.magics["line"]["timeit"], LazyMagic)
+    # ... and the placeholder still works for anything holding on to it.
+    assert placeholder.__doc__ == manager.magics["line"]["timeit"].__doc__
+
+
+def test_lazy_magic_with_a_wrong_table_fails_loudly(manager):
+    from IPython.core.error import UsageError
+
+    manager.register_lazy_class(EXECUTION_SPEC, line_magics=["dummy_lazy"])
+    # ExecutionMagics provides no `%dummy_lazy`: resolving must raise and drop
+    # the stale entry rather than recurse or silently do nothing.
+    with pytest.raises(UsageError):
+        manager.magics["line"]["dummy_lazy"]._lazy_resolve()
+    assert "dummy_lazy" not in manager.magics["line"]
+
+
+def test_register_lazy_class_does_not_shadow_a_loaded_class(manager):
+    from IPython.core.magic import LazyMagic
+
+    manager.register_lazy_class(EXECUTION_SPEC, line_magics=["timeit"])
+    manager.load_lazy_class(EXECUTION_SPEC)
+    manager.register_lazy_class(EXECUTION_SPEC, line_magics=["timeit"])
+    assert not isinstance(manager.magics["line"]["timeit"], LazyMagic)
+
+
+def test_registry_loads_lazily(manager):
+    manager.register_lazy_class(EXECUTION_SPEC, line_magics=["timeit"])
+    assert "ExecutionMagics" not in dict(manager.registry)
+
+    assert manager.registry["ExecutionMagics"].__class__.__name__ == "ExecutionMagics"
+
+    with pytest.raises(KeyError):
+        manager.registry["NoSuchMagics"]
+
+
+def test_load_all_lazy_magics(manager):
+    from IPython.core.magic import LazyMagic
+
+    for class_name, kinds in _table.BUILTIN_MAGICS.items():
+        manager.register_lazy_class(
+            f"{_table.MAGICS_CLASSES[class_name]}:{class_name}",
+            kinds["line"],
+            kinds["cell"],
+        )
+    manager.load_all_lazy_magics()
+    left = [
+        name
+        for table in manager.magics.values()
+        for name, fn in table.items()
+        if isinstance(fn, LazyMagic)
+    ]
+    assert left == []
+
+
+STARTUP_CHECK = textwrap.dedent(
+    """
+    import sys
+    from IPython.core.interactiveshell import InteractiveShell
+
+    shell = InteractiveShell.instance()
+    loaded = sorted(
+        name
+        for name in sys.modules
+        if name.startswith("IPython.core.magics.")
+        and not name.rsplit(".", 1)[1].startswith("_")
+    )
+    print(",".join(loaded))
+    """
+)
+
+
+def test_startup_does_not_import_the_magics_modules():
+    """The whole point: starting a shell imports no magics implementation."""
+    result = subprocess.run(
+        [sys.executable, "-c", STARTUP_CHECK],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "", (
+        "starting a shell imported magics modules eagerly: " + result.stdout
+    )


### PR DESCRIPTION
Starting a shell imported all fifteen modules under IPython.core.magics
and instantiated every Magics class in them, even though a session
typically uses a handful of magics at most. Most of that cost is not the
class bodies but what they drag in: urllib and ast for %edit, cProfile,
pstats and timeit for %timeit, plus the eighteen @magic_arguments()
decorations that each build an argparse parser and format its help at
import time.

Only the magic *names* are now known up front, from hand-maintained
tables in IPython.core.magics._table, and the module implementing a magic
is imported the first time that magic is looked up. Registering a name
installs a LazyMagic placeholder: listing magics, completing them and
membership tests only read the table's keys and stay cheap, while
calling a magic -- or touching any attribute of one -- imports the
module, registers the real Magics instance in its place and delegates.
The same mechanism is available to third parties through
MagicsManager.register_lazy_class(), which, unlike the existing
lazy_magics config, does not require packaging the magics as an
extension.

This takes roughly 30 ms off `import IPython` and 20 ms off
import-plus-shell-startup.

Keeping the tables honest is tests/test_magic_table.py: it imports every
magics module, instantiates every Magics subclass, and fails -- printing
the corrected table -- if anything is missing, stale or attributed to
the wrong class. It also checks that starting a shell still imports no
magics module at all.

Places that need the whole picture rather than one magic keep working:
%config and its completions load everything first, so the list of
configurable classes is unchanged, and registry["ExecutionMagics"]-style
lookups load the class on the miss. init_magics no longer runs %colors
purely to trigger its observer, since that alone would import the basic
magics on every startup.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BqGDoRyv11kHsBvvFQD4T4