### PR TITLE
strip control characters from the title in _set_term_title_xterm

### DIFF
--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -13,12 +13,17 @@ from __future__ import annotations
 # Distributed under the terms of the Modified BSD License.
 
 import os
+import re
 import sys
 import warnings
 from shutil import get_terminal_size as _get_terminal_size
 
 # This variable is part of the expected API of the module:
 ignore_termtitle = True
+
+# C0/C1 controls and DEL. These terminate or abort the OSC string used to set
+# the title, leaving the rest of it to be read as a new terminal command.
+_title_controls_re = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 
@@ -74,7 +79,7 @@ def _set_term_title_xterm(title):
         # save the current title to the xterm "stack"
         sys.stdout.write("\033[22;0t")
         _xterm_term_title_saved = True
-    sys.stdout.write('\033]0;%s\007' % title)
+    sys.stdout.write("\033]0;%s\007" % _title_controls_re.sub("", title))
 
 
 def _restore_term_title_xterm():

--- a/tests/test_utils_terminal.py
+++ b/tests/test_utils_terminal.py
@@ -75,6 +75,16 @@ def test_set_term_title_xterm_saves_once(monkeypatch, capsys):
     assert capsys.readouterr().out == "\033]0;second\007"
 
 
+def test_set_term_title_xterm_strips_control_characters(monkeypatch, capsys):
+    monkeypatch.setattr(terminal, "_xterm_term_title_saved", True)
+    # a directory name may hold any byte but "/" and NUL, so the title can carry
+    # a BEL closing our OSC string followed by a sequence of the author's choice
+    terminal._set_term_title_xterm("IPython: proj\a\033]52;c;cm0gLXJmIH4K\a")
+    out = capsys.readouterr().out
+    assert out == "\033]0;IPython: proj]52;c;cm0gLXJmIH4K\007"
+    assert out.count("\007") == 1
+
+
 def test_restore_term_title_xterm(monkeypatch, capsys):
     monkeypatch.setattr(terminal, "_xterm_term_title_saved", True)
     terminal._restore_term_title_xterm()


### PR DESCRIPTION
`_set_term_title_xterm` interpolates its argument into an OSC 0 string with nothing filtered out:

- the title is `term_title_format.format(cwd=abbrev_cwd())`, written by `%cd` (osm.py:409) and by `init_term_title` at startup, so its variable part is a directory name off the filesystem
- a directory name may hold any byte but `/` and NUL, so a BEL in it closes our OSC string early and what follows is read by the terminal as a new command
- starting ipython inside a directory named `proj\a\033]52;c;cm0gLXJmIH4K\a` makes the terminal take an OSC 52 clipboard write, no cell executed and no interaction past being in that directory

GHSA-29gw-9793-fvw7 covered the same untrusted-directory-name case for the Windows `os.system` branch of `set_term_title`; the xterm branch still writes the value raw. Swept the rest of the tree for the same shape: the kitty graphics writer base64s its payload and the vi cursor-shape writer formats an int from a fixed table, so this is the only site.
