### PR TITLE
Handle missing cwd when resetting history

### DIFF
--- a/IPython/core/history.py
+++ b/IPython/core/history.py
@@ -921,8 +921,8 @@ class HistoryManager(HistoryAccessor):
         self.outputs.clear()
         self.exceptions.clear()
 
-        # The directory history can't be completely empty
-        self.dir_hist[:] = [Path.cwd()]
+        # Use the same missing-CWD fallback as initial directory history.
+        self.dir_hist[:] = self._dir_hist_default()
 
         if new_session:
             if self.session_number:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -195,6 +195,27 @@ def test_history(hmmax2):
             ip.history_manager = hist_manager_ori
 
 
+def test_history_reset_without_cwd(tmp_path, monkeypatch):
+    ip = get_ipython()
+    history_manager = HistoryManager(
+        shell=ip,
+        hist_file=tmp_path / "history-no-cwd.sqlite",
+    )
+
+    def missing_cwd():
+        raise FileNotFoundError("current working directory was removed")
+
+    try:
+        with monkeypatch.context() as patcher:
+            patcher.setattr(Path, "cwd", missing_cwd)
+            history_manager.reset(new_session=False)
+
+        assert history_manager.dir_hist == []
+    finally:
+        history_manager.end_session()
+        history_manager.close()
+
+
 def test_extract_hist_ranges():
     instr = "1 2/3 ~4/5-6 ~4/7-~4/9 ~9/2-~7/5 ~10/"
     expected = [


### PR DESCRIPTION
🤖🍆

Fixes #12867

## Summary
- reuse HistoryManager's existing missing-CWD fallback when resetting directory history
- avoid raising FileNotFoundError when the process current directory has been removed
- add regression coverage for reset with Path.cwd() unavailable

<!-- pr-relay-job relay-90-4add774d000d636606dc -->