### PR TITLE
Fix #15132: preserve sys.exit() exit codes in non-interactive mode

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -482,6 +482,17 @@ class InteractiveShellApp(Configurable):
                     self.exit(2)
             try:
                 self._exec_file(fname, shell_futures=True)
+            except SystemExit as e:
+                if not self.interact:
+                    # Preserve the exit code requested by the script (issue
+                    # #15132). SystemExit is not an Exception, so we handle it
+                    # before the bare except: below which is for real errors.
+                    exit_code = 1
+                    if isinstance(e.code, int):
+                        exit_code = e.code
+                    elif e.code is None:
+                        exit_code = 0
+                    self.exit(exit_code)
             except Exception:
                 self.shell.showtraceback(tb_offset=4)
                 if not self.interact:

--- a/IPython/terminal/ipapp.py
+++ b/IPython/terminal/ipapp.py
@@ -328,7 +328,19 @@ class TerminalIPythonApp(BaseIPythonApplication, InteractiveShellApp):
             self.log.debug("IPython not interactive...")
             self.shell.restore_term_title()
             if not self.shell.last_execution_succeeded:
-                sys.exit(1)
+                # Preserve the original exit code when the user called
+                # sys.exit(N) (issue #15132). InteractiveShell catches the
+                # SystemExit and stores it on last_execution_result; default
+                # to 1 only for genuine execution failures.
+                exit_code = 1
+                result = self.shell.last_execution_result
+                if result is not None and isinstance(result.error_in_exec, SystemExit):
+                    code = result.error_in_exec.code
+                    if isinstance(code, int):
+                        exit_code = code
+                    elif code is None:
+                        exit_code = 0
+                sys.exit(exit_code)
 
 def load_default_config(ipython_dir=None):
     """Load the default config file from the default ipython_dir.

--- a/tests/test_shellapp.py
+++ b/tests/test_shellapp.py
@@ -15,6 +15,7 @@ Authors
 # -----------------------------------------------------------------------------
 # Imports
 # -----------------------------------------------------------------------------
+import subprocess
 import sys
 
 import pytest
@@ -141,3 +142,52 @@ def test_init_shell_not_implemented():
 
     with pytest.raises(NotImplementedError):
         InteractiveShellApp().init_shell()
+
+
+# -----------------------------------------------------------------------------
+# Exit-code preservation (issue #15132)
+# -----------------------------------------------------------------------------
+
+
+def _ipython_exit_code(*args):
+    """Run ``python -m IPython [args]`` and return the subprocess exit code."""
+    cmd = [sys.executable, "-m", "IPython"] + tt.default_argv() + list(args)
+    return subprocess.call(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+
+
+def test_sys_exit_preserves_code_zero():
+    assert _ipython_exit_code("-c", "import sys; sys.exit(0)") == 0
+
+
+def test_sys_exit_preserves_code_one():
+    assert _ipython_exit_code("-c", "import sys; sys.exit(1)") == 1
+
+
+def test_sys_exit_preserves_code_two():
+    # Regression test for issue #15132: previously this returned 1.
+    assert _ipython_exit_code("-c", "import sys; sys.exit(2)") == 2
+
+
+def test_sys_exit_preserves_arbitrary_code():
+    assert _ipython_exit_code("-c", "import sys; sys.exit(42)") == 42
+
+
+def test_sys_exit_no_arg_returns_zero():
+    # ``sys.exit()`` with no argument means exit code 0.
+    assert _ipython_exit_code("-c", "import sys; sys.exit()") == 0
+
+
+def test_normal_execution_returns_zero():
+    assert _ipython_exit_code("-c", "print('hello')") == 0
+
+
+def test_sys_exit_in_script_file(tmp_pyfile):
+    fname = tmp_pyfile("import sys; sys.exit(2)\n")
+    assert _ipython_exit_code("--", fname) == 2
+
+
+def test_sys_exit_zero_in_script_file(tmp_pyfile):
+    fname = tmp_pyfile("import sys; sys.exit(0)\n")
+    assert _ipython_exit_code("--", fname) == 0


### PR DESCRIPTION
Fixes #15132

When running `ipython -c "import sys;sys.exit(N)"` or executing a script via `ipython script.py` that calls `sys.exit(N)`, IPython returned exit code 1 instead of the value passed to `sys.exit()`. The exit code was hardcoded in two places:

- `IPython/terminal/ipapp.py` — `TerminalIPythonApp.start()` called `sys.exit(1)` whenever the last execution failed, regardless of whether the failure was a `SystemExit` raised by user code.
- `IPython/core/shellapp.py` — `_run_cmd_line_code()` had the same hardcoded `self.exit(1)` for file execution errors.

This change extracts the original exit code from the `SystemExit` exception that `InteractiveShell` stores on `last_execution_result.error_in_exec` (and that `_exec_file` raises in the file path), and propagates it to the process exit. Exit code 1 is preserved only for genuine execution failures that aren't `SystemExit`.

Behavior:
- `sys.exit(0)` / `sys.exit()` → exit code 0
- `sys.exit(N)` for any integer `N` → preserves `N`
- Non-`SystemExit` execution failures → exit code 1 (unchanged)
- `SystemExit` in script file path → exits quietly, no traceback

## AI disclosure

This PR was authored with assistance from Claude (Anthropic). The implementation, tests, and review were AI-assisted.

Co-Authored-By: Claude <noreply@anthropic.com>