### PR TITLE
Name the argument _get_conda_like_executable actually takes

### DIFF
--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -39,7 +39,7 @@ def _get_conda_like_executable(command):
     Parameters
     ----------
 
-    executable: string
+    command: string
         Value should be: conda, mamba or micromamba
     """
     # Check for a environment variable bound to the base executable, both conda and mamba


### PR DESCRIPTION
`_get_conda_like_executable` takes `command` and documents `executable`. The three call sites pass `"conda"`, `"mamba"` and `"micromamba"`, so the description is right and only the name is off.

That is the whole change. I checked the rest of the tree while I was there: 179 functions carry a `Parameters` section and this was the only name that does not match its signature. The four others my checker flagged are the magics, where `Parameters` documents the command flags rather than the Python arguments, and those are fine as they are.
