### PR TITLE
Fix local image URL when not embedding

### DIFF
--- a/IPython/core/display.py
+++ b/IPython/core/display.py
@@ -1067,8 +1067,9 @@ class Image(DisplayObject):
                 klass = ' class="unconfined"'
             if self.alt:
                 alt = ' alt="%s"' % html.escape(self.alt)
+            url = self.url if self.url is not None else self.filename
             return '<img src="{url}"{width}{height}{klass}{alt}/>'.format(
-                url=html.escape(self.url or ""),
+                url=html.escape(url or ""),
                 width=width,
                 height=height,
                 klass=klass,

--- a/tests/test_display_2.py
+++ b/tests/test_display_2.py
@@ -37,6 +37,13 @@ def test_image_size():
     assert '<img src="%s" class="unconfined"/>' % (thisurl) == img._repr_html_()
 
 
+def test_image_local_file_url_without_embedding():
+    """A local image requested without embedding keeps its file URL."""
+    filename = os.path.join(os.path.dirname(__file__), "2x2.png")
+    img = display.Image(filename=filename, embed=False)
+    assert f'<img src="{filename}"/>' == img._repr_html_()
+
+
 def test_image_mimes():
     fmt = get_ipython().display_formatter.format
     for name, format in ImageFormat.__members__.items():


### PR DESCRIPTION
Fixes #13971

## Summary

When `Image` is constructed with a local `filename` and `embed=False`, the path is stored in `filename` while `url` is unset. Use the local filename as the HTML image source when no URL is present.

Add regression coverage for the non-embedded local-file path.