### PR TITLE
fix: allow pastebin options after arguments

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import os
 import re
 import sys
-from getopt import getopt, GetoptError
+from getopt import GetoptError, getopt, gnu_getopt
 
 from traitlets.config.configurable import Configurable
 from .error import UsageError
@@ -713,6 +713,9 @@ class Magics(Configurable):
             Whether to split the input line in POSIX mode or not, as per the
             conventions outlined in the :mod:`shlex` module from the standard
             library.
+        interspersed : bool, default False
+            Whether options may appear after non-option arguments. The default
+            preserves the historical option parsing behavior.
         """
 
         # inject default options at the beginning of the input line
@@ -726,6 +729,7 @@ class Magics(Configurable):
         list_all = kw.get("list_all", 0)
         posix = kw.get("posix", os.name == "posix")
         strict = kw.get("strict", True)
+        interspersed = kw.get("interspersed", False)
 
         preserve_non_opts = kw.get("preserve_non_opts", False)
         remainder_arg_str = arg_str
@@ -740,7 +744,8 @@ class Magics(Configurable):
             argv = arg_split(arg_str, posix, strict)
             # Do regular option processing
             try:
-                opts, args = getopt(argv, opt_str, long_opts)
+                parser = gnu_getopt if interspersed else getopt
+                opts, args = parser(argv, opt_str, long_opts)
             except GetoptError as e:
                 raise UsageError(
                     '%s (allowed: "%s"%s)'

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -280,7 +280,7 @@ class CodeMagics(Magics):
         from urllib.parse import urlencode
         from urllib.request import Request
 
-        opts, args = self.parse_options(parameter_s, "d:e:")
+        opts, args = self.parse_options(parameter_s, "d:e:", interspersed=True)
 
         try:
             code = self.shell.find_user_code(args)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -204,6 +204,19 @@ def test_magic_parse_long_options():
     assert opts["bar"] == "bubble"
 
 
+def test_magic_parse_options_interspersed_is_opt_in():
+    ip = get_ipython()
+    m = DummyMagics(ip)
+
+    opts, args = m.parse_options('1 -d "later"', "d:")
+    assert "d" not in opts
+    assert args == '1 -d later'
+
+    opts, args = m.parse_options('1 -d "later"', "d:", interspersed=True)
+    assert opts["d"] == "later"
+    assert args == "1"
+
+
 def doctest_hist_f():
     """Test %hist -f with temporary filename.
 


### PR DESCRIPTION
Fixes #13059

Adds opt-in interspersed option parsing and enables it for %pastebin, so options such as -d work before or after the history/file argument without changing other magics' parsing behavior.

Tests: focused pytest regression (2 passed); changed Python modules compile cleanly.

<!-- pr-relay-job relay-108-d73ca5573da0b49431d3 -->