### PR TITLE
Fix cell magic help completion

### DIFF
--- a/IPython/core/inputtransformer2.py
+++ b/IPython/core/inputtransformer2.py
@@ -827,6 +827,10 @@ class TransformerManager:
             return "invalid", None
 
         if lines[0].startswith("%%"):
+            # Help queries are complete without a blank line.
+            if len(lines) == 1 and re.match(r"^%%\w+\?{1,2}\s*$", lines[0]):
+                return "complete", None
+
             # Special case for cell magics - completion marked by blank line
             if lines[-1].strip():
                 return "incomplete", find_last_indent(lines)

--- a/tests/test_inputtransformer2.py
+++ b/tests/test_inputtransformer2.py
@@ -319,6 +319,8 @@ examples = [
     pytest.param("for a in range(5):", "incomplete", 4),
     pytest.param("for a in range(5):\n    if a > 0:", "incomplete", 8),
     pytest.param("raise = 2", "invalid", None),
+    pytest.param("%%writefile?", "complete", None),
+    pytest.param("%%writefile??", "complete", None),
     # Invalid number literals (ipython/ipython#15320): on Python <= 3.11 the
     # tokenizer splits these into separate tokens and compilation fails;
     # since Python 3.12 the tokenizer raises TokenError for malformed


### PR DESCRIPTION
Fixes #13996

Treat single-line `%%magic?` and `%%magic??` help queries as complete input while preserving the blank-line completion rule for actual cell magic bodies.

Tests: focused completion regression cases passed locally.

<!-- pr-relay-job relay-117-65a91895be70571bd69a -->