### PR TITLE
Skip instance migration for identical autoreload types

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -374,6 +374,9 @@ def update_instances(old, new):
     class definition and update their __class__ to point to the new class
     definition"""
 
+    if old is new:
+        return
+
     refs = gc.get_referrers(old)
 
     for ref in refs:

--- a/tests/test_zzz_autoreload.py
+++ b/tests/test_zzz_autoreload.py
@@ -23,12 +23,13 @@ import random
 import time
 import traceback
 import types
+from functools import partial
 from io import StringIO
 from dataclasses import dataclass
 
 import IPython.testing.tools as tt
 
-from IPython.extensions.autoreload import AutoreloadMagics
+from IPython.extensions.autoreload import AutoreloadMagics, update_instances
 from IPython.core.events import EventManager, pre_run_cell
 from IPython.testing.decorators import skipif_not_numpy
 from IPython.core.interactiveshell import ExecutionInfo
@@ -162,6 +163,12 @@ def autoreload_fixture():
 # -----------------------------------------------------------------------------
 # Test automatic reloading
 # -----------------------------------------------------------------------------
+
+
+def test_update_instances_skips_identical_types():
+    instance = partial(int, base=16)
+    update_instances(partial, partial)
+    assert instance("10") == 16
 
 
 def pickle_get_current_class(obj):


### PR DESCRIPTION
🤖🍆

Fixes #14984

## Summary
- skip instance migration when autoreload resolves the old and new class to the same object
- avoid invalid `__class__` assignment for immutable/builtin extension types such as `functools.partial`
- add focused regression coverage for the identical-type path

## Testing
- Not run locally; added a direct regression test for `update_instances(partial, partial)`.

<!-- pr-relay-job relay-99-6c1b8fd0a0f155676cec -->