### PR TITLE
Correct ctypes restype and argtypes in Windows code

### DIFF
--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -160,11 +160,11 @@ def getoutput(cmd: str) -> str:
 try:
     windll = ctypes.windll  # type: ignore [attr-defined]
     CommandLineToArgvW = windll.shell32.CommandLineToArgvW
-    CommandLineToArgvW.arg_types = [LPCWSTR, POINTER(c_int)]
+    CommandLineToArgvW.argtypes = [LPCWSTR, POINTER(c_int)]
     CommandLineToArgvW.restype = POINTER(LPCWSTR)
     LocalFree = windll.kernel32.LocalFree
-    LocalFree.res_type = HLOCAL
-    LocalFree.arg_types = [HLOCAL]
+    LocalFree.restype = HLOCAL
+    LocalFree.argtypes = [HLOCAL]
 
     def arg_split(
         commandline: str, posix: bool = False, strict: bool = True


### PR DESCRIPTION
Looking at the ctypes documentation, the correct attributes are `restype` and `argtypes`, not `res_type` and `arg_types`.

This is caught by running `mypy` on windows. 

I think this has gone unnoticed since this code is inside a try except block that provides a pure python fallback on AttributeError
and mypy is not currently running in CI on Windows. 

On Windows using python 3.14

```
In [5]: ctypes.windll.kernel32.LocalFree.restype
Out[5]: ctypes.c_void_p

In [6]: ctypes.windll.kernel32.LocalFree.res_type
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[6], line 1
----> 1 ctypes.windll.kernel32.LocalFree.res_type

AttributeError: '_FuncPtr' object has no attribute 'res_type'
```
