### PR TITLE
Fix lazy magic lookup resolving the wrong provider per kind

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -363,13 +363,16 @@ class LazyMagic:
         magic_name: str,
         shadowed: LazyMagic | Callable[..., Any] | None = None,
     ) -> None:
+        """Create a lazy magic, optionally preserving a displaced entry.
+
+        ``shadowed`` is the table entry displaced by this declaration, if
+        any. It can be another lazy declaration or an already registered
+        callable.
+        """
         self.spec = spec
         self._manager = manager
         self._kind = magic_kind
         self._name = magic_name
-        # The table entry this declaration displaced, if any. A name may be
-        # declared lazily any number of times; the chain is walked if a
-        # newer declaration never delivers the magic.
         self.shadowed = shadowed
 
     def _resolve(self) -> Callable[..., Any]:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -572,7 +572,10 @@ class MagicsManager(Configurable):
             existing = self.magics[kind].get(name)
             if existing is not None and not isinstance(existing, LazyMagic):
                 continue
-            if isinstance(existing, LazyMagic) and existing.spec != fully_qualified_name:
+            if (
+                isinstance(existing, LazyMagic)
+                and existing.spec != fully_qualified_name
+            ):
                 # A newer declaration displaces an older one for this kind;
                 # remember the old spec so it can be restored if the new
                 # declaration never delivers the magic.

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -361,11 +361,16 @@ class LazyMagic:
         spec: str,
         magic_kind: _MagicKind,
         magic_name: str,
+        shadowed: LazyMagic | Callable[..., Any] | None = None,
     ) -> None:
         self.spec = spec
         self._manager = manager
         self._kind = magic_kind
         self._name = magic_name
+        # The table entry this declaration displaced, if any. A name may be
+        # declared lazily any number of times; the chain is walked if a
+        # newer declaration never delivers the magic.
+        self.shadowed = shadowed
 
     def _resolve(self) -> Callable[..., Any]:
         fn = self._manager.find(self._kind, self._name)
@@ -486,11 +491,6 @@ class MagicsManager(Configurable):
         self.magics = dict(line={}, cell={})
         # Specs already loaded, so a class is never registered twice.
         self._loaded_lazy: set[str] = set()
-        # Previous lazy specs displaced by a newer declaration, keyed by
-        # (kind, name). If the newer declaration turns out not to deliver
-        # the magic ("declared but not delivered"), the previous one is
-        # restored instead of leaving the name unresolvable.
-        self._lazy_fallbacks: dict[tuple[str, str], str] = {}
         self.registry = _MagicsRegistry(self)
         # Let's add the user_magics to the registry for uniformity, so *all*
         # registered magic containers can be found there.
@@ -572,15 +572,19 @@ class MagicsManager(Configurable):
             existing = self.magics[kind].get(name)
             if existing is not None and not isinstance(existing, LazyMagic):
                 continue
+            shadowed = None
             if (
                 isinstance(existing, LazyMagic)
                 and existing.spec != fully_qualified_name
             ):
-                # A newer declaration displaces an older one for this kind;
-                # remember the old spec so it can be restored if the new
-                # declaration never delivers the magic.
-                self._lazy_fallbacks[(kind, name)] = existing.spec
-            self.magics[kind][name] = LazyMagic(self, fully_qualified_name, kind, name)
+                # A newer declaration displaces an older one for this kind.
+                # The displaced entry rides on the placeholder itself, so a
+                # name declared any number of times unwinds to whatever
+                # declaration actually delivers it.
+                shadowed = existing
+            self.magics[kind][name] = LazyMagic(
+                self, fully_qualified_name, kind, name, shadowed=shadowed
+            )
 
     def load_lazy(self, magic_name: str, magic_kind: _MagicKind | None = None) -> None:
         """Import and register whatever provides `magic_name`.
@@ -646,23 +650,24 @@ class MagicsManager(Configurable):
         """
         fn = self.magics[magic_kind].get(magic_name)
         if isinstance(fn, LazyMagic) or (fn is None and magic_name in self.lazy_magics):
-            self.load_lazy(magic_name, magic_kind)
-            fn = self.magics[magic_kind].get(magic_name)
-            if isinstance(fn, LazyMagic):
-                # Declared but not delivered. If an older declaration for
-                # this kind was displaced, restore it and give it one
-                # chance rather than dropping the name entirely.
-                fallback = self._lazy_fallbacks.pop((magic_kind, magic_name), None)
-                if fallback is not None and fallback != fn.spec:
-                    self.magics[magic_kind][magic_name] = LazyMagic(
-                        self, fallback, magic_kind, magic_name
-                    )
-                    self.load_lazy(magic_name, magic_kind)
-                    fn = self.magics[magic_kind].get(magic_name)
-                if isinstance(fn, LazyMagic):
-                    # Still nothing delivered; drop the stale placeholder.
+            while isinstance(fn, LazyMagic):
+                self.load_lazy(magic_name, magic_kind)
+                current = self.magics[magic_kind].get(magic_name)
+                if current is not fn:
+                    # The load delivered something (or cleared the name).
+                    fn = current
+                    continue
+                # Declared but not delivered: swap in whatever this
+                # declaration displaced and give that a chance instead of
+                # dropping the name entirely.
+                shadowed = fn.shadowed
+                if shadowed is None:
+                    # Nothing left in the chain; drop the stale placeholder.
                     del self.magics[magic_kind][magic_name]
                     fn = None
+                else:
+                    self.magics[magic_kind][magic_name] = shadowed
+                    fn = shadowed
         return t.cast("Callable[..., Any] | None", fn)
 
     def register(self, *magic_objects: type[Magics] | Magics) -> None:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -486,6 +486,11 @@ class MagicsManager(Configurable):
         self.magics = dict(line={}, cell={})
         # Specs already loaded, so a class is never registered twice.
         self._loaded_lazy: set[str] = set()
+        # Previous lazy specs displaced by a newer declaration, keyed by
+        # (kind, name). If the newer declaration turns out not to deliver
+        # the magic ("declared but not delivered"), the previous one is
+        # restored instead of leaving the name unresolvable.
+        self._lazy_fallbacks: dict[tuple[str, str], str] = {}
         self.registry = _MagicsRegistry(self)
         # Let's add the user_magics to the registry for uniformity, so *all*
         # registered magic containers can be found there.
@@ -567,18 +572,33 @@ class MagicsManager(Configurable):
             existing = self.magics[kind].get(name)
             if existing is not None and not isinstance(existing, LazyMagic):
                 continue
+            if isinstance(existing, LazyMagic) and existing.spec != fully_qualified_name:
+                # A newer declaration displaces an older one for this kind;
+                # remember the old spec so it can be restored if the new
+                # declaration never delivers the magic.
+                self._lazy_fallbacks[(kind, name)] = existing.spec
             self.magics[kind][name] = LazyMagic(self, fully_qualified_name, kind, name)
 
-    def load_lazy(self, magic_name: str) -> None:
+    def load_lazy(self, magic_name: str, magic_kind: _MagicKind | None = None) -> None:
         """Import and register whatever provides `magic_name`.
 
         Does nothing if `magic_name` was not declared through
         :meth:`register_lazy` or :attr:`lazy_magics`, or if what provides it
         has already been loaded.
+
+        When `magic_kind` is given, the placeholder for that kind decides
+        which spec to load: a name may be declared with a different provider
+        per kind, and the lookup must resolve the kind that was asked for,
+        not whichever placeholder happens to be checked first.
         """
         # `lazy_magics` is user-configurable and may have been replaced
         # wholesale, so prefer the spec the placeholder carries.
-        fn = self.magics["line"].get(magic_name) or self.magics["cell"].get(magic_name)
+        if magic_kind is not None:
+            fn = self.magics[magic_kind].get(magic_name)
+        else:
+            fn = self.magics["line"].get(magic_name) or self.magics["cell"].get(
+                magic_name
+            )
         spec = (
             fn.spec if isinstance(fn, LazyMagic) else self.lazy_magics.get(magic_name)
         )
@@ -623,12 +643,23 @@ class MagicsManager(Configurable):
         """
         fn = self.magics[magic_kind].get(magic_name)
         if isinstance(fn, LazyMagic) or (fn is None and magic_name in self.lazy_magics):
-            self.load_lazy(magic_name)
+            self.load_lazy(magic_name, magic_kind)
             fn = self.magics[magic_kind].get(magic_name)
             if isinstance(fn, LazyMagic):
-                # Declared but not delivered; drop the stale placeholder.
-                del self.magics[magic_kind][magic_name]
-                fn = None
+                # Declared but not delivered. If an older declaration for
+                # this kind was displaced, restore it and give it one
+                # chance rather than dropping the name entirely.
+                fallback = self._lazy_fallbacks.pop((magic_kind, magic_name), None)
+                if fallback is not None and fallback != fn.spec:
+                    self.magics[magic_kind][magic_name] = LazyMagic(
+                        self, fallback, magic_kind, magic_name
+                    )
+                    self.load_lazy(magic_name, magic_kind)
+                    fn = self.magics[magic_kind].get(magic_name)
+                if isinstance(fn, LazyMagic):
+                    # Still nothing delivered; drop the stale placeholder.
+                    del self.magics[magic_kind][magic_name]
+                    fn = None
         return t.cast("Callable[..., Any] | None", fn)
 
     def register(self, *magic_objects: type[Magics] | Magics) -> None:

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -402,10 +402,13 @@ class _MagicsRegistry(dict[str, Any]):
         self._manager = manager
 
     def __missing__(self, key: str) -> Any:
-        for magic_name, spec in list(self._manager.lazy_magics.items()):
+        for magic_name, magic_kind, spec in self._manager._lazy_declarations():
             if spec.endswith(":" + key):
-                self._manager.load_lazy(magic_name)
-                break
+                self._manager.load_lazy(magic_name, magic_kind)
+                # A matching spec declared once per kind
+                # has one spec per kind, so keep going until `key` shows up.
+                if key in self:
+                    break
         if key not in self:
             # A second miss must not loop back here.
             raise KeyError(key)
@@ -631,24 +634,36 @@ class MagicsManager(Configurable):
             self._loaded_lazy.discard(spec)
             raise
 
+    def _lazy_declarations(self) -> list[tuple[str, _MagicKind | None, str]]:
+        """Every live lazy declaration, as ``(name, kind, spec)``.
+
+        The placeholders in :attr:`magics` are the source of truth, because
+        :attr:`lazy_magics` is keyed by name alone and so keeps only the last
+        spec for a name declared once per kind. A name declared only through
+        the trait has no placeholder, and so no known kind.
+        """
+        seen: set[tuple[str, str]] = set()
+        declarations: list[tuple[str, _MagicKind | None, str]] = []
+        for kind in magic_kinds:
+            for name, fn in list(self.magics[kind].items()):
+                if isinstance(fn, LazyMagic) and (name, fn.spec) not in seen:
+                    seen.add((name, fn.spec))
+                    declarations.append((name, kind, fn.spec))
+        for name, spec in list(self.lazy_magics.items()):
+            if (name, spec) not in seen:
+                seen.add((name, spec))
+                declarations.append((name, None, spec))
+        return declarations
+
     def load_all_lazy_magics(self) -> None:
         """Import and register every magic still declared lazily.
 
         Only the ``module:MagicsClass`` ones: loading an extension can run
         arbitrary code, so that waits for the magic to actually be used.
         """
-        # Load per kind from the placeholders themselves: one name may be
-        # declared with a different provider per kind, and ``lazy_magics``
-        # only remembers the last spec per name. Extensions (specs without a
-        # ":") are still skipped: importing one can run arbitrary code.
-        for kind in magic_kinds:
-            for magic_name in list(self.magics[kind]):
-                fn = self.magics[kind].get(magic_name)
-                if isinstance(fn, LazyMagic) and ":" in fn.spec:
-                    self.load_lazy(magic_name, kind)
-        for magic_name, spec in list(self.lazy_magics.items()):
+        for magic_name, magic_kind, spec in self._lazy_declarations():
             if ":" in spec:
-                self.load_lazy(magic_name)
+                self.load_lazy(magic_name, magic_kind)
 
     def find(
         self, magic_kind: _MagicKind, magic_name: str

--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -637,6 +637,15 @@ class MagicsManager(Configurable):
         Only the ``module:MagicsClass`` ones: loading an extension can run
         arbitrary code, so that waits for the magic to actually be used.
         """
+        # Load per kind from the placeholders themselves: one name may be
+        # declared with a different provider per kind, and ``lazy_magics``
+        # only remembers the last spec per name. Extensions (specs without a
+        # ":") are still skipped: importing one can run arbitrary code.
+        for kind in magic_kinds:
+            for magic_name in list(self.magics[kind]):
+                fn = self.magics[kind].get(magic_name)
+                if isinstance(fn, LazyMagic) and ":" in fn.spec:
+                    self.load_lazy(magic_name, kind)
         for magic_name, spec in list(self.lazy_magics.items()):
             if ":" in spec:
                 self.load_lazy(magic_name)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2035,8 +2035,6 @@ def test_lazy_magic_help_finds_both_kinds_first_try(line_first):
                 mm.magics["line"].pop("dual", None)
                 mm.magics["cell"].pop("dual", None)
                 mm.lazy_magics.pop("dual", None)
-                for key in [("line", "dual"), ("cell", "dual")]:
-                    mm._lazy_fallbacks.pop(key, None)
                 mm._loaded_lazy.discard(line_spec)
                 mm._loaded_lazy.discard(cell_spec)
                 mm.registry.pop("LineHalf", None)
@@ -2086,11 +2084,71 @@ def test_lazy_magic_falls_back_to_previous_declaration():
                 else:
                     mm.magics["cell"].pop("time", None)
                 mm.lazy_magics.pop("time", None)
-                mm._lazy_fallbacks.pop(("cell", "time"), None)
-                mm._lazy_fallbacks.pop(("line", "time"), None)
                 mm._loaded_lazy.discard(spec)
                 mm.registry.pop("LineOnly", None)
                 sys.modules.pop(mod, None)
+
+
+def test_lazy_magic_falls_back_through_two_declarations():
+    """The displaced chain unwinds to whatever declaration delivers.
+
+    Three lazy declarations for one name: the two newest provide no
+    ``time`` at all, so the lookup must walk past both and resolve the
+    oldest provider instead of giving up after one level.
+    See https://github.com/ipython/ipython/issues/15383.
+    """
+    mm = ip.magics_manager
+    with TemporaryDirectory() as tmpdir:
+        with prepended_to_syspath(tmpdir):
+            Path(tmpdir, "depth_first_mod.py").write_text(
+                dedent(
+                    """
+                    from IPython.core.magic import Magics, line_magic, magics_class
+
+
+                    @magics_class
+                    class First(Magics):
+                        @line_magic
+                        def mydepth(self, line):
+                            \"\"\"The original provider.\"\"\"
+                    """
+                )
+            )
+            for mod in ("depth_second_mod", "depth_third_mod"):
+                Path(tmpdir, mod + ".py").write_text(
+                    dedent(
+                        """
+                        from IPython.core.magic import Magics, magics_class
+
+
+                        @magics_class
+                        class Empty(Magics):
+                            pass
+                        """
+                    )
+                )
+            invalidate_caches()
+            specs = [
+                "depth_first_mod:First",
+                "depth_second_mod:Empty",
+                "depth_third_mod:Empty",
+            ]
+            try:
+                for spec in specs:
+                    mm.register_lazy("mydepth", spec, "line")
+                fn = mm.find("line", "mydepth")
+                assert fn is not None
+                assert not isinstance(fn, magic.LazyMagic)
+                assert fn.__doc__ == "The original provider."
+            finally:
+                mm.magics["line"].pop("mydepth", None)
+                mm.lazy_magics.pop("mydepth", None)
+                for spec in specs:
+                    mm._loaded_lazy.discard(spec)
+                mm.registry.pop("First", None)
+                mm.registry.pop("Empty", None)
+                for mod in ("depth_first_mod", "depth_second_mod", "depth_third_mod"):
+                    sys.modules.pop(mod, None)
 
 
 TEST_MODULE = """

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -23,11 +23,15 @@ from unittest import mock
 
 import pytest
 
+from traitlets.config import Config, Configurable
+
 from IPython import get_ipython
 from IPython.core import magic
 from IPython.core.error import UsageError
+from IPython.core.interactiveshell import InteractiveShellABC
 from IPython.core.magic import (
     Magics,
+    MagicsManager,
     cell_magic,
     line_magic,
     magics_class,
@@ -60,6 +64,22 @@ from tempfile import NamedTemporaryFile
 @magic.magics_class
 class DummyMagics(magic.Magics):
     pass
+
+
+class _UnconfiguredShell(Configurable):
+    """Just enough of a shell for a ``Magics`` class to be instantiated."""
+
+    def __init__(self):
+        super().__init__(config=Config())
+
+
+InteractiveShellABC.register(_UnconfiguredShell)
+
+
+@pytest.fixture
+def standalone_manager():
+    """A standalone MagicsManager, so tests don't disturb the shared shell."""
+    return MagicsManager(shell=_UnconfiguredShell())
 
 
 def test_extract_code_ranges():
@@ -2151,7 +2171,7 @@ def test_lazy_magic_falls_back_through_two_declarations():
                     sys.modules.pop(mod, None)
 
 
-def test_load_all_lazy_magics_loads_both_kind_halves():
+def test_load_all_lazy_magics_loads_both_kind_halves(standalone_manager):
     """`load_all_lazy_magics` loads every kind's provider, not just one.
 
     One name may be declared with a different provider per kind, but
@@ -2160,7 +2180,7 @@ def test_load_all_lazy_magics_loads_both_kind_halves():
     ``%config CellHalf.trait`` fails until something else loads it.
     See https://github.com/ipython/ipython/issues/15383.
     """
-    mm = ip.magics_manager
+    mm = standalone_manager
     with TemporaryDirectory() as tmpdir:
         with prepended_to_syspath(tmpdir):
             mod = "split_load_all_module"
@@ -2197,13 +2217,6 @@ def test_load_all_lazy_magics_loads_both_kind_halves():
                 assert not isinstance(mm.find("line", "dual"), magic.LazyMagic)
                 assert not isinstance(mm.find("cell", "dual"), magic.LazyMagic)
             finally:
-                mm.magics["line"].pop("dual", None)
-                mm.magics["cell"].pop("dual", None)
-                mm.lazy_magics.pop("dual", None)
-                mm._loaded_lazy.discard(line_spec)
-                mm._loaded_lazy.discard(cell_spec)
-                mm.registry.pop("LineHalf", None)
-                mm.registry.pop("CellHalf", None)
                 sys.modules.pop(mod, None)
 
 

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -2151,6 +2151,62 @@ def test_lazy_magic_falls_back_through_two_declarations():
                     sys.modules.pop(mod, None)
 
 
+def test_load_all_lazy_magics_loads_both_kind_halves():
+    """`load_all_lazy_magics` loads every kind's provider, not just one.
+
+    One name may be declared with a different provider per kind, but
+    ``lazy_magics`` only remembers the last spec per name — so loading from
+    it alone (line-first) never imports the other half's class, and e.g.
+    ``%config CellHalf.trait`` fails until something else loads it.
+    See https://github.com/ipython/ipython/issues/15383.
+    """
+    mm = ip.magics_manager
+    with TemporaryDirectory() as tmpdir:
+        with prepended_to_syspath(tmpdir):
+            mod = "split_load_all_module"
+            Path(tmpdir, mod + ".py").write_text(
+                dedent(
+                    """
+                    from IPython.core.magic import Magics, line_magic, cell_magic, magics_class
+
+
+                    @magics_class
+                    class LineHalf(Magics):
+                        @line_magic
+                        def dual(self, line):
+                            \"\"\"The line half.\"\"\"
+
+
+                    @magics_class
+                    class CellHalf(Magics):
+                        @cell_magic
+                        def dual(self, line, cell):
+                            \"\"\"The cell half.\"\"\"
+                    """
+                )
+            )
+            invalidate_caches()
+            line_spec = f"{mod}:LineHalf"
+            cell_spec = f"{mod}:CellHalf"
+            try:
+                mm.register_lazy("dual", line_spec, "line")  # type: ignore[arg-type]
+                mm.register_lazy("dual", cell_spec, "cell")  # type: ignore[arg-type]
+                mm.load_all_lazy_magics()
+                assert "LineHalf" in mm.registry
+                assert "CellHalf" in mm.registry
+                assert not isinstance(mm.find("line", "dual"), magic.LazyMagic)
+                assert not isinstance(mm.find("cell", "dual"), magic.LazyMagic)
+            finally:
+                mm.magics["line"].pop("dual", None)
+                mm.magics["cell"].pop("dual", None)
+                mm.lazy_magics.pop("dual", None)
+                mm._loaded_lazy.discard(line_spec)
+                mm._loaded_lazy.discard(cell_spec)
+                mm.registry.pop("LineHalf", None)
+                mm.registry.pop("CellHalf", None)
+                sys.modules.pop(mod, None)
+
+
 TEST_MODULE = """
 print('Loaded my_tmp')
 if __name__ == "__main__":

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1978,6 +1978,121 @@ def test_registered_magic_beats_lazy_one():
         mm.registry.pop("OverridingMagics", None)
 
 
+SPLIT_LAZY_MAGIC = """
+from IPython.core.magic import Magics, cell_magic, line_magic, magics_class
+
+
+@magics_class
+class LineHalf(Magics):
+    @line_magic
+    def dual(self, line):
+        \"\"\"The line half of the dual magic.\"\"\"
+
+
+@magics_class
+class CellHalf(Magics):
+    @cell_magic
+    def dual(self, line, cell):
+        \"\"\"The cell half of the dual magic.\"\"\"
+"""
+
+
+@pytest.mark.parametrize("line_first", [True, False])
+def test_lazy_magic_help_finds_both_kinds_first_try(line_first):
+    """`?` help resolves a lazily declared magic on the first attempt.
+
+    The same name may be declared with a different provider per kind; the
+    lookup must load the provider for the kind that was asked for, no
+    matter in which order the declarations were registered.
+    See https://github.com/ipython/ipython/issues/15383.
+    """
+    mm = ip.magics_manager
+    with TemporaryDirectory() as tmpdir:
+        with prepended_to_syspath(tmpdir):
+            mod = "split_lazy_magic_module"
+            Path(tmpdir, mod + ".py").write_text(dedent(SPLIT_LAZY_MAGIC))
+            invalidate_caches()
+            line_spec = f"{mod}:LineHalf"
+            cell_spec = f"{mod}:CellHalf"
+            first, second = (
+                (("line", line_spec), ("cell", cell_spec))
+                if line_first
+                else (("cell", cell_spec), ("line", line_spec))
+            )
+            try:
+                mm.register_lazy("dual", first[1], first[0])  # type: ignore[arg-type]
+                mm.register_lazy("dual", second[1], second[0])  # type: ignore[arg-type]
+                # Both kinds resolve on the very first lookup ...
+                assert "dual" in mm.magics["cell"]
+                assert mm.find("cell", "dual") is not None
+                assert not isinstance(mm.find("cell", "dual"), magic.LazyMagic)
+                assert mm.find("line", "dual") is not None
+                assert not isinstance(mm.find("line", "dual"), magic.LazyMagic)
+                # ... and so does `?` help in both spellings.
+                assert ip._ofind("%%dual").found
+                assert ip._ofind("%dual").found
+            finally:
+                mm.magics["line"].pop("dual", None)
+                mm.magics["cell"].pop("dual", None)
+                mm.lazy_magics.pop("dual", None)
+                for key in [("line", "dual"), ("cell", "dual")]:
+                    mm._lazy_fallbacks.pop(key, None)
+                mm._loaded_lazy.discard(line_spec)
+                mm._loaded_lazy.discard(cell_spec)
+                mm.registry.pop("LineHalf", None)
+                mm.registry.pop("CellHalf", None)
+                sys.modules.pop(mod, None)
+
+
+def test_lazy_magic_falls_back_to_previous_declaration():
+    """A declaration that delivers nothing restores the previous one.
+
+    Declaring ``time`` for both kinds displaces IPython's own lazy ``time``;
+    if the new class only provides the line half, the cell half must fall
+    back to the previously declared provider instead of vanishing.
+    See https://github.com/ipython/ipython/issues/15383.
+    """
+    mm = ip.magics_manager
+    with TemporaryDirectory() as tmpdir:
+        with prepended_to_syspath(tmpdir):
+            mod = "line_only_lazy_magic_module"
+            Path(tmpdir, mod + ".py").write_text(
+                dedent(
+                    """
+                    from IPython.core.magic import Magics, line_magic, magics_class
+
+
+                    @magics_class
+                    class LineOnly(Magics):
+                        @line_magic
+                        def time(self, line):
+                            \"\"\"My own line-only time.\"\"\"
+                    """
+                )
+            )
+            invalidate_caches()
+            spec = f"{mod}:LineOnly"
+            original_cell = mm.magics["cell"].get("time")
+            try:
+                mm.register_lazy("time", spec)
+                assert mm.find("line", "time") is not None
+                cell_fn = mm.find("cell", "time")
+                assert cell_fn is not None
+                assert not isinstance(cell_fn, magic.LazyMagic)
+                assert ip._ofind("%%time").found
+            finally:
+                if original_cell is not None:
+                    mm.magics["cell"]["time"] = original_cell
+                else:
+                    mm.magics["cell"].pop("time", None)
+                mm.lazy_magics.pop("time", None)
+                mm._lazy_fallbacks.pop(("cell", "time"), None)
+                mm._lazy_fallbacks.pop(("line", "time"), None)
+                mm._loaded_lazy.discard(spec)
+                mm.registry.pop("LineOnly", None)
+                sys.modules.pop(mod, None)
+
+
 TEST_MODULE = """
 print('Loaded my_tmp')
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #15383.

When one magic name is lazily declared with a different provider per kind, `load_lazy()` always preferred the line-table placeholder, so `%%name?` loaded the wrong provider and left a stale cell placeholder behind. On retry the stale placeholder was dropped, which made the outcome depend on registration order: line-then-cell worked on the second attempt, cell-then-line never worked at all.

This passes the requested kind from `find()` into `load_lazy()`, so each kind loads its own provider on the first lookup. It also remembers a displaced lazy declaration per (kind, name): if the newer declaration never delivers the magic, the previous one is restored for one retry instead of the name going unresolvable. That last part covers the `time` case in the issue, where a line-only override kept working for `%time`/`time?` while `%%time?` and `%%time` fell back to IPython's own cell magic again.

Tests added in `tests/test_magic.py` (`test_lazy_magic_help_finds_both_kinds_first_try`, parametrized over both registration orders, and `test_lazy_magic_falls_back_to_previous_declaration`). All three fail without the fix and pass with it. Full `test_magic.py` + `test_magic_table.py` green (149 passed, 5 skipped); the 5 failures in `test_interactiveshell.py`/`test_prefilter.py` are pre-existing environment failures, identical on clean main.

@Darshan808 would appreciate your review when you have a moment.