### PR TITLE
fix: defer nonlocal binding completeness error

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -896,8 +896,11 @@ class TransformerManager:
             with warnings.catch_warnings():
                 warnings.simplefilter("error", SyntaxWarning)
                 res = compile_command("".join(lines), symbol="exec")
+        except SyntaxError as exc:
+            if exc.msg.startswith("no binding for nonlocal ") and lines[-1].strip():
+                return "incomplete", find_last_indent(lines)
+            return "invalid", None
         except (
-            SyntaxError,
             OverflowError,
             ValueError,
             TypeError,

--- a/tests/test_inputtransformer2.py
+++ b/tests/test_inputtransformer2.py
@@ -346,6 +346,19 @@ def test_check_complete_param(code, expected, number):
     assert cc(code) == (expected, number)
 
 
+def test_check_complete_defers_nonlocal_binding_error():
+    cc = ipt2.TransformerManager().check_complete
+    partial = "def a():\n    def b():\n        nonlocal c"
+    complete = (
+        partial
+        + "\n        return c + 1\n    c = 1\n    b()\n    return c\n"
+    )
+
+    assert cc(partial) == ("incomplete", 8)
+    assert cc(partial + "\n\n") == ("invalid", None)
+    assert cc(complete) == ("complete", None)
+
+
 @pytest.mark.xfail(platform.python_implementation() == "PyPy", reason="fail on pypy")
 def test_check_complete():
     cc = ipt2.TransformerManager().check_complete


### PR DESCRIPTION
Fixes #12408

Treats a missing nonlocal binding as incomplete while the enclosing interactive block is still open, then reports it invalid once the block is terminated without a binding.

Tests: focused pytest regression (2 passed); changed Python module compiles cleanly.

<!-- pr-relay-job relay-110-21a373625b8b59c1bab8 -->