### PR TITLE
Restore pathlib.Path support in iFrame

### DIFF
--- a/IPython/lib/display.py
+++ b/IPython/lib/display.py
@@ -292,7 +292,7 @@ class IFrame:
         else:
             params = ""
         return self.iframe.format(
-            src=html_escape(self.src),
+            src=html_escape(str(self.src)),
             width=html_escape(str(self.width)),
             height=html_escape(str(self.height)),
             params=params,

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 import warnings
+from pathlib import Path
 
 from unittest import mock
 
@@ -593,6 +594,12 @@ def test_iframe_escaping():
 
     html = display.IFrame("http://example.com", '400" onload="alert(1)', 300)
     assert 'width="400&quot; onload=&quot;alert(1)"' in html._repr_html_()
+
+
+def test_iframe_path_source():
+    """IFrame: pathlib sources are converted to strings before escaping."""
+    html = display.IFrame(Path("report&notes.html"), 400, 300)._repr_html_()
+    assert 'src="report&amp;notes.html"' in html
 
 
 def test_image_bad_filename_raises_proper_exception():


### PR DESCRIPTION
Fixes #15345

PR #15334 broke pathlib.Path support in IFrame._repr_html_() because html.escape() doesn't handle Path objects (it hits Path.replace() instead of converting to a string).

### Changes:

- Explicitly convert src to a string before passing it to html.escape().
- Add a regression test using a path with & to verify both conversion and escaping work as expected.