### PR TITLE
docs: hide Edit on GitHub link for autogenerated API pages

### DIFF
--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -263,7 +263,7 @@ class ApiDocWriter:
         # titles
         uri_short = re.sub(r'^%s\.' % self.package_name,'',uri)
 
-        ad = '.. AUTO-GENERATED FILE -- DO NOT EDIT!\n\n'
+        ad = ':github_url: hide\n\n.. AUTO-GENERATED FILE -- DO NOT EDIT!\n\n'
 
         # Set the chapter title to read 'Module:' for all modules except for the
         # main packages

--- a/docs/sphinxext/apigen.py
+++ b/docs/sphinxext/apigen.py
@@ -263,7 +263,7 @@ class ApiDocWriter:
         # titles
         uri_short = re.sub(r'^%s\.' % self.package_name,'',uri)
 
-        ad = ':github_url: hide\n\n.. AUTO-GENERATED FILE -- DO NOT EDIT!\n\n'
+        ad = ":github_url: hide\n\n.. AUTO-GENERATED FILE -- DO NOT EDIT!\n\n"
 
         # Set the chapter title to read 'Module:' for all modules except for the
         # main packages


### PR DESCRIPTION
Closes #11919\n\nThe docs/source/_templates/breadcrumbs.html template already suppresses the "Edit on GitHub" link for pages under `api/generated/`, but it also respects a `:github_url: hide` page metadata flag. This change adds that metadata to the RST files produced by `docs/sphinxext/apigen.py` so the broken edit link is hidden on the autogenerated API pages built by ReadTheDocs.\n\nVerified by running `python docs/autogen_api.py` in a fresh venv and confirming that generated files start with `:github_url: hide`.\n\nNote: this change was prepared with assistance from Claude (Anthropic).