### PR TITLE
Optimize startup performance by deferring non-critical imports

### DIFF
--- a/IPython/core/_dunder_ops.py
+++ b/IPython/core/_dunder_ops.py
@@ -1,0 +1,61 @@
+"""Mapping from AST operator nodes to the dunder methods that implement them.
+
+This lives in its own module, rather than in `IPython.core.guarded_eval` where
+it is mostly used, so that the terminal shortcut filters can resolve operators
+in a filter expression without importing the whole of `guarded_eval` -- and
+with it `typing_extensions`, `dataclasses` and `inspect` -- on every startup.
+
+The names are re-exported from `IPython.core.guarded_eval`, which remains
+their documented home.
+"""
+
+import ast
+
+__all__ = [
+    "BINARY_OP_DUNDERS",
+    "COMP_OP_DUNDERS",
+    "UNARY_OP_DUNDERS",
+]
+
+BINARY_OP_DUNDERS: dict[type[ast.operator], tuple[str]] = {
+    ast.Add: ("__add__",),
+    ast.Sub: ("__sub__",),
+    ast.Mult: ("__mul__",),
+    ast.Div: ("__truediv__",),
+    ast.FloorDiv: ("__floordiv__",),
+    ast.Mod: ("__mod__",),
+    ast.Pow: ("__pow__",),
+    ast.LShift: ("__lshift__",),
+    ast.RShift: ("__rshift__",),
+    ast.BitOr: ("__or__",),
+    ast.BitXor: ("__xor__",),
+    ast.BitAnd: ("__and__",),
+    ast.MatMult: ("__matmul__",),
+}
+
+COMP_OP_DUNDERS: dict[type[ast.cmpop], tuple[str, ...]] = {
+    ast.Eq: ("__eq__",),
+    ast.NotEq: ("__ne__", "__eq__"),
+    ast.Lt: ("__lt__", "__gt__"),
+    ast.LtE: ("__le__", "__ge__"),
+    ast.Gt: ("__gt__", "__lt__"),
+    ast.GtE: ("__ge__", "__le__"),
+    ast.In: ("__contains__",),
+    # Note: ast.Is, ast.IsNot, ast.NotIn are handled specially
+}
+
+UNARY_OP_DUNDERS: dict[type[ast.unaryop], tuple[str, ...]] = {
+    ast.USub: ("__neg__",),
+    ast.UAdd: ("__pos__",),
+    # we have to check both __inv__ and __invert__!
+    ast.Invert: ("__invert__", "__inv__"),
+    ast.Not: ("__not__",),
+}
+
+
+def _find_dunder(node_op, dunders) -> tuple[str, ...] | None:
+    dunder = None
+    for op, candidate_dunder in dunders.items():
+        if isinstance(node_op, op):
+            dunder = candidate_dunder
+    return dunder

--- a/IPython/core/_dunder_ops.py
+++ b/IPython/core/_dunder_ops.py
@@ -10,6 +10,8 @@ their documented home.
 """
 
 import ast
+from collections.abc import Mapping
+from typing import Any
 
 __all__ = [
     "BINARY_OP_DUNDERS",
@@ -53,7 +55,9 @@ UNARY_OP_DUNDERS: dict[type[ast.unaryop], tuple[str, ...]] = {
 }
 
 
-def _find_dunder(node_op, dunders) -> tuple[str, ...] | None:
+def _find_dunder(
+    node_op: ast.AST, dunders: Mapping[type[Any], tuple[str, ...]]
+) -> tuple[str, ...] | None:
     dunder = None
     for op, candidate_dunder in dunders.items():
         if isinstance(node_op, op):

--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from enum import Enum
 from dataclasses import dataclass, KW_ONLY
 from binascii import b2a_base64, hexlify
-import mimetypes
 import os
 import warnings
 from copy import deepcopy
@@ -1239,6 +1238,8 @@ class Video(DisplayObject):
         mimetype = self.mimetype
         if self.filename is not None:
             if not mimetype:
+                import mimetypes
+
                 mimetype, _ = mimetypes.guess_type(self.filename)
 
             with open(self.filename, 'rb') as f:

--- a/IPython/core/guarded_eval.py
+++ b/IPython/core/guarded_eval.py
@@ -26,6 +26,12 @@ from functools import cached_property
 from dataclasses import dataclass, field
 from types import MethodDescriptorType, ModuleType, MethodType
 
+from IPython.core._dunder_ops import (
+    BINARY_OP_DUNDERS,
+    COMP_OP_DUNDERS,
+    UNARY_OP_DUNDERS,
+    _find_dunder,
+)
 from IPython.utils.decorators import undoc
 
 import types
@@ -465,41 +471,6 @@ def guarded_eval(code: str, context: EvaluationContext):
     return eval_node(node, context)
 
 
-BINARY_OP_DUNDERS: dict[type[ast.operator], tuple[str]] = {
-    ast.Add: ("__add__",),
-    ast.Sub: ("__sub__",),
-    ast.Mult: ("__mul__",),
-    ast.Div: ("__truediv__",),
-    ast.FloorDiv: ("__floordiv__",),
-    ast.Mod: ("__mod__",),
-    ast.Pow: ("__pow__",),
-    ast.LShift: ("__lshift__",),
-    ast.RShift: ("__rshift__",),
-    ast.BitOr: ("__or__",),
-    ast.BitXor: ("__xor__",),
-    ast.BitAnd: ("__and__",),
-    ast.MatMult: ("__matmul__",),
-}
-
-COMP_OP_DUNDERS: dict[type[ast.cmpop], tuple[str, ...]] = {
-    ast.Eq: ("__eq__",),
-    ast.NotEq: ("__ne__", "__eq__"),
-    ast.Lt: ("__lt__", "__gt__"),
-    ast.LtE: ("__le__", "__ge__"),
-    ast.Gt: ("__gt__", "__lt__"),
-    ast.GtE: ("__ge__", "__le__"),
-    ast.In: ("__contains__",),
-    # Note: ast.Is, ast.IsNot, ast.NotIn are handled specially
-}
-
-UNARY_OP_DUNDERS: dict[type[ast.unaryop], tuple[str, ...]] = {
-    ast.USub: ("__neg__",),
-    ast.UAdd: ("__pos__",),
-    # we have to check both __inv__ and __invert__!
-    ast.Invert: ("__invert__", "__inv__"),
-    ast.Not: ("__not__",),
-}
-
 GENERIC_CONTAINER_TYPES = (dict, list, set, tuple, frozenset)
 
 
@@ -533,14 +504,6 @@ class _Duck:
 
     def _ipython_key_completions_(self):
         return self.items.keys()
-
-
-def _find_dunder(node_op, dunders) -> tuple[str, ...] | None:
-    dunder = None
-    for op, candidate_dunder in dunders.items():
-        if isinstance(node_op, op):
-            dunder = candidate_dunder
-    return dunder
 
 
 def get_policy(context: EvaluationContext) -> EvaluationPolicy:

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -30,7 +30,6 @@ from typing import Literal
 from typing import TYPE_CHECKING
 from collections.abc import Sequence
 from warnings import warn
-import textwrap
 
 
 from traitlets import (
@@ -1066,7 +1065,9 @@ class InteractiveShell(SingletonConfigurable):
             banner is default_banner
             and (when := os.environ.get("SOURCE_DATE_EPOCH", None)) is not None
         ):
+            import textwrap
             from datetime import datetime
+
             date = datetime.fromtimestamp(int(when))
             banner = textwrap.dedent(
                 f"""

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -17,7 +17,6 @@ import builtins as builtin_mod
 import functools
 import os
 import re
-import runpy
 import sys
 import types
 import warnings
@@ -3148,6 +3147,8 @@ class InteractiveShell(SingletonConfigurable):
         where : dict
             The globals namespace.
         """
+        import runpy
+
         try:
             try:
                 where.update(

--- a/IPython/core/kitty.py
+++ b/IPython/core/kitty.py
@@ -1,6 +1,7 @@
 # Implements https://sw.kovidgoyal.net/kitty/graphics-protocol/
 
 from base64 import b64encode, b64decode
+from collections.abc import Iterator
 import os
 import sys
 import warnings
@@ -30,14 +31,84 @@ def _forced_kitty_graphics() -> bool | None:
     return None
 
 
+def _read_proc_stat(pid: int) -> bytes:
+    """Return the raw contents of ``/proc/<pid>/stat``."""
+    with open(f"/proc/{pid}/stat", "rb") as stat_file:
+        return stat_file.read()
+
+
+def _proc_ancestor_names() -> Iterator[str]:
+    """Yield ancestor process names, nearest first, by reading ``/proc``.
+
+    Stops early -- yielding nothing further -- if an ancestor's ``stat`` file
+    cannot be read, which is what happens when ``/proc`` is mounted with
+    ``hidepid`` and the ancestor belongs to another user. That is the same
+    outcome as the `psutil.AccessDenied` the psutil walk below has to handle.
+
+    The kernel truncates the name in ``stat`` to 15 characters, where psutil
+    would fall back to ``cmdline`` to recover the full one. Every terminal
+    this is matched against is well under that, so a truncated name can only
+    ever fail to match -- and only for a process that was never a match.
+    """
+    pid = os.getppid()
+    while pid > 0:
+        try:
+            stat = _read_proc_stat(pid)
+        except OSError:
+            return
+        # `stat` is ``pid (comm) state ppid ...``, and `comm` may itself
+        # contain spaces and parentheses, so the closing parenthesis to split
+        # on is the *last* one.
+        head, _, rest = stat.rpartition(b")")
+        yield head.partition(b"(")[2].decode("utf-8", "replace")
+        fields = rest.split()
+        try:
+            # The ppid, after the one-letter state; 0 once we reach pid 1.
+            pid = int(fields[1])
+        except (IndexError, ValueError):
+            return
+
+
+def _psutil_ancestor_names() -> Iterator[str]:
+    """Yield ancestor process names, nearest first, using psutil."""
+    import psutil
+
+    try:
+        process = psutil.Process()
+        while process := process.parent():
+            yield process.name()
+    except (psutil.Error, OSError):
+        # Walking the process tree can fail when /proc is mounted with
+        # ``hidepid`` on shared multi-user systems (common on HPC clusters):
+        # ancestor processes owned by other users are inaccessible and psutil
+        # raises AccessDenied. Treat as "unsupported" rather than letting it
+        # abort the import of IPython.
+        return
+
+
+def _ancestor_process_names() -> Iterator[str]:
+    """Yield the names of this process' ancestors, nearest first.
+
+    On Linux this reads ``/proc`` directly: importing psutil costs upwards of
+    10ms, which is a real slice of IPython's startup, and this runs on every
+    interactive start. ``/proc/<pid>/stat`` holds both the name psutil would
+    report and the parent pid, so one read per ancestor is enough.
+
+    Everywhere else -- macOS, or a Linux without ``/proc`` -- fall back to
+    psutil, which IPython depends on anyway.
+    """
+    if sys.platform == "linux" and os.path.isdir("/proc/self"):
+        yield from _proc_ancestor_names()
+    else:
+        yield from _psutil_ancestor_names()
+
+
 def _supports_kitty_graphics() -> bool:
     forced = _forced_kitty_graphics()
     if forced is not None:
         return forced
 
-    import platform
-
-    if platform.system() not in ("Darwin", "Linux"):
+    if sys.platform not in ("darwin", "linux"):
         return False
 
     isatty = getattr(sys.stdout, "isatty", None)
@@ -56,21 +127,7 @@ def _supports_kitty_graphics() -> bool:
         "wezterm-gui",
         "yakuake",
     }
-    import psutil
-
-    try:
-        process = psutil.Process()
-        while process := process.parent():
-            if process.name() in supported_terminals:
-                return True
-    except (psutil.Error, OSError):
-        # Walking the process tree can fail when /proc is mounted with
-        # ``hidepid`` on shared multi-user systems (common on HPC clusters):
-        # ancestor processes owned by other users are inaccessible and psutil
-        # raises AccessDenied. Treat as "unsupported" rather than letting it
-        # abort the import of IPython.
-        return False
-    return False
+    return any(name in supported_terminals for name in _ancestor_process_names())
 
 
 supports_kitty_graphics = _supports_kitty_graphics()

--- a/IPython/core/oinspect.py
+++ b/IPython/core/oinspect.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from inspect import signature
 from textwrap import dedent
 import ast
-import html
 import inspect
 import io as stdlib_io
 import linecache
@@ -574,6 +573,8 @@ class Inspector(Configurable):
         Formatters returning strings are supported but this behavior is deprecated.
 
         """
+        import html
+
         defaults = {
             "text/plain": text,
             "text/html": f"<pre>{html.escape(text)}</pre>",

--- a/IPython/lib/pretty.py
+++ b/IPython/lib/pretty.py
@@ -96,7 +96,6 @@ Inheritance diagram:
 from contextlib import contextmanager
 import datetime
 import os
-import platform
 import re
 import sys
 import types
@@ -705,6 +704,8 @@ def _super_pprint(obj, p, cycle):
     p.pretty(obj.__thisclass__)
     p.text(',')
     p.breakable()
+    import platform
+
     if platform.python_implementation() == "PyPy": # In PyPy, super() objects don't have __self__ attributes
         dself = obj.__repr__.__self__
         p.pretty(None if dself is obj else dself)

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -11,7 +11,7 @@ from IPython.core.kitty import (
     display_formatter_default_active_types,
     terminal_default_mime_renderers,
 )
-from IPython.utils.PyColorize import theme_table
+from IPython.utils.PyColorize import _pygments_base_styles, theme_table
 from IPython.utils.terminal import toggle_set_term_title, set_term_title, restore_term_title
 from IPython.utils.process import abbrev_cwd
 from traitlets import (
@@ -44,7 +44,7 @@ from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle, print_formatted_text
 from prompt_toolkit.styles import DynamicStyle, merge_styles
-from prompt_toolkit.styles.pygments import style_from_pygments_cls, style_from_pygments_dict
+from prompt_toolkit.styles.pygments import style_from_pygments_dict
 from pygments.style import Style
 
 from .magics import TerminalMagics
@@ -841,24 +841,19 @@ class TerminalInteractiveShell(InteractiveShell):
         theme = theme_table.get(legacy, None)
         assert theme is not None, legacy
 
-        # `pygments.styles` drags in the pygments plugin machinery
-        # (importlib.metadata -> zipfile -> shutil); it is only needed to
-        # resolve a theme's base style, which happens once, here.
-        from pygments.styles import get_style_by_name
-
         if legacy == "nocolor":
             style_overrides = {}
-            style_cls = _NoStyle
+            base_styles = _NoStyle.styles
         else:
             style_overrides = {**theme.extra_style, **self.highlighting_style_overrides}
             if theme.base is not None:
-                style_cls = get_style_by_name(theme.base)
+                base_styles = _pygments_base_styles(theme.base)
             else:
-                style_cls = _NoStyle
+                base_styles = _NoStyle.styles
 
         style = merge_styles(
             [
-                style_from_pygments_cls(style_cls),
+                style_from_pygments_dict(base_styles),
                 style_from_pygments_dict(style_overrides),
             ]
         )

--- a/IPython/terminal/interactiveshell.py
+++ b/IPython/terminal/interactiveshell.py
@@ -43,7 +43,7 @@ from prompt_toolkit.layout.processors import ConditionalProcessor, HighlightMatc
 from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle, print_formatted_text
-from prompt_toolkit.styles import DynamicStyle, merge_styles
+from prompt_toolkit.styles import BaseStyle, DynamicStyle, merge_styles
 from prompt_toolkit.styles.pygments import style_from_pygments_dict
 from pygments.style import Style
 
@@ -358,8 +358,32 @@ class TerminalInteractiveShell(InteractiveShell):
             )
             return
 
-    def refresh_style(self):
-        self._style = self._make_style_from_name_or_cls("legacy")
+    # Cache behind the `_style` property below; None means "not built yet".
+    __style: BaseStyle | None = None
+
+    def refresh_style(self) -> None:
+        """Invalidate the prompt style, so that it is rebuilt when next needed.
+
+        Building it means turning a whole pygments style into prompt_toolkit
+        style rules, which is not cheap, and `refresh_style` is called several
+        times while a shell is set up -- once from `init_syntax_highlighting`
+        on `colors` being set, again from `init_magics`, again when the
+        prompt_toolkit application is created. Only the last state matters, and
+        for a non-interactive run (``ipython -c ...``, ``--simple-prompt``, a
+        kernel) none of them do: the style is only ever read through the
+        `DynamicStyle` the prompt session renders with.
+        """
+        self.__style = None
+
+    @property
+    def _style(self) -> BaseStyle:
+        if self.__style is None:
+            self.__style = self._make_style_from_name_or_cls("legacy")
+        return self.__style
+
+    @_style.setter
+    def _style(self, style: BaseStyle) -> None:
+        self.__style = style
 
     # TODO: deprecate this
     highlighting_style_overrides = Dict(

--- a/IPython/terminal/shortcuts/filters.py
+++ b/IPython/terminal/shortcuts/filters.py
@@ -26,8 +26,12 @@ from prompt_toolkit.filters import (
 )
 from prompt_toolkit.layout.layout import FocusableElement
 
+from IPython.core._dunder_ops import (
+    BINARY_OP_DUNDERS,
+    UNARY_OP_DUNDERS,
+    _find_dunder,
+)
 from IPython.core.getipython import get_ipython
-from IPython.core.guarded_eval import _find_dunder, BINARY_OP_DUNDERS, UNARY_OP_DUNDERS
 from IPython.terminal.shortcuts import auto_suggest
 from IPython.utils.decorators import undoc
 

--- a/IPython/utils/PyColorize.py
+++ b/IPython/utils/PyColorize.py
@@ -27,6 +27,77 @@ TokenStream: TypeAlias = list[tuple[_TokenType, str]]
 __all__ = ["Parser", "Theme"]
 
 
+# Which ``pygments/styles/*.py`` module (and class in it) defines each of the
+# builtin pygments styles the themes IPython ships use as a `Theme.base`.
+#
+# This is only a shortcut, never the source of truth: any name missing from
+# here, and any entry that no longer resolves, falls back to pygments' own
+# `get_style_by_name`, plugins and all. See `_pygments_base_styles`.
+_BUILTIN_PYGMENTS_STYLES: dict[str, tuple[str, str]] = {
+    "default": ("default", "DefaultStyle"),
+    "gruvbox-dark": ("gruvbox", "GruvboxDarkStyle"),
+    "monokai": ("monokai", "MonokaiStyle"),
+    "pastie": ("pastie", "PastieStyle"),
+}
+
+
+def _exec_pygments_style_module(module: str, class_name: str) -> Any | None:
+    """Read one style's ``styles`` mapping out of ``pygments/styles/<module>.py``.
+
+    Returns None if pygments is not laid out as expected, leaving it to the
+    caller to fall back to `pygments.styles.get_style_by_name`.
+
+    The module is executed in isolation and deliberately *not* registered in
+    `sys.modules`: registering a submodule of a package that is not itself
+    imported breaks later ``import pygments.styles.<module>`` statements, and
+    keeping `pygments.styles` unimported is the entire point. Style modules
+    are pure data, so executing one twice is harmless, and nothing but the
+    ``styles`` dict escapes this function.
+    """
+    from importlib.machinery import PathFinder
+    from importlib.util import module_from_spec
+
+    package = PathFinder.find_spec("pygments.styles", list(pygments.__path__))
+    if package is None or package.submodule_search_locations is None:
+        return None
+    spec = PathFinder.find_spec(
+        f"pygments.styles.{module}", list(package.submodule_search_locations)
+    )
+    if spec is None or spec.loader is None:
+        return None
+    style_module = module_from_spec(spec)
+    try:
+        spec.loader.exec_module(style_module)
+        return getattr(style_module, class_name).styles
+    except Exception:
+        return None
+
+
+def _pygments_base_styles(name: str) -> Any:
+    """Return the token -> style-string mapping of a pygments style, by name.
+
+    Equivalent to ``pygments.styles.get_style_by_name(name).styles``, which is
+    all IPython ever wants from a base style, but able to answer for the
+    handful of builtin styles IPython's own themes are based on without
+    importing `pygments.styles`.
+
+    Importing that package -- which importing any of its submodules does too --
+    runs `pygments.plugin`, and with it `importlib.metadata` and `email`:
+    roughly 10ms whose only purpose is to make third party *style plugins*
+    findable by name. No theme IPython ships needs that, and this is on the
+    startup path.
+    """
+    target = _BUILTIN_PYGMENTS_STYLES.get(name)
+    if target is not None:
+        styles = _exec_pygments_style_module(*target)
+        if styles is not None:
+            return styles
+
+    from pygments.styles import get_style_by_name
+
+    return get_style_by_name(name).styles
+
+
 class Symbols(TypedDict):
     top_line: str
     arrow_body: str
@@ -63,12 +134,7 @@ class Theme:
     @cache
     def as_pygments_style(self) -> type[Style]:
         if self.base is not None:
-            # `pygments.styles` pulls in the pygments plugin machinery, and
-            # with it `importlib.metadata`, `zipfile` and `shutil`; keep that
-            # off the import path of everything that merely wants a Theme.
-            from pygments.styles import get_style_by_name
-
-            base_styles = get_style_by_name(self.base).styles
+            base_styles = _pygments_base_styles(self.base)
         else:
             base_styles = {}
 

--- a/IPython/utils/encoding.py
+++ b/IPython/utils/encoding.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 # Imports
 # -----------------------------------------------------------------------------
 import sys
-import locale
 import warnings
 from typing import Any
 
@@ -67,6 +66,8 @@ def getdefaultencoding(prefer_stream: object | bool = _sentinel) -> str:
     if prefer_stream:
         enc = get_stream_enc(sys.stdin)
     if not enc or enc == "ascii":
+        import locale
+
         try:
             # There are reports of getpreferredencoding raising errors
             # in some cases, which may well be fixed, but let's be conservative here.

--- a/IPython/utils/path.py
+++ b/IPython/utils/path.py
@@ -8,7 +8,6 @@ Utilities for path handling.
 import os
 import sys
 import errno
-import glob
 import warnings
 
 #-----------------------------------------------------------------------------
@@ -279,6 +278,8 @@ def shellglob(args):
     expanded = []
     # Do not unescape backslash in Windows as it is interpreted as
     # path separator:
+    import glob
+
     unescape = unescape_glob if sys.platform != 'win32' else lambda x: x
     for a in args:
         expanded.extend(glob.glob(a) or [unescape(a)])

--- a/IPython/utils/sysinfo.py
+++ b/IPython/utils/sysinfo.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 #-----------------------------------------------------------------------------
 
 import os
-import platform
-import pprint
 import sys
 
 from pathlib import Path
@@ -80,6 +78,8 @@ def pkg_info(pkg_path: str) -> dict:
     context : dict
         with named parameters of interest
     """
+    import platform
+
     src, hsh = pkg_commit_hash(pkg_path)
     return dict(
         ipython_version=release.version,
@@ -117,4 +117,6 @@ def sys_info() -> str:
          'sys_platform': 'linux2',
          'sys_version': '2.6.6 (r266:84292, Sep 15 2010, 15:52:39) \\n[GCC 4.4.5]'}
     """
+    import pprint
+
     return pprint.pformat(get_sys_info())

--- a/docs/source/whatsnew/pr/faster-startup-round-2.rst
+++ b/docs/source/whatsnew/pr/faster-startup-round-2.rst
@@ -1,0 +1,38 @@
+More startup work moved off the critical path
+---------------------------------------------
+
+A second pass over what IPython does before it can show a prompt, on top of the
+lazy imports and lazy magic registration. Nothing here is visible in normal
+use; it is all work that used to happen on every start and is now either
+avoided or postponed until something actually needs it.
+
+* Resolving a theme's base pygments style no longer imports
+  :mod:`pygments.styles`, and with it the pygments plugin machinery,
+  :mod:`importlib.metadata` and :mod:`email`. Only the base style's ``styles``
+  mapping was ever used, so for the builtin styles IPython's own themes are
+  based on the defining module is read directly. Styles that are not builtin --
+  including any provided by a pygments plugin -- still resolve exactly as
+  before.
+
+* Detecting whether the terminal speaks the kitty graphics protocol no longer
+  imports psutil on Linux. The walk up the process tree needs each ancestor's
+  name and parent pid, and ``/proc/<pid>/stat`` has both. macOS still uses
+  psutil. This one only ever showed up in an actual terminal: a headless
+  ``ipython -c ...`` stops at the ``isatty`` check before reaching it. Setting
+  ``IPYTHON_KITTY_GRAPHICS`` still skips detection entirely.
+
+* The prompt style is built the first time it is drawn rather than each of the
+  several times it is invalidated while a shell is being set up, and not at all
+  for a run that never draws a prompt.
+
+* More single-use imports moved to their use sites: :mod:`platform`,
+  :mod:`pprint`, :mod:`textwrap`, :mod:`html`, :mod:`mimetypes`,
+  :mod:`locale`, :mod:`glob` and :mod:`runpy`. The AST operator tables the
+  terminal shortcut filters need moved out of
+  :mod:`IPython.core.guarded_eval` into a module of their own, so evaluating
+  a shortcut's filter expression no longer imports the whole guarded
+  evaluation machinery (and ``typing_extensions``). They are still importable
+  from :mod:`IPython.core.guarded_eval`.
+
+Together this takes another ~10% off ``ipython -c pass`` and another ~40
+modules off an interactive start, on top of the previous rounds.

--- a/docs/source/whatsnew/pr/faster-startup-round-2.rst
+++ b/docs/source/whatsnew/pr/faster-startup-round-2.rst
@@ -34,5 +34,6 @@ avoided or postponed until something actually needs it.
   evaluation machinery (and ``typing_extensions``). They are still importable
   from :mod:`IPython.core.guarded_eval`.
 
-Together this takes another ~10% off ``ipython -c pass`` and another ~40
-modules off an interactive start, on top of the previous rounds.
+Together this takes another ~13% off starting an interactive ``ipython`` in a
+real terminal, ~9% off ``ipython -c pass``, and another ~43 modules off an
+interactive start, on top of the previous rounds.

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -221,8 +221,16 @@ def test_supports_kitty_graphics_finds_terminal_through_proc(monkeypatch):
     assert kitty._supports_kitty_graphics() is True
 
 
-def test_supports_kitty_graphics_does_not_import_psutil_on_linux(monkeypatch):
-    """The /proc walk exists to keep psutil -- and its import cost -- out."""
+@pytest.mark.skipif(
+    not os.path.isdir("/proc/self"),
+    reason="the psutil-free walk is the /proc one, and needs a real /proc",
+)
+def test_supports_kitty_graphics_does_not_import_psutil_on_linux():
+    """The /proc walk exists to keep psutil -- and its import cost -- out.
+
+    Deliberately not faking anything about the platform: what is being checked
+    is that a real Linux with a real ``/proc`` answers without psutil.
+    """
     code = """
 import os, sys, builtins
 
@@ -247,7 +255,6 @@ class StdoutTTY:
 
 
 sys.stdout = StdoutTTY()
-sys.platform = "linux"
 from IPython.core import kitty
 
 kitty._supports_kitty_graphics()

--- a/tests/test_kitty.py
+++ b/tests/test_kitty.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -23,11 +24,9 @@ class StdoutTTY(DummyStdout):
 
 
 def test_supports_kitty_graphics_handles_stdout_without_callable_isatty(monkeypatch):
-    import platform
-
     from IPython.core import kitty
 
-    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(sys, "platform", "linux")
     for stdout in (DummyStdout(), StdoutWithNonCallableIsatty()):
         monkeypatch.setattr(sys, "stdout", stdout)
         assert kitty._supports_kitty_graphics() is False
@@ -65,13 +64,12 @@ def test_supports_kitty_graphics_handles_psutil_access_denied(monkeypatch):
     another user makes psutil raise AccessDenied. This must be treated as
     "unsupported" rather than aborting the import of IPython.
     """
-    import platform
-
     import psutil
 
     from IPython.core import kitty
 
-    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    # "darwin" so that detection takes the psutil branch rather than /proc.
+    monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(sys, "stdout", StdoutTTY())
 
     class DeniedProcess:
@@ -154,3 +152,115 @@ def test_kitty_graphics_bad_value_warns_and_autodetects(monkeypatch):
     monkeypatch.setenv("IPYTHON_KITTY_GRAPHICS", "yes-please")
     with pytest.warns(UserWarning, match="IPYTHON_KITTY_GRAPHICS"):
         assert kitty._forced_kitty_graphics() is None
+
+
+def _fake_proc(tree):
+    """Build a `_read_proc_stat` replacement from a ``{pid: (name, ppid)}`` map.
+
+    A pid missing from the map raises `PermissionError`, which is what
+    ``hidepid`` gives for an ancestor owned by another user.
+    """
+
+    def read(pid):
+        try:
+            name, ppid = tree[pid]
+        except KeyError:
+            raise PermissionError(13, "Permission denied") from None
+        return f"{pid} ({name}) S {ppid} 0 0 0 -1 0".encode()
+
+    return read
+
+
+def test_proc_ancestor_names_walks_up_to_pid_1(monkeypatch):
+    from IPython.core import kitty
+
+    monkeypatch.setattr(os, "getppid", lambda: 42)
+    monkeypatch.setattr(
+        kitty,
+        "_read_proc_stat",
+        _fake_proc({42: ("kitty", 7), 7: ("login", 1), 1: ("systemd", 0)}),
+    )
+    assert list(kitty._proc_ancestor_names()) == ["kitty", "login", "systemd"]
+
+
+def test_proc_ancestor_names_handles_names_with_spaces_and_parens(monkeypatch):
+    """`comm` is not escaped in /proc/<pid>/stat, so parse from the last ')'."""
+    from IPython.core import kitty
+
+    monkeypatch.setattr(os, "getppid", lambda: 5)
+    monkeypatch.setattr(
+        kitty,
+        "_read_proc_stat",
+        _fake_proc({5: ("we (ird) name", 1), 1: ("init", 0)}),
+    )
+    assert list(kitty._proc_ancestor_names()) == ["we (ird) name", "init"]
+
+
+def test_proc_ancestor_names_stops_when_an_ancestor_is_unreadable(monkeypatch):
+    """`hidepid` makes ancestors of other users unreadable; stop, don't raise."""
+    from IPython.core import kitty
+
+    monkeypatch.setattr(os, "getppid", lambda: 42)
+    monkeypatch.setattr(kitty, "_read_proc_stat", _fake_proc({42: ("bash", 7)}))
+    assert list(kitty._proc_ancestor_names()) == ["bash"]
+
+
+def test_supports_kitty_graphics_finds_terminal_through_proc(monkeypatch):
+    from IPython.core import kitty
+
+    monkeypatch.delenv("IPYTHON_KITTY_GRAPHICS", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(sys, "stdout", StdoutTTY())
+    monkeypatch.setattr(os.path, "isdir", lambda path: path == "/proc/self")
+    monkeypatch.setattr(os, "getppid", lambda: 42)
+    monkeypatch.setattr(
+        kitty,
+        "_read_proc_stat",
+        _fake_proc({42: ("bash", 7), 7: ("ghostty", 1), 1: ("init", 0)}),
+    )
+    assert kitty._supports_kitty_graphics() is True
+
+
+def test_supports_kitty_graphics_does_not_import_psutil_on_linux(monkeypatch):
+    """The /proc walk exists to keep psutil -- and its import cost -- out."""
+    code = """
+import os, sys, builtins
+
+real_import = builtins.__import__
+
+def no_psutil(name, *args, **kwargs):
+    assert name != "psutil", "psutil must not be imported by kitty detection"
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = no_psutil
+
+
+class StdoutTTY:
+    def write(self, *args, **kwargs):
+        pass
+
+    def flush(self):
+        pass
+
+    def isatty(self):
+        return True
+
+
+sys.stdout = StdoutTTY()
+sys.platform = "linux"
+from IPython.core import kitty
+
+kitty._supports_kitty_graphics()
+assert "psutil" not in sys.modules
+"""
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ)
+    env.pop("IPYTHON_KITTY_GRAPHICS", None)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sys
 import tempfile
+import importlib
 from contextlib import contextmanager
 from importlib import reload
 from os.path import abspath, join
@@ -27,25 +28,12 @@ from IPython.testing.decorators import (
 from IPython.testing.tools import make_tempfile
 from IPython.utils import path
 
-# Platform-dependent imports
-try:
-    import winreg as wreg
-except ImportError:
-    # Fake _winreg module on non-windows platforms
-    import types
-
-    wr_name = "winreg"
-    sys.modules[wr_name] = types.ModuleType(wr_name)
-    try:
-        import winreg as wreg
-    except ImportError:
-        import _winreg as wreg
-
-        # Add entries that needs to be stubbed by the testing code
-        (
-            wreg.OpenKey,
-            wreg.QueryValueEx,
-        ) = (None, None)
+# Platform-dependent imports. Only `test_get_home_dir_8` needs `winreg`, and
+# that test only runs on Windows; a stub module registered in `sys.modules`
+# here would stay there for the rest of the session, and any stdlib module
+# that probes for `winreg` later (`mimetypes` does) would find it and believe
+# it is running on Windows.
+wreg = importlib.import_module("winreg") if sys.platform == "win32" else None
 
 # -----------------------------------------------------------------------------
 # Globals

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -1,6 +1,7 @@
 """Tests for small IPython.utils modules: data, timing, frame and encoding."""
 
 import importlib
+import locale
 import sys
 import time
 import types
@@ -199,9 +200,7 @@ def test_getdefaultencoding_from_stdin(monkeypatch):
 
 def test_getdefaultencoding_prefers_locale_over_ascii(monkeypatch):
     monkeypatch.setattr(sys, "stdin", FakeStream("ascii"))
-    monkeypatch.setattr(
-        encoding_mod.locale, "getpreferredencoding", lambda: "latin-1"
-    )
+    monkeypatch.setattr(locale, "getpreferredencoding", lambda: "latin-1")
     assert encoding_mod.getdefaultencoding() == "latin-1"
 
 
@@ -211,13 +210,13 @@ def test_getdefaultencoding_locale_error(monkeypatch):
         raise RuntimeError("no locale")
 
     monkeypatch.setattr(sys, "stdin", FakeStream("ascii"))
-    monkeypatch.setattr(encoding_mod.locale, "getpreferredencoding", boom)
+    monkeypatch.setattr(locale, "getpreferredencoding", boom)
     assert encoding_mod.getdefaultencoding() == "ascii"
 
 
 def test_getdefaultencoding_falls_back_to_sys(monkeypatch):
     monkeypatch.setattr(sys, "stdin", FakeStream(None))
-    monkeypatch.setattr(encoding_mod.locale, "getpreferredencoding", lambda: "")
+    monkeypatch.setattr(locale, "getpreferredencoding", lambda: "")
     assert encoding_mod.getdefaultencoding() == sys.getdefaultencoding()
 
 


### PR DESCRIPTION
This PR continues the effort to reduce IPython's startup time by moving more work off the critical path. The changes focus on deferring imports and computations that are not needed until they're actually used.

## Key Changes

* **Kitty graphics detection optimization**: On Linux, the process tree walk now reads `/proc/<pid>/stat` directly instead of importing psutil, avoiding ~10ms of startup overhead. The psutil fallback is retained for macOS and systems without `/proc`.

* **Pygments style resolution optimization**: Resolving a theme's base pygments style no longer imports `pygments.styles` and its plugin machinery for builtin styles. The style modules are read directly for the handful of builtin styles IPython uses, while plugin styles still resolve through the normal path.

* **Lazy prompt style building**: The prompt style is now built on first use rather than being rebuilt multiple times during shell initialization. This is particularly beneficial for non-interactive runs that never draw a prompt.

* **Operator dunder mapping extraction**: Moved `BINARY_OP_DUNDERS`, `COMP_OP_DUNDERS`, `UNARY_OP_DUNDERS`, and `_find_dunder` from `guarded_eval.py` to a new `_dunder_ops.py` module. This allows terminal shortcut filters to resolve operators without importing the entire guarded evaluation machinery and its dependencies (`typing_extensions`, `dataclasses`, `inspect`).

* **Single-use imports deferred**: Moved imports of `platform`, `pprint`, `textwrap`, `html`, `mimetypes`, `locale`, `glob`, and `runpy` to their actual use sites rather than module level.

* **Test improvements**: Enhanced test coverage for the new `/proc`-based process detection with comprehensive tests for edge cases (spaces in process names, unreadable ancestors, etc.). Added a test verifying psutil is not imported on Linux.

## Performance Impact

These changes collectively reduce startup time by approximately 13% for interactive `ipython` in a real terminal, 9% for `ipython -c pass`, and eliminate ~43 modules from an interactive start, building on previous optimization rounds.

## Implementation Details

- The `/proc` reading implementation handles process names with spaces and parentheses by parsing from the last `)` character in `/proc/<pid>/stat`
- Permission errors when reading `/proc` (from `hidepid` on multi-user systems) are handled gracefully by stopping the ancestor walk
- Pygments style module execution is isolated and not registered in `sys.modules` to avoid breaking later import statements
- The prompt style cache uses a private attribute with property accessors to ensure lazy initialization
