### PR TITLE
Add cross-platform mypy type checking to CI workflow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,9 +12,11 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.14"]
 
     steps:
@@ -29,13 +31,30 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     - name: Install dependencies
+      shell: bash
       run: |
         uv pip install --system mypy pyflakes flake8 '.[all]'
     - name: Lint with mypy
+      shell: bash
       run: |
         set -e
         mypy IPython
+    - name: Lint with mypy (cross-platform typeshed checks)
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        set -e
+        mypy --platform linux IPython
+        mypy --platform darwin IPython
+        mypy --platform win32 IPython
+    - name: Lint with mypy (win32 typeshed check)
+      if: matrix.os == 'windows-latest'
+      shell: bash
+      run: |
+        set -e
+        mypy --platform win32 IPython
     - name: Lint with pyflakes
+      shell: bash
       run: |
         set -e
         flake8  IPython/core/magics/script.py

--- a/IPython/utils/_process_win32.py
+++ b/IPython/utils/_process_win32.py
@@ -158,7 +158,7 @@ def getoutput(cmd: str) -> str:
 
 
 try:
-    windll = ctypes.windll  # type: ignore [attr-defined]
+    windll = ctypes.windll  # type: ignore[attr-defined, unused-ignore]
     CommandLineToArgvW = windll.shell32.CommandLineToArgvW
     CommandLineToArgvW.argtypes = [LPCWSTR, POINTER(c_int)]
     CommandLineToArgvW.restype = POINTER(LPCWSTR)

--- a/IPython/utils/terminal.py
+++ b/IPython/utils/terminal.py
@@ -58,7 +58,7 @@ def toggle_set_term_title(val: bool):
     ignore_termtitle = not(val)
 
 
-def _set_term_title(*args,**kw):
+def _set_term_title(title: str) -> None:
     """Dummy no-op."""
     pass
 
@@ -70,7 +70,7 @@ def _restore_term_title():
 _xterm_term_title_saved = False
 
 
-def _set_term_title_xterm(title):
+def _set_term_title_xterm(title: str) -> None:
     """ Change virtual terminal title in xterm-workalikes """
     global _xterm_term_title_saved
     # Only save the title the first time we set, otherwise restore will only
@@ -107,12 +107,12 @@ elif sys.platform == 'win32':
     SetConsoleTitleW = ctypes.windll.kernel32.SetConsoleTitleW
     SetConsoleTitleW.argtypes = [ctypes.c_wchar_p]
 
-    def _set_term_title(title):
+    def _set_term_title(title: str) -> None:
         """Set terminal title using ctypes to access the Win32 APIs."""
         SetConsoleTitleW(title)
 
 
-def set_term_title(title):
+def set_term_title(title: str) -> None:
     """Set terminal title using the necessary platform-dependent calls."""
     if ignore_termtitle:
         return


### PR DESCRIPTION
## Summary
Enhanced the mypy CI workflow to run on multiple operating systems and perform cross-platform typeshed validation checks.

## Key Changes
- **Multi-OS testing**: Updated the workflow to run on both `ubuntu-latest` and `windows-latest` instead of just Ubuntu
- **Fail-fast disabled**: Set `fail-fast: false` to allow all matrix jobs to complete even if one fails
- **Cross-platform type checking**: Added dedicated mypy checks for different Python platforms (linux, darwin, win32) on Ubuntu to catch platform-specific type issues
- **Windows-specific validation**: Added a separate mypy check for win32 platform when running on Windows
- **Shell specification**: Explicitly set `shell: bash` for all run steps to ensure consistent behavior across platforms

## Implementation Details
- The cross-platform checks on Ubuntu validate typeshed compatibility for all three major platforms without requiring separate OS runners
- Windows runner performs its own win32 platform validation to ensure native Windows type checking works correctly
- All mypy steps use `set -e` to fail on first error, maintaining strict type checking standards

https://claude.ai/code/session_01Ag9F9f3JAsE2PZm8o1fjK1