### PR TITLE
Preserve source line numbers in deduperreload reloaded functions

### DIFF
--- a/IPython/extensions/deduperreload/deduperreload.py
+++ b/IPython/extensions/deduperreload/deduperreload.py
@@ -8,7 +8,6 @@ import os
 import pickle
 import platform
 import sys
-import textwrap
 import tokenize
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -446,10 +445,12 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
                 if isinstance(to_patch_to, (staticmethod, classmethod)):
                     to_patch_to = to_patch_to.__func__
                 # exec new source code using old function's (obj) globals environment.
-                func_code = textwrap.dedent(ast.unparse(new_ast_def))
                 if is_method := (len(prefixes) > 0):
-                    func_code = "class __autoreload_class__:\n" + textwrap.indent(
-                        func_code, "    "
+                    # Wrap in a class so the method binds `self`. Operate on the AST
+                    # node directly (rather than unparse + reparse) below to keep the
+                    # original source line numbers in tracebacks. See #15359.
+                    new_ast_def = ast.ClassDef(
+                        name="__autoreload_class__", body=[new_ast_def]
                     )
                 global_env = ns.__dict__
                 if not isinstance(global_env, dict):
@@ -460,7 +461,10 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
                     and to_patch_to.__code__.co_filename
                     or "<string>"
                 )
-                func_asts = [ast.parse(func_code)]
+                # Wrap in a Module (what ast.parse returns) so compile() accepts it,
+                # while keeping the original AST node and its line numbers. See #15359.
+                func_asts = [ast.Module(body=[new_ast_def], type_ignores=[])]
+                ast.fix_missing_locations(func_asts[0])
                 if len(cast(ast.FunctionDef, func_asts[0].body[0]).decorator_list) > 0:
                     without_decorator_list = pickle.loads(pickle.dumps(func_asts[0]))
                     cast(

--- a/IPython/extensions/tests/test_deduperreload.py
+++ b/IPython/extensions/tests/test_deduperreload.py
@@ -2308,3 +2308,32 @@ def test_reload_enums(shell_fixture):
     )
     shell_fixture.shell.run_code("pass")
     assert mod.MyEnum.C.value == "C"
+
+
+def test_deduperreload_preserves_source_line_numbers(shell_fixture):
+    """Reloaded functions keep their original source line numbers (#15359).
+
+    Previously the function AST was unparsed to source and re-parsed before
+    exec, which reset line information and made tracebacks point at the wrong
+    line. The def is on line 3 of the (squish_text-preserved) source.
+    """
+    shell_fixture.shell.magic_autoreload("2")
+    src_v1 = """
+        # leading comment so the def is not on line 1
+
+        def foo():
+            raise ValueError("v1")
+    """
+    src_v2 = """
+        # leading comment so the def is not on line 1
+
+        def foo():
+            raise ValueError("v2")
+    """
+    mod_name, mod_fn = shell_fixture.new_module(src_v1)
+    shell_fixture.shell.run_code(f"import {mod_name}")
+    shell_fixture.shell.run_code("pass")
+    shell_fixture.write_file(mod_fn, src_v2)
+    shell_fixture.shell.run_code("pass")
+    mod = sys.modules[mod_name]
+    assert mod.foo.__code__.co_firstlineno == 3


### PR DESCRIPTION
## Problem

`DeduperReloader._patch_namespace_inner` unparsed the new function AST to source (`textwrap.dedent(ast.unparse(new_ast_def))`) and re-parsed it before `exec`. That round-trip discards the original source line numbers, so reloading a function resets its line information and tracebacks point at the wrong line — the offset within the unparsed text rather than the source file (#15359).

## Fix

Operate on the AST node directly instead of unparse→reparse:

```diff
-                func_code = textwrap.dedent(ast.unparse(new_ast_def))
                 if is_method := (len(prefixes) > 0):
-                    func_code = "class __autoreload_class__:\n" + textwrap.indent(func_code, "    ")
+                    new_ast_def = ast.ClassDef(name="__autoreload_class__", body=[new_ast_def])
                 ...
-                func_asts = [ast.parse(func_code)]
+                func_asts = [ast.Module(body=[new_ast_def], type_ignores=[])]
+                ast.fix_missing_locations(func_asts[0])
```

The function node keeps its original `lineno`, so tracebacks point at the right line. The `ast.Module` wrap keeps the structure `ast.parse` returns (so the existing decorator-list check on `func_asts[0].body[0]` is unchanged and `compile()` accepts it).

This builds on the direction sketched by @yut23 in #15359, but that snippet set `func_asts = [new_ast_def]`, which `compile(..., mode="exec")` rejects (`TypeError: expected Module node, got FunctionDef/ClassDef`); wrapping in `ast.Module` is what makes it actually run. Also drops the now-unused `textwrap` import.

## Verification

The unparse→reparse reset is reproducible directly:

```
src: def line 3, raise line 5
OLD unparse:    func lineno=1, raise lineno=3   (renumbered — wrong)
NEW Module-wrap: compile OK, traceback -> "line 5, in f"   (preserved)
```

`squish_text` keeps the leading comment + blank line, so the `def` is on line 3 of the reloaded source; added `test_deduperreload_preserves_source_line_numbers` asserting the reloaded `foo.__code__.co_firstlineno == 3` (it would be `1` with the old unparse path).

(The repo's editable `[test]` build failed in my local venv, so the new test wasn't executed locally — the mechanism is verified via the AST round-trip above and the line-number is pinned by `squish_text`. CI will run it.)

Closes #15359