### PR TITLE
Preserve source line numbers when deduperreload patches functions

### DIFF
--- a/IPython/extensions/deduperreload/deduperreload.py
+++ b/IPython/extensions/deduperreload/deduperreload.py
@@ -8,7 +8,6 @@ import os
 import pickle
 import platform
 import sys
-import textwrap
 import tokenize
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -446,11 +445,21 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
                 if isinstance(to_patch_to, (staticmethod, classmethod)):
                     to_patch_to = to_patch_to.__func__
                 # exec new source code using old function's (obj) globals environment.
-                func_code = textwrap.dedent(ast.unparse(new_ast_def))
+                # Methods are exec'd inside a synthetic class so that ``super()``
+                # and zero-arg ``__class__`` closures keep working.
                 if is_method := (len(prefixes) > 0):
-                    func_code = "class __autoreload_class__:\n" + textwrap.indent(
-                        func_code, "    "
+                    # compile() requires every statement node to carry
+                    # position info; derive it from the wrapped method.
+                    wrapped = new_ast_def
+                    new_ast_def = ast.ClassDef(
+                        name="__autoreload_class__",
+                        bases=[],
+                        keywords=[],
+                        body=[wrapped],
+                        decorator_list=[],
                     )
+                    new_ast_def.lineno = wrapped.lineno
+                    new_ast_def.col_offset = wrapped.col_offset
                 global_env = ns.__dict__
                 if not isinstance(global_env, dict):
                     global_env = dict(global_env)
@@ -460,7 +469,12 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
                     and to_patch_to.__code__.co_filename
                     or "<string>"
                 )
-                func_asts = [ast.parse(func_code)]
+                # Wrap in a module so the downstream ``func_asts[0].body[0]``
+                # accesses keep working. Reusing the freshly-parsed AST node
+                # (rather than unparse/re-indent/re-parse) preserves the
+                # original source line numbers, so tracebacks from reloaded
+                # code point at the real lines (#15359).
+                func_asts = [ast.Module(body=[new_ast_def], type_ignores=[])]
                 if len(cast(ast.FunctionDef, func_asts[0].body[0]).decorator_list) > 0:
                     without_decorator_list = pickle.loads(pickle.dumps(func_asts[0]))
                     cast(

--- a/IPython/extensions/tests/test_deduperreload.py
+++ b/IPython/extensions/tests/test_deduperreload.py
@@ -910,6 +910,57 @@ def test_deduperreloader_need_to_default_back(shell_fixture):
     assert mod.foo(0) == 5
 
 
+def test_deduperreloader_preserves_traceback_lines(shell_fixture):
+    """Tracebacks after a deduperreload point at the real source lines.
+
+    Regression test for #15359: the old implementation re-created the new
+    function's source text (unparse + re-indent + re-parse), which reset all
+    line numbers to 1. After reload, a traceback inside the function pointed
+    at the top of the file (typically a docstring) instead of the failing
+    line.
+    """
+    shell_fixture.shell.magic_autoreload("2")
+    mod_name, mod_fn = shell_fixture.new_module(
+        '''
+        """
+        This docstring sits on line 2 of the file; a traceback that
+        loses line numbers points here.
+        """
+        def func():
+            assert False, "v1"
+        ''',
+    )
+    shell_fixture.shell.run_code("import %s" % mod_name)
+    shell_fixture.shell.run_code("pass")
+    shell_fixture.write_file(
+        mod_fn,
+        '''
+        """
+        This docstring sits on line 2 of the file; a traceback that
+        loses line numbers points here.
+        """
+        def func():
+            assert False, "v2"
+        ''',
+    )
+    shell_fixture.shell.run_code("pass")
+    # Capture the traceback's file:line frame for func() after reload.
+    shell_fixture.shell.run_code(
+        "import traceback\n"
+        "import sys\n"
+        "result = None\n"
+        "try:\n"
+        "    %s.func()\n"
+        "except AssertionError:\n"
+        "    result = traceback.extract_tb(sys.exc_info()[2])[-1]" % mod_name
+    )
+    frame = shell_fixture.shell.user_ns["result"]
+    # The assert lives on line 6 of the squished module text
+    # (docstring on lines 2-4, def on line 5, assert on line 6).
+    assert frame.lineno == 6, f"got {frame}"
+    assert frame.name == "func"
+
+
 def test_deduperreloader_failure(shell_fixture):
     shell_fixture.shell.magic_autoreload("2")
     mod_name, mod_fn = shell_fixture.new_module(


### PR DESCRIPTION
## What

Fixes #15359 — after `%autoreload` patches a function via deduperreload, tracebacks point at the real source lines instead of the top of the file.

## Why

`DeduperReloader._patch_namespace_inner` rebuilt the replacement function's source text (`ast.unparse` → dedent → re-indent → `ast.parse`), which resets every line number to 1. The patched function's code object then reported `co_firstlineno == 1`, so a traceback pointed at the file's first lines — typically a docstring — rather than the failing statement:

```text
File /tmp/module.py:2, in func()
      1 """
----> 2 The traceback incorrectly points to this line (line 2 of the file)
      3 """
      4 def func():
      5     assert False, "after reload"
```

## How

Instead of round-tripping through text, wrap the **freshly-parsed AST node** directly:

- top-level functions: `ast.Module(body=[new_ast_def])`
- methods: wrap in a synthetic `ast.ClassDef(name="__autoreload_class__", ...)` (so `super()` and zero-arg `__class__` closures keep working), then wrap that in a module

Both keep the same `func_asts[0].body[0]` shape the downstream decorator handling expects, so the decorated-function path is unchanged. `compile()` requires position info on every node, so the synthetic `ClassDef` gets `lineno`/`col_offset` from the wrapped method. The `textwrap` import is no longer needed.

## Tests

Added `test_deduperreloader_preserves_traceback_lines` in `IPython/extensions/tests/test_deduperreload.py`: reloads a module whose function raises, then asserts the captured traceback frame is the real `assert` line (line 6) inside `func` — fails before the fix (points at the docstring line 2), passes after. Full deduperreload suite: 72 passed (was 71). Ruff and darker clean.

🤖 Generated with Codebuff
