### PR TITLE
Only treat exact -m token as %run module option

### DIFF
--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -690,15 +690,16 @@ class ExecutionMagics(Magics):
         # Add '--' after '-m <module_name>' to ignore additional args passed to a module.
         if '-m' in parameter_s and '--' not in parameter_s:
             argv = shlex.split(parameter_s, posix=(os.name == 'posix'))
-            for idx, arg in enumerate(argv):
-                if arg and arg.startswith('-') and arg != '-':
-                    if arg == '-m':
-                        argv.insert(idx + 2, '--')
+            if '-m' in argv:
+                for idx, arg in enumerate(argv):
+                    if arg and arg.startswith('-') and arg != '-':
+                        if arg == '-m':
+                            argv.insert(idx + 2, '--')
+                            break
+                    else:
+                        # Positional arg, break
                         break
-                else:
-                    # Positional arg, break
-                    break
-            parameter_s = shlex.join(argv)
+                parameter_s = shlex.join(argv)
 
         # get arguments and set sys.argv for program to be run.
         opts, arg_lst = self.parse_options(parameter_s,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -251,6 +251,21 @@ def test_simpledef(run_tmpfile):
     assert _ip.user_ns["t"] is True
 
 
+def test_run_path_containing_dash_m_is_not_rewritten(tmp_path, monkeypatch):
+    script_dir = tmp_path / "test-main"
+    script_dir.mkdir()
+    script = script_dir / "script.py"
+    script.write_text("dash_m_path_ran = True\n", encoding="utf-8")
+
+    def fail_join(_argv):
+        raise AssertionError("ordinary script path should not be rewritten")
+
+    monkeypatch.setattr("IPython.core.magics.execution.shlex.join", fail_join)
+    _ip = get_ipython()
+    _ip.run_line_magic("run", str(script))
+    assert _ip.user_ns["dash_m_path_ran"] is True
+
+
 @pytest.mark.xfail(
     platform.python_implementation() == "PyPy",
     reason="expecting __del__ call on exit is unreliable and doesn't happen on PyPy",


### PR DESCRIPTION
🤖🍆

Fixes #14849

## Summary
- only run the special `%run -m` rewrite when `-m` is an exact parsed token
- leave ordinary script paths containing `-m` unchanged
- add a regression test that fails if an ordinary path is rewritten

## Testing
- Not run locally; added focused regression coverage for the reported path case.

<!-- pr-relay-job relay-97-2d69c19f1f32dc87434f -->