### PR TITLE
Lazily register most builtin magics to improve startup time

### DIFF
--- a/IPython/core/completer.py
+++ b/IPython/core/completer.py
@@ -2339,10 +2339,11 @@ class IPCompleter(Completer):
         if not rest:
             return line
         args = rest[0]
-        known_magics = self.shell.magics_manager.lsmagic()
-        line_magics = known_magics["line"]
         magic_name = maybe_magic.lstrip(self.magic_escape)
-        if magic_name not in line_magics:
+        mman = self.shell.magics_manager
+        if magic_name not in mman.magics["line"] and (
+            "line" not in mman.lazy_magic_kinds(magic_name)
+        ):
             return line
 
         if not maybe_magic.startswith(self.magic_escape):
@@ -2353,7 +2354,10 @@ class IPCompleter(Completer):
                 # a magic). In these cases users need to use explicit `%time`.
                 return line
 
-        magic_method = line_magics[magic_name]
+        # This may lazily load the magic's module if it hasn't been used yet.
+        magic_method = self.shell._find_with_lazy_load("line", magic_name)
+        if magic_method is None:
+            return line
 
         try:
             if magic_name == "timeit":
@@ -2388,9 +2392,26 @@ class IPCompleter(Completer):
         # Get all shell magics now rather than statically, so magics loaded at
         # runtime show up too.
         text = context.token
-        lsm = self.shell.magics_manager.lsmagic()
-        line_magics = lsm['line']
-        cell_magics = lsm['cell']
+        mman = self.shell.magics_manager
+        lsm = mman.lsmagic()
+        # Include names of not-yet-loaded lazy magics too, without forcing
+        # them to be imported.
+        line_magics = {
+            **lsm["line"],
+            **{
+                name: None
+                for name in mman.lazy_magics
+                if "line" in mman.lazy_magic_kinds(name)
+            },
+        }
+        cell_magics = {
+            **lsm["cell"],
+            **{
+                name: None
+                for name in mman.lazy_magics
+                if "cell" in mman.lazy_magic_kinds(name)
+            },
+        }
         pre = self.magic_escape
         pre2 = pre + pre
 

--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -1036,7 +1036,7 @@ class Pdb(OldPdb):
             ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
-        self.shell.find_line_magic("pdef")(arg, namespaces=namespaces)
+        self.shell._find_with_lazy_load("line", "pdef")(arg, namespaces=namespaces)
 
     def do_pdoc(self, arg):
         """Print the docstring for an object.
@@ -1047,7 +1047,7 @@ class Pdb(OldPdb):
             ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
-        self.shell.find_line_magic("pdoc")(arg, namespaces=namespaces)
+        self.shell._find_with_lazy_load("line", "pdoc")(arg, namespaces=namespaces)
 
     def do_pfile(self, arg):
         """Print (or run through pager) the file where an object is defined.
@@ -1059,7 +1059,7 @@ class Pdb(OldPdb):
             ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
-        self.shell.find_line_magic("pfile")(arg, namespaces=namespaces)
+        self.shell._find_with_lazy_load("line", "pfile")(arg, namespaces=namespaces)
 
     def do_pinfo(self, arg):
         """Provide detailed information about an object.
@@ -1070,7 +1070,7 @@ class Pdb(OldPdb):
             ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
-        self.shell.find_line_magic("pinfo")(arg, namespaces=namespaces)
+        self.shell._find_with_lazy_load("line", "pinfo")(arg, namespaces=namespaces)
 
     def do_pinfo2(self, arg):
         """Provide extra detailed information about an object.
@@ -1081,7 +1081,7 @@ class Pdb(OldPdb):
             ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
-        self.shell.find_line_magic("pinfo2")(arg, namespaces=namespaces)
+        self.shell._find_with_lazy_load("line", "pinfo2")(arg, namespaces=namespaces)
 
     def do_psource(self, arg):
         """Print (or run through pager) the source code for an object."""
@@ -1090,7 +1090,7 @@ class Pdb(OldPdb):
             ("Locals", self._curframe_locals),
             ("Globals", self.curframe.f_globals),
         ]
-        self.shell.find_line_magic("psource")(arg, namespaces=namespaces)
+        self.shell._find_with_lazy_load("line", "psource")(arg, namespaces=namespaces)
 
     def do_where(self, arg: str):
         """w(here)

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2491,7 +2491,10 @@ class InteractiveShell(SingletonConfigurable):
         # session) eagerly. The rest are registered lazily via
         # ``mman.register_lazy`` below, and only imported on first use, to
         # keep startup cost down.
-        self.register_magics(m.AutoMagics, m.BasicMagics, m.ConfigMagics,
+        self.register_magics(
+            m.AutoMagics,
+            m.BasicMagics,
+            m.ConfigMagics,
             m.ExtensionMagics,
         )
         self.register_magics(m.AsyncMagics)
@@ -2506,56 +2509,103 @@ class InteractiveShell(SingletonConfigurable):
         # can list these without having to import/load them.
         lazy_magic_modules = {
             "IPython.core.magics.code": {
-                "save": "line", "pastebin": "line", "loadpy": "line",
-                "load": "line", "edit": "line",
+                "save": "line",
+                "pastebin": "line",
+                "loadpy": "line",
+                "load": "line",
+                "edit": "line",
             },
             "IPython.core.magics.display": {
-                "js": "cell", "javascript": "cell", "latex": "cell",
-                "svg": "cell", "html": "cell", "markdown": "cell",
+                "js": "cell",
+                "javascript": "cell",
+                "latex": "cell",
+                "svg": "cell",
+                "html": "cell",
+                "markdown": "cell",
             },
             "IPython.core.magics.execution": {
-                "prun": "line_cell", "pdb": "line", "debug": "line_cell",
-                "tb": "line", "run": "line", "timeit": "line_cell",
-                "time": "line_cell", "macro": "line", "capture": "cell",
+                "prun": "line_cell",
+                "pdb": "line",
+                "debug": "line_cell",
+                "tb": "line",
+                "run": "line",
+                "timeit": "line_cell",
+                "time": "line_cell",
+                "macro": "line",
+                "capture": "cell",
                 "code_wrap": "line_cell",
             },
             "IPython.core.magics.history": {
-                "history": "line", "recall": "line", "rerun": "line",
+                "history": "line",
+                "recall": "line",
+                "rerun": "line",
             },
             "IPython.core.magics.logging": {
-                "logstart": "line", "logstop": "line", "logoff": "line",
-                "logon": "line", "logstate": "line",
+                "logstart": "line",
+                "logstop": "line",
+                "logoff": "line",
+                "logon": "line",
+                "logstate": "line",
             },
             "IPython.core.magics.namespace": {
-                "pinfo": "line", "pinfo2": "line", "pdef": "line",
-                "pdoc": "line", "psource": "line", "pfile": "line",
-                "psearch": "line", "who_ls": "line", "who": "line",
-                "whos": "line", "reset": "line", "reset_selective": "line",
+                "pinfo": "line",
+                "pinfo2": "line",
+                "pdef": "line",
+                "pdoc": "line",
+                "psource": "line",
+                "pfile": "line",
+                "psearch": "line",
+                "who_ls": "line",
+                "who": "line",
+                "whos": "line",
+                "reset": "line",
+                "reset_selective": "line",
                 "xdel": "line",
             },
             "IPython.core.magics.osm": {
-                "alias": "line", "unalias": "line", "rehashx": "line",
-                "pwd": "line", "cd": "line", "env": "line",
-                "set_env": "line", "pushd": "line", "popd": "line",
-                "dirs": "line", "dhist": "line", "sc": "line",
-                "sx": "line_cell", "bookmark": "line", "pycat": "line",
+                "alias": "line",
+                "unalias": "line",
+                "rehashx": "line",
+                "pwd": "line",
+                "cd": "line",
+                "env": "line",
+                "set_env": "line",
+                "pushd": "line",
+                "popd": "line",
+                "dirs": "line",
+                "dhist": "line",
+                "sc": "line",
+                "sx": "line_cell",
+                "bookmark": "line",
+                "pycat": "line",
                 "writefile": "cell",
             },
             "IPython.core.magics.packaging": {
-                "pip": "line", "conda": "line", "mamba": "line",
-                "micromamba": "line", "uv": "line",
+                "pip": "line",
+                "conda": "line",
+                "mamba": "line",
+                "micromamba": "line",
+                "uv": "line",
             },
             "IPython.core.magics.pylab": {
-                "matplotlib": "line", "pylab": "line",
+                "matplotlib": "line",
+                "pylab": "line",
             },
             "IPython.core.magics.script": {
-                "script": "cell", "killbgscripts": "line",
+                "script": "cell",
+                "killbgscripts": "line",
                 # ScriptMagics also generates a cell magic per interpreter
                 # found on PATH (see ScriptMagics._generate_script_magics);
                 # register the common ones so e.g. %%bash lazy-loads too.
-                "sh": "cell", "bash": "cell", "perl": "cell",
-                "ruby": "cell", "python": "cell", "python2": "cell",
-                "python3": "cell", "pypy": "cell", "cmd": "cell",
+                "sh": "cell",
+                "bash": "cell",
+                "perl": "cell",
+                "ruby": "cell",
+                "python": "cell",
+                "python2": "cell",
+                "python3": "cell",
+                "pypy": "cell",
+                "cmd": "cell",
             },
         }
         for module_name, magic_kinds in lazy_magic_modules.items():
@@ -4003,6 +4053,9 @@ class InteractiveShell(SingletonConfigurable):
         # Now we must activate the gui pylab wants to use, and fix %run to take
         # plot updates into account
         self.enable_gui(gui)
+        # `run` may not have been loaded yet if it is registered lazily;
+        # looking it up forces ExecutionMagics to be imported and registered.
+        self._find_with_lazy_load("line", "run")
         self.magics_manager.registry['ExecutionMagics'].default_runner = \
             pt.mpl_runner(self.safe_execfile)
 

--- a/IPython/core/interactiveshell.py
+++ b/IPython/core/interactiveshell.py
@@ -2486,16 +2486,82 @@ class InteractiveShell(SingletonConfigurable):
         # Expose as public API from the magics manager
         self.register_magics = self.magics_manager.register
 
-        self.register_magics(m.AutoMagics, m.BasicMagics, m.CodeMagics,
-            m.ConfigMagics, m.DisplayMagics, m.ExecutionMagics,
-            m.ExtensionMagics, m.HistoryMagics, m.LoggingMagics,
-            m.NamespaceMagics, m.OSMagics, m.PackagingMagics,
-            m.PylabMagics, m.ScriptMagics,
+        # Only register the magics that are needed unconditionally (e.g. for
+        # IPython's own startup, or that are cheap/likely to be used in every
+        # session) eagerly. The rest are registered lazily via
+        # ``mman.register_lazy`` below, and only imported on first use, to
+        # keep startup cost down.
+        self.register_magics(m.AutoMagics, m.BasicMagics, m.ConfigMagics,
+            m.ExtensionMagics,
         )
         self.register_magics(m.AsyncMagics)
 
         # Register Magic Aliases
         mman = self.magics_manager
+
+        # Lazily register the rest of the builtin magics: the underlying
+        # module is only imported (as an "extension") the first time one of
+        # its magics is actually invoked. Each name is mapped to its magic
+        # kind ("line", "cell" or "line_cell") so that e.g. tab completion
+        # can list these without having to import/load them.
+        lazy_magic_modules = {
+            "IPython.core.magics.code": {
+                "save": "line", "pastebin": "line", "loadpy": "line",
+                "load": "line", "edit": "line",
+            },
+            "IPython.core.magics.display": {
+                "js": "cell", "javascript": "cell", "latex": "cell",
+                "svg": "cell", "html": "cell", "markdown": "cell",
+            },
+            "IPython.core.magics.execution": {
+                "prun": "line_cell", "pdb": "line", "debug": "line_cell",
+                "tb": "line", "run": "line", "timeit": "line_cell",
+                "time": "line_cell", "macro": "line", "capture": "cell",
+                "code_wrap": "line_cell",
+            },
+            "IPython.core.magics.history": {
+                "history": "line", "recall": "line", "rerun": "line",
+            },
+            "IPython.core.magics.logging": {
+                "logstart": "line", "logstop": "line", "logoff": "line",
+                "logon": "line", "logstate": "line",
+            },
+            "IPython.core.magics.namespace": {
+                "pinfo": "line", "pinfo2": "line", "pdef": "line",
+                "pdoc": "line", "psource": "line", "pfile": "line",
+                "psearch": "line", "who_ls": "line", "who": "line",
+                "whos": "line", "reset": "line", "reset_selective": "line",
+                "xdel": "line",
+            },
+            "IPython.core.magics.osm": {
+                "alias": "line", "unalias": "line", "rehashx": "line",
+                "pwd": "line", "cd": "line", "env": "line",
+                "set_env": "line", "pushd": "line", "popd": "line",
+                "dirs": "line", "dhist": "line", "sc": "line",
+                "sx": "line_cell", "bookmark": "line", "pycat": "line",
+                "writefile": "cell",
+            },
+            "IPython.core.magics.packaging": {
+                "pip": "line", "conda": "line", "mamba": "line",
+                "micromamba": "line", "uv": "line",
+            },
+            "IPython.core.magics.pylab": {
+                "matplotlib": "line", "pylab": "line",
+            },
+            "IPython.core.magics.script": {
+                "script": "cell", "killbgscripts": "line",
+                # ScriptMagics also generates a cell magic per interpreter
+                # found on PATH (see ScriptMagics._generate_script_magics);
+                # register the common ones so e.g. %%bash lazy-loads too.
+                "sh": "cell", "bash": "cell", "perl": "cell",
+                "ruby": "cell", "python": "cell", "python2": "cell",
+                "python3": "cell", "pypy": "cell", "cmd": "cell",
+            },
+        }
+        for module_name, magic_kinds in lazy_magic_modules.items():
+            for magic_name, magic_kind in magic_kinds.items():
+                mman.register_lazy(magic_name, module_name, magic_kind=magic_kind)
+
         # FIXME: magic aliases should be defined by the Magics classes
         # or in MagicsManager, not here
         mman.register_alias('ed', 'edit')

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -384,6 +384,12 @@ class MagicsManager(Configurable):
         config=True,
     )
 
+    # Mapping from magic names registered via `register_lazy` to their kind
+    # ("line", "cell" or "line_cell"), when known. Used by tab-completion to
+    # list not-yet-loaded lazy magics without importing them. Not meant to be
+    # set directly; use `register_lazy` instead.
+    lazy_magics_kind = Dict()
+
     # A registry of the original objects that we've been given holding magics.
     registry = Dict()
 
@@ -461,7 +467,9 @@ class MagicsManager(Configurable):
             docs[m_type] = m_docs
         return docs
 
-    def register_lazy(self, name: str, fully_qualified_name: str) -> None:
+    def register_lazy(
+        self, name: str, fully_qualified_name: str, magic_kind: str | None = None
+    ) -> None:
         """
         Lazily register a magic via an extension.
 
@@ -475,9 +483,33 @@ class MagicsManager(Configurable):
             as an extensions when the magic is first called.
             It is assumed that loading this extensions will register the given
             magic.
+        magic_kind : str, optional
+            One of ``"line"``, ``"cell"`` or ``"line_cell"``, if known. This is
+            only used so that tools like tab completion can know about the
+            magic (and its kind) before it is actually loaded.
         """
 
         self.lazy_magics[name] = fully_qualified_name
+        if magic_kind is not None:
+            self.lazy_magics_kind[name] = magic_kind
+
+    def lazy_magic_kinds(self, name: str) -> set[str]:
+        """Return the set of magic kinds (``"line"``/``"cell"``) a not-yet
+        loaded lazy magic ``name`` is expected to provide.
+
+        Used by tab-completion to list not-yet-loaded magics without forcing
+        them to be imported. Returns an empty set for names that are not
+        (known) lazy magics.
+        """
+        if name not in self.lazy_magics:
+            return set()
+        kind = self.lazy_magics_kind.get(name)
+        if kind is None:
+            # Unknown kind: assume it could be either.
+            return {"line", "cell"}
+        if kind == "line_cell":
+            return {"line", "cell"}
+        return {kind}
 
     def register(self, *magic_objects: type[Magics] | Magics) -> None:
         """Register one or more instances of Magics.
@@ -808,7 +840,7 @@ class MagicAlias:
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Call the magic alias."""
-        fn = self.shell.find_magic(self.magic_name, self.magic_kind)  # type: ignore[no-untyped-call]
+        fn = self.shell._find_with_lazy_load(self.magic_kind, self.magic_name)  # type: ignore[no-untyped-call]
         if fn is None:
             raise UsageError("Magic `%s` not found." % self.pretty_target)
 

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -840,7 +840,7 @@ class MagicAlias:
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Call the magic alias."""
-        fn = self.shell._find_with_lazy_load(self.magic_kind, self.magic_name)  # type: ignore[no-untyped-call]
+        fn = self.shell._find_with_lazy_load(self.magic_kind, self.magic_name)
         if fn is None:
             raise UsageError("Magic `%s` not found." % self.pretty_target)
 

--- a/IPython/core/magics/basic.py
+++ b/IPython/core/magics/basic.py
@@ -147,9 +147,9 @@ class BasicMagics(Magics):
                 or (params.startswith("'") and params.endswith("'")))):
             params = params[1:-1]
 
-        # Find the requested magics.
-        m_line = shell.find_magic(target, 'line')
-        m_cell = shell.find_magic(target, 'cell')
+        # Find the requested magics, lazy-loading them if needed.
+        m_line = shell._find_with_lazy_load("line", target)
+        m_cell = shell._find_with_lazy_load("cell", target)
         if args.line and m_line is None:
             raise UsageError('Line magic function `%s%s` not found.' %
                              (magic_escapes['line'], target))

--- a/IPython/core/magics/code.py
+++ b/IPython/core/magics/code.py
@@ -768,3 +768,12 @@ class CodeMagics(Magics):
                     return
                 else:
                     self.shell.showtraceback()
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(CodeMagics)

--- a/IPython/core/magics/display.py
+++ b/IPython/core/magics/display.py
@@ -91,3 +91,12 @@ Isolated cells are rendered inside their own <iframe> tag"""
     def markdown(self, line, cell):
         """Render the cell as Markdown text block"""
         display(Markdown(cell))
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(DisplayMagics)

--- a/IPython/core/magics/execution.py
+++ b/IPython/core/magics/execution.py
@@ -1717,3 +1717,12 @@ def _format_time(timespan, precision=3):
     else:
         order = 3
     return "%.*g %s" % (precision, timespan * scaling[order], units[order])
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(ExecutionMagics)

--- a/IPython/core/magics/history.py
+++ b/IPython/core/magics/history.py
@@ -359,3 +359,12 @@ class HistoryMagics(Magics):
         print(histlines)
         print("=== Output: ===")
         self.shell.run_cell("\n".join(hist), store_history=False)
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(HistoryMagics)

--- a/IPython/core/magics/logging.py
+++ b/IPython/core/magics/logging.py
@@ -193,3 +193,12 @@ class LoggingMagics(Magics):
         """Print the status of the logging system."""
 
         self.shell.logger.logstate()
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(LoggingMagics)

--- a/IPython/core/magics/namespace.py
+++ b/IPython/core/magics/namespace.py
@@ -721,3 +721,12 @@ class NamespaceMagics(Magics):
             self.shell.del_var(varname, ('n' in opts))
         except (NameError, ValueError) as e:
             print(type(e).__name__ +": "+ str(e))
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(NamespaceMagics)

--- a/IPython/core/magics/osm.py
+++ b/IPython/core/magics/osm.py
@@ -854,3 +854,12 @@ class OSMagics(Magics):
         mode = 'a' if args.append else 'w'
         with open(filename, mode, encoding='utf-8') as f:
             f.write(cell)
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(OSMagics)

--- a/IPython/core/magics/packaging.py
+++ b/IPython/core/magics/packaging.py
@@ -179,3 +179,12 @@ class PackagingMagics(Magics):
         self.shell.system(" ".join([python, "-m", "uv", line]))
 
         print("Note: you may need to restart the kernel to use updated packages.")
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(PackagingMagics)

--- a/IPython/core/magics/pylab.py
+++ b/IPython/core/magics/pylab.py
@@ -171,3 +171,12 @@ class PylabMagics(Magics):
         """show matplotlib message backend message"""
         if not gui or gui == 'auto':
             print("Using matplotlib backend: %s" % backend)
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(PylabMagics)

--- a/IPython/core/magics/script.py
+++ b/IPython/core/magics/script.py
@@ -441,3 +441,12 @@ class ScriptMagics(Magics):
 
     def _gc_bg_processes(self):
         self.bg_processes = [p for p in self.bg_processes if p.returncode is None]
+
+
+def load_ipython_extension(ip):
+    """Load the magics in this module as an IPython extension.
+
+    Used to lazily register these magics via
+    ``MagicsManager.lazy_magics``.
+    """
+    ip.register_magics(ScriptMagics)

--- a/IPython/core/prefilter.py
+++ b/IPython/core/prefilter.py
@@ -452,7 +452,11 @@ class AutoMagicChecker(PrefilterChecker):
         check_esc_chars. This just checks for automagic.  Also, before
         triggering the magic handler, make sure that there is nothing in the
         user namespace which could shadow it."""
-        if not self.shell.automagic or not self.shell.find_magic(line_info.ifun):
+        if not self.shell.automagic:
+            return None
+        if not self.shell.find_magic(line_info.ifun) and (
+            line_info.ifun not in self.shell.magics_manager.lazy_magics
+        ):
             return None
 
         # We have a likely magic method.  Make sure we should actually call it.

--- a/docs/source/whatsnew/pr/lazy-builtin-magics.rst
+++ b/docs/source/whatsnew/pr/lazy-builtin-magics.rst
@@ -1,0 +1,22 @@
+Most builtin magics are now registered lazily
+----------------------------------------------
+
+Previously, ``init_magics`` imported and instantiated every builtin
+``Magics`` class up front, including ``IPython.core.magics.execution``,
+``.namespace``, ``.osm``, ``.history``, ``.display``, ``.packaging``,
+``.pylab``, ``.script``, ``.code`` and ``.logging`` -- pulling in things like
+``pdb``, ``timeit``, ``subprocess`` machinery and more before a single cell
+had run.
+
+These modules are now registered via
+:attr:`~IPython.core.magic.MagicsManager.lazy_magics`, the same mechanism
+already used for user/config supplied lazy magics, and are only imported the
+first time one of their magics (``%run``, ``%time``, ``%%bash``, ``%history``,
+``%pip``, ...) is actually used -- whether typed explicitly, via automagic, as
+a magic alias (e.g. ``%hist``), or through ``%alias_magic``. Tab completion
+still lists these magics (and their line/cell kind) without importing them.
+
+A handful of magics that are needed unconditionally during shell startup, or
+that are already essentially free to import, are still registered eagerly:
+``AutoMagics``, ``BasicMagics``, ``ConfigMagics``, ``ExtensionMagics`` and
+``AsyncMagics``.

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1439,9 +1439,13 @@ def test_file_spaces():
 
 def test_script_config():
     ip = get_ipython()
-    ip.config.ScriptMagics.script_magics = ["whoda"]
-    sm = script.ScriptMagics(shell=ip)
-    assert "whoda" in sm.magics["cell"]
+    previous = ip.config.ScriptMagics.script_magics
+    try:
+        ip.config.ScriptMagics.script_magics = ["whoda"]
+        sm = script.ScriptMagics(shell=ip)
+        assert "whoda" in sm.magics["cell"]
+    finally:
+        ip.config.ScriptMagics.script_magics = previous
 
 
 def _interrupt_after_1s():
@@ -1587,7 +1591,7 @@ def test_script_defaults(cmd):
         find_cmd(cmd)
     except Exception:
         pytest.skip(f"{cmd} not found")
-    assert cmd in ip.magics_manager.magics["cell"]
+    assert ip._find_with_lazy_load("cell", cmd) is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR implements lazy registration of most builtin IPython magics to reduce startup time. Previously, all builtin magic modules were imported and instantiated eagerly during shell initialization. Now, only essential magics are registered upfront, while the rest are loaded on-demand when first used.

## Key Changes

- **Lazy magic registration in `init_magics()`**: Moved most builtin magic classes (CodeMagics, DisplayMagics, ExecutionMagics, HistoryMagics, LoggingMagics, NamespaceMagics, OSMagics, PackagingMagics, PylabMagics, ScriptMagics) to lazy registration via `MagicsManager.register_lazy()`. Only AutoMagics, BasicMagics, ConfigMagics, ExtensionMagics, and AsyncMagics are registered eagerly.

- **Enhanced `MagicsManager.register_lazy()`**: Added optional `magic_kind` parameter to track whether a lazy magic is "line", "cell", or "line_cell" without importing the module. Added new `lazy_magic_kinds()` method to query magic kinds for tab completion.

- **New `lazy_magics_kind` attribute**: Stores the kind information for lazy magics, enabling tab completion to list not-yet-loaded magics with their correct type.

- **Added `load_ipython_extension()` functions**: Each builtin magic module now includes a `load_ipython_extension()` function to support lazy loading as an extension.

- **Updated magic lookup**: Modified `_find_with_lazy_load()` calls in debugger, completer, and basic magics to support lazy loading of magics on first use.

- **Enhanced tab completion**: Updated `magic_matcher()` in completer to include lazy magic names without forcing their import, and updated `_extract_code()` to check both loaded and lazy magics.

- **Automagic support**: Updated prefilter to check lazy_magics registry when determining if automagic should be triggered.

- **Test fixes**: Updated `test_script_config()` to properly restore previous configuration state.

## Implementation Details

- A comprehensive mapping of lazy magic modules to their contained magics and kinds is defined in `init_magics()`, allowing the system to know about magics before they're imported.
- The lazy loading mechanism reuses the existing extension loading infrastructure, so each magic module just needs a `load_ipython_extension()` entry point.
- Tab completion and automagic detection now work with lazy magics without triggering imports, maintaining the startup performance benefit.

https://claude.ai/code/session_01TzmUcFAdqoDwkWaKJLzJKm