### PR TITLE
Surface malformed number literal errors as syntax errors in check_complete

### DIFF
--- a/IPython/utils/tokenutil.py
+++ b/IPython/utils/tokenutil.py
@@ -38,6 +38,15 @@ def generate_tokens_catch_errors(
         "unterminated string literal",
         "invalid non-printable character",
         "after line continuation character",
+        # Since Python 3.12 the tokenizer raises TokenError for malformed
+        # number literals (e.g. 0b12, 0o1239, 1__2).  Those are syntax
+        # errors, not incomplete input (see ipython/ipython#15320).
+        "invalid decimal literal",
+        "invalid binary literal",
+        "invalid octal literal",
+        "invalid hexadecimal literal",
+        "in binary literal",
+        "in octal literal",
     ]
     assert extra_errors_to_catch is None or isinstance(extra_errors_to_catch, list)
     errors_to_catch = default_errors_to_catch + (extra_errors_to_catch or [])

--- a/tests/test_inputtransformer2.py
+++ b/tests/test_inputtransformer2.py
@@ -319,6 +319,17 @@ examples = [
     pytest.param("for a in range(5):", "incomplete", 4),
     pytest.param("for a in range(5):\n    if a > 0:", "incomplete", 8),
     pytest.param("raise = 2", "invalid", None),
+    # Invalid number literals (ipython/ipython#15320): on Python <= 3.11 the
+    # tokenizer splits these into separate tokens and compilation fails;
+    # since Python 3.12 the tokenizer raises TokenError for malformed
+    # literals, which must be surfaced as a syntax error, not mistaken for
+    # incomplete input (0x123g is "invalid" on every version via the
+    # compile path; it guards the surrounding tokenizer-regression rows).
+    pytest.param("0b12", "invalid", None),
+    pytest.param("0o1239", "invalid", None),
+    pytest.param("0x123g", "invalid", None),
+    pytest.param("0b12+1", "invalid", None),
+    pytest.param("(0b12)", "invalid", None),
     pytest.param("a = [1,\n2,", "incomplete", 0),
     extra_closing_paren_param,
     pytest.param("\\\r\n", "incomplete", 0),

--- a/tests/test_tokenutil.py
+++ b/tests/test_tokenutil.py
@@ -3,10 +3,18 @@
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import pytest
+import io
+import sys
 import textwrap
+import tokenize
 
-from IPython.utils.tokenutil import token_at_cursor, line_at_cursor
+import pytest
+
+from IPython.utils.tokenutil import (
+    generate_tokens_catch_errors,
+    line_at_cursor,
+    token_at_cursor,
+)
 
 
 def expect_token(expected: str, cell: str, cursor_pos: int | None = None) -> None:
@@ -181,3 +189,33 @@ int()
 map()
 """
     expect_token(token, cell, c)
+
+
+def test_generate_tokens_catch_errors_eof_reraised():
+    # A genuine end-of-input error is still re-raised: the input is
+    # incomplete, not invalid.
+    with pytest.raises(tokenize.TokenError):
+        list(generate_tokens_catch_errors(io.StringIO("'''abc\n").readline))
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="the tokenizer only raises these errors since 3.12",
+)
+@pytest.mark.parametrize(
+    "cell",
+    [
+        "'abc\n",  # unterminated string literal
+        "0b12\n",  # invalid digit in binary literal (ipython/ipython#15320)
+        "0o1239\n",  # invalid digit in octal literal
+        "1__2\n",  # invalid decimal literal
+        "0b\n",  # invalid binary literal
+        "0xg\n",  # invalid hexadecimal literal
+    ],
+)
+def test_generate_tokens_catch_errors_yields_errortoken(cell):
+    # Hard tokenizer errors are converted into an ERRORTOKEN instead of
+    # propagating, so that check_complete reports a syntax error rather
+    # than hanging on incomplete input (ipython/ipython#15320).
+    tokens = list(generate_tokens_catch_errors(io.StringIO(cell).readline))
+    assert tokens[-1].type == tokenize.ERRORTOKEN


### PR DESCRIPTION
Fixes #15320

Since Python 3.12 the stdlib tokenizer raises `TokenError` for malformed
number literals (e.g. `invalid digit '2' in binary literal` for `0b12`),
where older versions silently split them into separate tokens.
`generate_tokens_catch_errors` did not recognize these messages, so the
error was re-raised, swallowed by `make_tokens_by_line`, and the token
stream ended without an `ENDMARKER` — `check_complete` reported such input
as `incomplete` and the terminal REPL kept waiting at the `...:`
continuation prompt instead of raising `SyntaxError`.

Teach `generate_tokens_catch_errors` to convert this family of tokenizer
errors into an `ERRORTOKEN`, like the other hard tokenizer errors it
already handles, so the existing `ERRORTOKEN` path in `check_complete`
reports the input as `invalid`. Genuine end-of-input errors (unterminated
multiline strings or expressions) are still re-raised and reported as
`incomplete`.

Tests:
- new `check_complete` cases for `0b12`, `0o1239`, `0x123g`, `0b12+1`,
  `(0b12)` asserting `invalid` (the tokenizer-regression rows encode the
  3.12+ behavior while staying identical on Python <= 3.11; `0x123g` is
  `invalid` on every version via the compile path),
- new `generate_tokens_catch_errors` tests: hard tokenizer errors yield
  an `ERRORTOKEN` (3.12+), genuine EOF errors are still re-raised.
